### PR TITLE
Unskip paging test

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -194,16 +194,16 @@ func TestPaging(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
 
-	if err := session.Query("CREATE TABLE large (id int primary key)").Exec(); err != nil {
+	if err := session.Query("CREATE TABLE paging (id int primary key)").Exec(); err != nil {
 		t.Fatal("create table:", err)
 	}
 	for i := 0; i < 100; i++ {
-		if err := session.Query("INSERT INTO large (id) VALUES (?)", i).Exec(); err != nil {
+		if err := session.Query("INSERT INTO paging (id) VALUES (?)", i).Exec(); err != nil {
 			t.Fatal("insert:", err)
 		}
 	}
 
-	iter := session.Query("SELECT id FROM large").PageSize(10).Iter()
+	iter := session.Query("SELECT id FROM paging").PageSize(10).Iter()
 	var id int
 	count := 0
 	for iter.Scan(&id) {


### PR DESCRIPTION
This test was skipped because of issues with Cassandra 2.0.4 (see #110 for the background), but now that #163 has landed, maybe we can run this test again. Note that this means that we are effectively saying that we don't officially support 2.0.4, but I don't see this as a big issue.
