### PR TITLE
Resolved issue with Keyspace defined at the cluster level not being set

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -342,7 +342,7 @@ func (c *Conn) Address() string {
 }
 
 func (c *Conn) UseKeyspace(keyspace string) error {
-	resp, err := c.exec(&queryFrame{Stmt: "USE " + keyspace, Cons: Any}, nil)
+	resp, err := c.exec(&queryFrame{Stmt: "USE " + keyspace}, nil)
 	if err != nil {
 		return err
 	}

--- a/gocql_test/main.go
+++ b/gocql_test/main.go
@@ -51,11 +51,10 @@ func initSchema() error {
 		}`).Exec(); err != nil {
 		return err
 	}
-
-	if err := session.Query("USE gocql_test").Exec(); err != nil {
-		return err
-	}
-
+	//Close the old session and create a new one using the defined keyspace
+	session.Close()
+	cluster.Keyspace = "gocql_test"
+	session = cluster.CreateSession()
 	if err := session.Query(`CREATE TABLE page (
 			title       varchar,
 			revid       timeuuid,


### PR DESCRIPTION
Resolved issue with Keyspace defined at the cluster level not being set when the connections are being created. Removed unnecessary concurrency when defining the keyspace on the connection. Changed the mutex lock
logic in the cluster.addConn to prevent a race condition since when
defining the keyspace there is a recursive call to cluster.addConn.

I added a log.Println(err) to the cluster.changeKeyspace to provide output in the event there is an error.
