### PR TITLE
Run test suite against multiple versions of Cassandra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
+
 go:
   - 1.1
   - 1.2
-services:
-  - cassandra
+
+script:
+  - bash integration.sh
+
 notifications:
-  email: false
+  - email: false

--- a/integration.sh
+++ b/integration.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+PID_FILE=cassandra.pid
+STARTUP_LOG=startup.log
+ARCHIVE_BASE_URL=http://archive.apache.org/dist/cassandra
+
+for v in 2.0.6 2.0.7
+do
+	TARBALL=apache-cassandra-$v-bin.tar.gz
+	CASSANDRA_DIR=apache-cassandra-$v
+
+	curl -L -O $ARCHIVE_BASE_URL/$v/$TARBALL
+	
+	if [ ! -f $CASSANDRA_DIR/bin/cassandra ]
+	then
+   		tar xzf $TARBALL
+	fi
+	
+	CASSANDRA_LOG_DIR=`pwd`/v${v}/log/cassandra
+	CASSANDRA_LOG=$CASSANDRA_LOG_DIR/system.log
+
+	mkdir -p $CASSANDRA_LOG_DIR
+	: >$CASSANDRA_LOG  # create an empty log file
+	
+	sed -i -e 's?/var?'`pwd`/v${v}'?' $CASSANDRA_DIR/conf/cassandra.yaml
+	sed -i -e 's?/var?'`pwd`/v${v}'?' $CASSANDRA_DIR/conf/log4j-server.properties
+
+	echo "Booting Cassandra ${v}, waiting for CQL listener to start ...."
+
+	$CASSANDRA_DIR/bin/cassandra -p $PID_FILE &> $STARTUP_LOG
+
+	{ tail -n +1 -f $CASSANDRA_LOG & } | sed -n '/Starting listening for CQL clients/q'
+	
+	PID=$(<"$PID_FILE")
+
+	echo "Cassandra ${v} running (PID ${PID}), about to run test suite ...."
+
+	go test -v ./...
+
+	echo "Test suite passed against Cassandra ${v}, killing server instance (PID ${PID})"
+	
+	kill -9 $PID
+	rm $PID_FILE
+done


### PR DESCRIPTION
This patch adds a test suite against different versions of Cassandra.

The motivation is that we are currently restricted by whatever version of Cassandra Travis supports. It would be nicer to be able to iterate through all versions that we want to support.

For note, this branch was transplanted from #159.
