### PR TITLE
Timestamp type deferences to *int64

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -332,6 +332,7 @@ func TestSliceMap(t *testing.T) {
 	defer session.Close()
 	if err := session.Query(`CREATE TABLE slice_map_table (
 			testuuid       timeuuid PRIMARY KEY,
+			testtimestamp  timestamp,
 			testvarchar    varchar,
 			testbigint     bigint,
 			testblob       blob,
@@ -348,6 +349,7 @@ func TestSliceMap(t *testing.T) {
 	m["testuuid"] = TimeUUID()
 	m["testvarchar"] = "Test VarChar"
 	m["testbigint"] = time.Now().Unix()
+	m["testtimestamp"] = time.Now().Truncate(time.Millisecond).UTC()
 	m["testblob"] = []byte("test blob")
 	m["testbool"] = true
 	m["testfloat"] = float32(4.564)
@@ -356,8 +358,8 @@ func TestSliceMap(t *testing.T) {
 	m["testset"] = []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	m["testmap"] = map[string]string{"field1": "val1", "field2": "val2", "field3": "val3"}
 	sliceMap := []map[string]interface{}{m}
-	if err := session.Query(`INSERT INTO slice_map_table (testuuid, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testset, testmap) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		m["testuuid"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testset"], m["testmap"]).Exec(); err != nil {
+	if err := session.Query(`INSERT INTO slice_map_table (testuuid, testtimestamp, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testset, testmap) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		m["testuuid"], m["testtimestamp"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testset"], m["testmap"]).Exec(); err != nil {
 		t.Fatal("insert:", err)
 	}
 	if returned, retErr := session.Query(`SELECT * FROM slice_map_table`).Iter().SliceMap(); retErr != nil {
@@ -365,6 +367,9 @@ func TestSliceMap(t *testing.T) {
 	} else {
 		if sliceMap[0]["testuuid"] != returned[0]["testuuid"] {
 			t.Fatal("returned testuuid did not match")
+		}
+		if sliceMap[0]["testtimestamp"] != returned[0]["testtimestamp"] {
+			t.Fatalf("returned testtimestamp did not match: %v %v", sliceMap[0]["testtimestamp"], returned[0]["testtimestamp"])
 		}
 		if sliceMap[0]["testvarchar"] != returned[0]["testvarchar"] {
 			t.Fatal("returned testvarchar did not match")
@@ -402,6 +407,9 @@ func TestSliceMap(t *testing.T) {
 	}
 	if sliceMap[0]["testuuid"] != testMap["testuuid"] {
 		t.Fatal("returned testuuid did not match")
+	}
+	if sliceMap[0]["testtimestamp"] != testMap["testtimestamp"] {
+		t.Fatal("returned testtimestamp did not match")
 	}
 	if sliceMap[0]["testvarchar"] != testMap["testvarchar"] {
 		t.Fatal("returned testvarchar did not match")

--- a/helpers.go
+++ b/helpers.go
@@ -4,14 +4,17 @@
 
 package gocql
 
-import "reflect"
+import (
+	"reflect"
+	"time"
+)
 
 type rowData struct {
 	Columns []string
-	Values []interface{}
+	Values  []interface{}
 }
 
-// New creates a pointer to an empty version of whatever type 
+// New creates a pointer to an empty version of whatever type
 // is referenced by the TypeInfo receiver
 func (t *TypeInfo) New() interface{} {
 	return reflect.New(goType(t)).Interface()
@@ -21,8 +24,10 @@ func goType(t *TypeInfo) reflect.Type {
 	switch t.Type {
 	case TypeVarchar, TypeAscii:
 		return reflect.TypeOf(*new(string))
-	case TypeBigInt, TypeCounter, TypeTimestamp:
+	case TypeBigInt, TypeCounter:
 		return reflect.TypeOf(*new(int64))
+	case TypeTimestamp:
+		return reflect.TypeOf(*new(time.Time))
 	case TypeBlob:
 		return reflect.TypeOf(*new([]byte))
 	case TypeBoolean:
@@ -67,7 +72,7 @@ func (iter *Iter) rowData() (rowData, error) {
 	}
 	rowData := rowData{
 		Columns: columns,
-		Values: values,
+		Values:  values,
 	}
 	return rowData, nil
 }
@@ -104,7 +109,7 @@ func (iter *Iter) MapScan(m map[string]interface{}) bool {
 	rowData, _ := iter.rowData()
 
 	if iter.Scan(rowData.Values...) {
-		rowData.rowMap(m)	
+		rowData.rowMap(m)
 		return true
 	}
 	return false


### PR DESCRIPTION
The switch statement to create the scan pointer incorrectly assigns a timestamp to `*int64`.
