### PR TITLE
Fix CREATE KEYSPACE statement for Cassandra 1.2.0-beta1

### DIFF
--- a/gocql_test.go
+++ b/gocql_test.go
@@ -59,8 +59,7 @@ func TestWiki(t *testing.T) {
 	}
 	db.Exec("DROP KEYSPACE gocql_wiki")
 	if _, err := db.Exec(`CREATE KEYSPACE gocql_wiki
-        WITH strategy_class = 'SimpleStrategy'
-        AND strategy_options:replication_factor = 1`); err != nil {
+	                      WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("USE gocql_wiki"); err != nil {


### PR DESCRIPTION
Fixes the test to use the new CREATE KEYSPACE syntax introduced in [CASSANDRA-4497](https://issues.apache.org/jira/browse/CASSANDRA-4497).
