### PR TITLE
Check the error status of prepareStatement in execute batch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -490,6 +490,9 @@ func (c *Conn) executeBatch(batch *Batch) error {
 		if len(entry.Args) > 0 || entry.binding != nil {
 			var err error
 			info, err = c.prepareStatement(entry.Stmt, nil)
+			if err != nil {
+				return err
+			}
 
 			if entry.binding == nil {
 				args = entry.Args
@@ -505,9 +508,6 @@ func (c *Conn) executeBatch(batch *Batch) error {
 			}
 
 			stmts[string(info.Id)] = entry.Stmt
-			if err != nil {
-				return err
-			}
 			f.writeByte(1)
 			f.writeShortBytes(info.Id)
 		} else {


### PR DESCRIPTION
Currently it seems some code got inserted in between the error check for prepare statement. This code access the info return value, which might be nil, which can cause a panic.

This PR simply moves up the error check.
