### PR TITLE
Added code to make working with batches a tad easier

### DIFF
--- a/session.go
+++ b/session.go
@@ -469,4 +469,6 @@ var (
 	ErrTooManyStmts = errors.New("too many statements")
 )
 
-const BatchSizeMaximum = 65536
+// BatchSizeMaximum is the maximum number of statements a batch operation can have.
+// This limit is set by cassandra and could change in the future.
+const BatchSizeMaximum = 65535


### PR DESCRIPTION
Hey guys its been a while since I have contributed but I am slowly getting more free time :)

In this request I am adding some conviences to the usage of batch statements.

I have added a Size() function so the user can see how many statements they have in their statement. Also I have moved the batch entry limit from being a hard coded value to being an exported constant.

This way a user can break a large batch statement up by matching sure the batch statement is <= to the BatchSizeMaximum.

Example:

``` go
b :=  session.NewBatch(gocql.LoggedBatch)
for {
   ...
   if b.Size() == gocql.BatchSizeMaximum {
      sess.ExecuteBatch(b)
      b = session.NewBatch(gocql.LoggedBatch)
      time.Sleep(5 * time.Seconds) //Sleep to allow cassandra to write changes to disk.
   }
   ...
}
```

This is a crude example but I hope it illustrates my point :)
