### PR TITLE
Instead of checking for timeouts check for Tempoary errors, which will a...

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -215,7 +215,7 @@ func (c *Conn) recv() (frame, error) {
 		nn, err := c.r.Read(resp[n:])
 		n += nn
 		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
 				if n > last {
 					// we hit the deadline but we made progress.
 					// simply extend the deadline


### PR DESCRIPTION
...llow 5 timeouts before returning false
