### PR TITLE
Let UUID implements Marshaling interface for encoding/json

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -208,3 +208,8 @@ func (u UUID) Time() time.Time {
 	nsec := t % 1e7
 	return time.Unix(sec+timeBase, nsec).UTC()
 }
+
+// Marshaling for JSON
+func (u UUID) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + u.String() + `"`), nil
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -59,6 +59,15 @@ func TestPredefinedUUID(t *testing.T) {
 				t.Errorf("Version #%d: expected %d got %d", i, testsUUID[i].version, version)
 			}
 		}
+
+		json, err := uuid.MarshalJSON()
+		if err != nil {
+			t.Errorf("MarshalJSON #%d: %v", i, err)
+		}
+		expectedJson := `"` + testsUUID[i].input + `"`
+		if string(json) != expectedJson {
+			t.Errorf("MarshalJSON #%d: expected %d got %d", i, expectedJson, string(json))
+		}
 	}
 }
 


### PR DESCRIPTION
I'd like to have the gocql.UUID type directly passable to json.Marshal for convenience.
