### PR TITLE
Fix possible infinite wait on prepare error.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -279,6 +279,13 @@ func (c *Conn) prepareStatement(stmt string, trace Tracer) (*queryInfo, error) {
 	}
 
 	flight.wg.Done()
+
+	if err != nil {
+		c.prepMu.Lock()
+		delete(c.prep, stmt)
+		c.prepMu.Unlock()
+	}
+
 	return flight.info, flight.err
 }
 


### PR DESCRIPTION
If multiple goroutines try to prepare the same statement at the
same time and the goroutine which prepares the statement errors
it will never release the other goroutines from the waitgroup
wait.

Fix this by storing the error and info in a struct and always
call WaitGroup.Done()
