### PR TITLE
export consistency names

### DIFF
--- a/session.go
+++ b/session.go
@@ -433,7 +433,7 @@ const (
 	LocalSerial
 )
 
-var consinstencyNames = []string{
+var ConsistencyNames = []string{
 	0:           "default",
 	Any:         "any",
 	One:         "one",
@@ -448,7 +448,7 @@ var consinstencyNames = []string{
 }
 
 func (c Consistency) String() string {
-	return consinstencyNames[c]
+	return ConsistencyNames[c]
 }
 
 type ColumnInfo struct {


### PR DESCRIPTION
This exports ConsistencyNames to make it available for consuming programs.

In my case I have built a cli client which makes the consistency level available as a parameter. But to be able to check it against available consistency levels, I have to be able to look them up.
