### PR TITLE
changed the String() method for UUID's

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -29,7 +29,6 @@ const (
 	VariantIETF      = 2
 	VariantMicrosoft = 6
 	VariantFuture    = 7
-	HexString = "0123456789abcdef"
 )
 
 func init() {
@@ -147,28 +146,12 @@ func UUIDFromTime(aTime time.Time) UUID {
 // String returns the UUID in it's canonical form, a 32 digit hexadecimal
 // number in the form of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 func (u UUID) String() string {
-	var b1, b2 byte
+	var offsets = [...]int{0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}
+	const hexString = "0123456789abcdef"
 	r := make([]byte, 36)
 	for i, b := range u {
-		b1 = HexString[b >> 4]
-		b2 = HexString[b &^ 240]
-		switch {
-		case i < 4:
-			r[i*2] = b1
-			r[(i*2)+1] = b2
-		case i >= 4 && i < 6:
-			r[(i*2)+1] = b1
-			r[(i*2)+2] = b2
-		case i >= 6 && i < 8:
-			r[(i*2)+2] = b1
-			r[(i*2)+3] = b2
-		case i >= 8 && i < 10:
-			r[(i*2)+3] = b1
-			r[(i*2)+4] = b2
-		case i >= 10:
-			r[(i*2)+4] = b1
-			r[(i*2)+5] = b2
-		}
+                r[offsets[i]] = hexString[b>>4]
+		r[offsets[i]+1] = hexString[b&0xF]
 	}
 	r[8] = '-'
 	r[13] = '-'


### PR DESCRIPTION
I was profiling some code for work, that uses the UUID.String() method a lot and saw it was using fmt.Sprintf(), which is a bit overkill, if you ask me. I changed it to use a switch statement. It is now between 4-6 times faster. Here is a [benchmark](https://gist.github.com/cwandrews/75a2b8f92d96e2aeb083).
