### PR TITLE
Remove check for available streams

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -423,7 +423,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 }
 
 func (c *Conn) Pick(qry *Query) *Conn {
-	if c.Closed() || len(c.uniq) == 0 {
+	if c.Closed() {
 		return nil
 	}
 	return c


### PR DESCRIPTION
A connection should be pickable even if no streams are currently
available. In this case, when executing the query, the connection will
block reading from the streams channel [see func (c *Conn) exec(...)]
until one is available.

This avoids 'unavailable' errors when there are more than
numConns*numStreams queries pending.
