### PR TITLE
Return Error when user provides an empty array for hosts

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -5,12 +5,12 @@
 package gocql
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 	"sync"
 	"time"
-	"errors"
 )
 
 // ClusterConfig is a struct to configure the default cluster implementation
@@ -53,15 +53,13 @@ func NewCluster(hosts ...string) *ClusterConfig {
 
 // CreateSession initializes the cluster based on this config and returns a
 // session object that can be used to interact with the database.
-func (cfg *ClusterConfig) CreateSession() (*Session,error) {
+func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 
 	//Check that hosts in the ClusterConfig is not empty
-	if cfg.Hosts == nil {
-		return nil,ErrNoHosts 
-	} else if len(cfg.Hosts) < 1 {
-		return nil,ErrNoHosts
+	if len(cfg.Hosts) < 1 {
+		return nil, ErrNoHosts
 	}
-	
+
 	impl := &clusterImpl{
 		cfg:      *cfg,
 		hostPool: NewRoundRobin(),
@@ -83,7 +81,7 @@ func (cfg *ClusterConfig) CreateSession() (*Session,error) {
 	impl.wgStart.Wait()
 	s := NewSession(impl)
 	s.SetConsistency(cfg.Consistency)
-	return s,nil
+	return s, nil
 }
 
 type clusterImpl struct {

--- a/gocql_test/main.go
+++ b/gocql_test/main.go
@@ -18,12 +18,12 @@ import (
 var cluster *gocql.ClusterConfig
 var session *gocql.Session
 
-func init(){
+func init() {
 	cluster = gocql.NewCluster("127.0.0.1")
 	// uncomment the following two lines if you want to use Cassandra 1.2
 	// cluster.ProtoVersion = 1
 	// cluster.CQLVersion = "3.0.0"
-	session,_ = cluster.CreateSession()
+	session, _ = cluster.CreateSession()
 }
 
 type Page struct {
@@ -56,7 +56,7 @@ func initSchema() error {
 	time.Sleep(15 * time.Second)
 	log.Println("If there were error messages that an address cannot be assigned then the test failed.")
 	cluster.Keyspace = "gocql_test"
-	session,_ = cluster.CreateSession()
+	session, _ = cluster.CreateSession()
 
 	if err := session.Query(`CREATE TABLE page (
 			title       varchar,
@@ -144,10 +144,10 @@ func getPage(title string, revid uuid.UUID) (*Page, error) {
 //This test checks to make sure a valid error and a nil reference to
 //a session are returned when an empty array of hosts are provided
 //to the cluster configuration
-func TestEmptyHosts () error{
-	empty := make([]string,0)
+func TestEmptyHosts() error {
+	empty := make([]string, 0)
 	cfg := gocql.NewCluster(empty...)
-	_,err := cfg.CreateSession()
+	_, err := cfg.CreateSession()
 	return err
 }
 


### PR DESCRIPTION
Added code that when cluster.CreateSession is called an error will be returned if the user provided an empty array of strings for the hosts argument in gocql.NewCluster().

Added a test case that will validate that this issue remains fixed.
