### PR TITLE
Changed the reconnection logic to reduce the flood of reconnects.

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -96,7 +96,7 @@ func TestInvalidKeyspace(t *testing.T) {
 		}
 	} else {
 		session.Close() //Clean up the session
-		t.Error("Expected an error but CreateSession returned none.")
+		t.Error("expected err, got nil.")
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -166,6 +166,7 @@ func TestConnClosing(t *testing.T) {
 	if err != nil {
 		t.Errorf("NewCluster: %v", err)
 	}
+	defer db.Close()
 
 	numConns := db.cfg.NumConns
 	count := db.cfg.NumStreams * numConns
@@ -181,17 +182,9 @@ func TestConnClosing(t *testing.T) {
 
 	wg.Wait()
 
+	time.Sleep(1 * time.Second) //Sleep so the fillPool can complete.
 	cluster := db.Node.(*clusterImpl)
-	//Commented out as not sure the reason for closing the connections
-	//after they have been killed via queries.
-	/*cluster.mu.Lock()
-	for conn := range cluster.conns {
-		conn.conn.Close()
-	}
 
-	cluster.mu.Unlock()*/
-
-	time.Sleep(20 * time.Millisecond)
 	cluster.mu.Lock()
 	conns := len(cluster.conns)
 	cluster.mu.Unlock()


### PR DESCRIPTION
As per my rant on the gocql mailing list. Sorry Chris this address the connection flooding when an invalid keyspace is defined.

Also in conn_test in the TestConnClose I commented out the connection closing as I did not understand the reason this was being done. Connections are closed with the kill query and then the code I commented out reached into the library to delibrately close connections. I just want to understand this as this causes the test to fail with 3 connections in the pool instead of the expected 2.

I cleaned up a lot of Cluster Config parameters that were related to the old connection retry logic.

The one improvement I can see right now is implementing debouncing of calls to fillPool() so that its not chugging away and consuming resources.
