### PR TITLE
Skip paging test until #110 lands

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -152,6 +152,9 @@ func TestTracing(t *testing.T) {
 }
 
 func TestPaging(t *testing.T) {
+
+	t.Skip("Skip until https://github.com/gocql/gocql/issues/110 is resolved")
+
 	if *flagProto == 1 {
 		t.Skip("Paging not supported. Please use Cassandra >= 2.0")
 	}


### PR DESCRIPTION
The paging test causes Travis to fail the build and #110 tracks the status of the resolution. Until #110 lands, we should just skip this particular test. 
