### PR TITLE
provide some details when encountering a protocol error

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -178,7 +178,7 @@ func (f *frame) skipHeader() {
 
 func (f *frame) readInt() int {
 	if len(*f) < 4 {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read an int while >4 bytes in the buffer"))
 	}
 	v := uint32((*f)[0])<<24 | uint32((*f)[1])<<16 | uint32((*f)[2])<<8 | uint32((*f)[3])
 	*f = (*f)[4:]
@@ -187,7 +187,7 @@ func (f *frame) readInt() int {
 
 func (f *frame) readShort() uint16 {
 	if len(*f) < 2 {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read a short while >2 bytes in the buffer"))
 	}
 	v := uint16((*f)[0])<<8 | uint16((*f)[1])
 	*f = (*f)[2:]
@@ -197,7 +197,7 @@ func (f *frame) readShort() uint16 {
 func (f *frame) readString() string {
 	n := int(f.readShort())
 	if len(*f) < n {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read a string of %d bytes from a buffer with %d bytes in it", n, len(*f)))
 	}
 	v := string((*f)[:n])
 	*f = (*f)[n:]
@@ -207,7 +207,7 @@ func (f *frame) readString() string {
 func (f *frame) readLongString() string {
 	n := f.readInt()
 	if len(*f) < n {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read a string of %d bytes from a buffer with %d bytes in it", n, len(*f)))
 	}
 	v := string((*f)[:n])
 	*f = (*f)[n:]
@@ -220,7 +220,7 @@ func (f *frame) readBytes() []byte {
 		return nil
 	}
 	if len(*f) < n {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read %d bytes from a buffer with %d bytes in it", n, len(*f)))
 	}
 	v := (*f)[:n]
 	*f = (*f)[n:]
@@ -230,7 +230,7 @@ func (f *frame) readBytes() []byte {
 func (f *frame) readShortBytes() []byte {
 	n := int(f.readShort())
 	if len(*f) < n {
-		panic(ErrProtocol)
+		panic(NewErrProtocol("Trying to read %d bytes from a buffer with %d bytes in it", n, len(*f)))
 	}
 	v := (*f)[:n]
 	*f = (*f)[n:]

--- a/session.go
+++ b/session.go
@@ -491,11 +491,16 @@ func (e Error) Error() string {
 var (
 	ErrNotFound     = errors.New("not found")
 	ErrUnavailable  = errors.New("unavailable")
-	ErrProtocol     = errors.New("protocol error")
 	ErrUnsupported  = errors.New("feature not supported")
 	ErrTooManyStmts = errors.New("too many statements")
 	ErrUseStmt      = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
 )
+
+type ErrProtocol struct{ error }
+
+func NewErrProtocol(format string, args ...interface{}) error {
+	return ErrProtocol{fmt.Errorf(format, args...)}
+}
 
 // BatchSizeMaximum is the maximum number of statements a batch operation can have.
 // This limit is set by cassandra and could change in the future.


### PR DESCRIPTION
Hey guys, this is a first cut at an implementation of more verbose messaging for protocol errors. The motivation is that we occasionally see `protocol error` in our logs, but have no further recourse for figuring out what was even happening.

This preserves the ability to broadly distinguish protocol errors from others (by doing `err.(ProtocolError)`) while also permitting more verbose logging. Functionally, this patch should be identical, though I would appreciate a good vetting to ensure the messages actually communicate the error correctly.

I would also love to see the same approach adopted to other errors that appear frequently in the code, but I haven't grepped to see if there are others yet and thought I'd cut this PR to see what everyone thought of the general idea.

The tests pass against cassandra 1.2 with `-proto=1`.
