### PR TITLE
Add LocalOne consistency

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -347,6 +347,7 @@ var consistencyCodes = []uint16{
 	EachQuorum:  0x0007,
 	Serial:      0x0008,
 	LocalSerial: 0x0009,
+	LocalOne:    0x000A,
 }
 
 type readyFrame struct{}

--- a/session.go
+++ b/session.go
@@ -456,6 +456,7 @@ const (
 	EachQuorum
 	Serial
 	LocalSerial
+	LocalOne
 )
 
 var ConsistencyNames = []string{
@@ -470,6 +471,7 @@ var ConsistencyNames = []string{
 	EachQuorum:  "eachquorum",
 	Serial:      "serial",
 	LocalSerial: "localserial",
+	LocalOne:    "localone",
 }
 
 func (c Consistency) String() string {


### PR DESCRIPTION
From the Cassandra documentation about LOCAL_ONE:

```
In a multiple data center clusters, a consistency level of ONE is often desirable, but cross-DC traffic is not. LOCAL_ONE accomplishes this. For security and quality reasons, you can use this consistency level in an offline datacenter to prevent automatic connection to online nodes in other data centers if an offline node goes down.
```
