### PR TITLE
When uunmarshalling uuid's, check if data is empty

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -921,7 +921,7 @@ func marshalUUID(info *TypeInfo, value interface{}) ([]byte, error) {
 }
 
 func unmarshalUUID(info *TypeInfo, data []byte, value interface{}) error {
-	if data == nil {
+	if data == nil || len(data) == 0 {
 		switch v := value.(type) {
 		case *string:
 			*v = ""
@@ -932,11 +932,15 @@ func unmarshalUUID(info *TypeInfo, data []byte, value interface{}) error {
 		default:
 			return unmarshalErrorf("can not unmarshal X %s into %T", info, value)
 		}
+
+		return nil
 	}
+
 	u, err := UUIDFromBytes(data)
 	if err != nil {
 		return unmarshalErrorf("Unable to parse UUID: %s", err)
 	}
+
 	switch v := value.(type) {
 	case *string:
 		*v = u.String()


### PR DESCRIPTION
If data is empty then it should be treated as null.
