### PR TITLE
Fix fatalf formatting

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -292,7 +292,7 @@ func TestCreateSessionTimeout(t *testing.T) {
 		t.Fatal("expected ErrNoConncetions, but no error was returned.")
 	}
 	if err != ErrNoConnections {
-		t.Fatal("expected ErrNoConnections, but received %v", err)
+		t.Fatalf("expected ErrNoConnections, but received %v", err)
 	}
 }
 


### PR DESCRIPTION
Fix using fatal instead of fatalf. Fixes gocql/gocql#128
