### PR TITLE
executeBatch can cause a dead lock to a nil deref causing c.prepMu not to be unlocked. 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -505,6 +505,9 @@ func (c *Conn) executeBatch(batch *Batch) error {
 		c.prepMu.Lock()
 		found := false
 		for stmt, flight := range c.prep {
+			if flight == nil || flight.info == nil {
+				continue
+			}
 			if bytes.Equal(flight.info.id, x.StatementId) {
 				found = true
 				delete(c.prep, stmt)


### PR DESCRIPTION
Currently in a high load situation `flight` or `flight.info` can be nil when execute batch is called (the prepareStatement call can take a long time or even timeout, during this time flight.info can be nil).

As executebatch searches for the prepared statement to reset, it can come across such a statement and panic. This panic causes `c.prepMu` not to be unlocked causing a dead lock.
