### PR TITLE
Removed "Alpha" project status warning from README.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Josh Wright <jshwright@gmail.com>
 Jacob Rhoden <jacob.rhoden@gmail.com>
 Ben Frye <benfrye@gmail.com>
 Fred McCann <fred@sharpnoodles.com>
+Dan Simmons <dan@simmons.io>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ gocql
 [![Build Status](https://travis-ci.org/gocql/gocql.png?branch=master)](https://travis-ci.org/gocql/gocql)
 [![GoDoc](http://godoc.org/github.com/gocql/gocql?status.png)](http://godoc.org/github.com/gocql/gocql)
 
-**Package Status:** Alpha 
-
 Package gocql implements a fast and robust Cassandra client for the
 Go programming language.
 


### PR DESCRIPTION
As discussed with @0x6e6562 [over Twitter](https://twitter.com/0x6e6562/status/497057217854832642).

I'm open to incrementing this to "Beta" or "Production-ready" instead, but it seemed like the most conflict-free thing to do would be to remove it altogether.
