### PR TITLE
Added new implementation of the preparedLRU cache.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -14,36 +14,38 @@ import (
 // behavior to fit the most common use cases. Applications that requre a
 // different setup must implement their own cluster.
 type ClusterConfig struct {
-	Hosts           []string      // addresses for the initial connections
-	CQLVersion      string        // CQL version (default: 3.0.0)
-	ProtoVersion    int           // version of the native protocol (default: 2)
-	Timeout         time.Duration // connection timeout (default: 600ms)
-	DefaultPort     int           // default port (default: 9042)
-	Keyspace        string        // initial keyspace (optional)
-	NumConns        int           // number of connections per host (default: 2)
-	NumStreams      int           // number of streams per connection (default: 128)
-	Consistency     Consistency   // default consistency level (default: Quorum)
-	Compressor      Compressor    // compression algorithm (default: nil)
-	Authenticator   Authenticator // authenticator (default: nil)
-	RetryPolicy     RetryPolicy   // Default retry policy to use for queries (default: 0)
-	SocketKeepalive time.Duration // The keepalive period to use, enabled if > 0 (default: 0)
-	ConnPoolType    NewPoolFunc   // The function used to create the connection pool for the session (default: NewSimplePool)
-	DiscoverHosts   bool          // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
+	Hosts            []string      // addresses for the initial connections
+	CQLVersion       string        // CQL version (default: 3.0.0)
+	ProtoVersion     int           // version of the native protocol (default: 2)
+	Timeout          time.Duration // connection timeout (default: 600ms)
+	DefaultPort      int           // default port (default: 9042)
+	Keyspace         string        // initial keyspace (optional)
+	NumConns         int           // number of connections per host (default: 2)
+	NumStreams       int           // number of streams per connection (default: 128)
+	Consistency      Consistency   // default consistency level (default: Quorum)
+	Compressor       Compressor    // compression algorithm (default: nil)
+	Authenticator    Authenticator // authenticator (default: nil)
+	RetryPolicy      RetryPolicy   // Default retry policy to use for queries (default: 0)
+	SocketKeepalive  time.Duration // The keepalive period to use, enabled if > 0 (default: 0)
+	ConnPoolType     NewPoolFunc   // The function used to create the connection pool for the session (default: NewSimplePool)
+	DiscoverHosts    bool          // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
+	MaxPreparedStmts int           // Adjusts the maximum size of the prepared statement cache that is global to all sessions (default: 1000)
 }
 
 // NewCluster generates a new config for the default cluster implementation.
 func NewCluster(hosts ...string) *ClusterConfig {
 	cfg := &ClusterConfig{
-		Hosts:         hosts,
-		CQLVersion:    "3.0.0",
-		ProtoVersion:  2,
-		Timeout:       600 * time.Millisecond,
-		DefaultPort:   9042,
-		NumConns:      2,
-		NumStreams:    128,
-		Consistency:   Quorum,
-		ConnPoolType:  NewSimplePool,
-		DiscoverHosts: false,
+		Hosts:            hosts,
+		CQLVersion:       "3.0.0",
+		ProtoVersion:     2,
+		Timeout:          600 * time.Millisecond,
+		DefaultPort:      9042,
+		NumConns:         2,
+		NumStreams:       128,
+		Consistency:      Quorum,
+		ConnPoolType:     NewSimplePool,
+		DiscoverHosts:    false,
+		MaxPreparedStmts: 1000,
 	}
 	return cfg
 }
@@ -57,6 +59,7 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 		return nil, ErrNoHosts
 	}
 	pool := cfg.ConnPoolType(cfg)
+	stmtsLRU.setMaxStmts(cfg.MaxPreparedStmts)
 
 	//See if there are any connections in the pool
 	if pool.Size() > 0 {


### PR DESCRIPTION
Hi Guys,

This is my second attempt at resolving issue #184. I took the comments from my last PR #187 and implemented a new version of the LRU cache for prepared statements using the `github.com/golang/groupcache/lru` package for guidance.

I implemented some integration tests to reproduce the issue this PR is trying to resolve. Also I didn't go to crazy with the integration tests because all queries are prepared and so the code is accessed many times with existing tests.

Hopefully this PR hits closer to the type of LRU implementation the team is looking for. Also I updated my [benchmark](https://github.com/phillipCouto/lrutest) to compare the LRU code in the PR against the lru package from groupcache and the PR code is out performing the lru package.
