### PR TITLE
Fix improper cast of <row_count> from int64 (on some systems) to int32

### DIFF
--- a/gocql.go
+++ b/gocql.go
@@ -434,7 +434,7 @@ func (r *rows) Next(values []driver.Value) error {
 		return io.EOF
 	}
 	for column := 0; column < len(r.columns); column++ {
-		n := int(binary.BigEndian.Uint32(r.body))
+		n := int32(binary.BigEndian.Uint32(r.body))
 		r.body = r.body[4:]
 		if n >= 0 {
 			values[column] = decode(r.body[:n], r.meta[column])


### PR DESCRIPTION
This possibly only effects 64 bit builds.

rows.Next() crashes if a column value is null.
n := int32(binary.BigEndian.Uint32(r.body))
The issue is here:

`n := int(binary.BigEndian.Uint32(r.body))`

binary.BigEndian.Uint32(r.body) is casted as an int64, and as such the value of length of the column value is interpreted as 4294967295 instead of -1. This commit changes the line to

`n := int32(binary.BigEndian.Uint32(r.body))`

This commit also includes an test. Without the fix, the test should return

```
$ go test -timeout 60s github.com/channelmeter/gocql
--- FAIL: TestNullColumnValues (0.07 seconds)
panic: runtime error: slice bounds out of range [recovered]
    panic: runtime error: slice bounds out of range
```
