### PR TITLE
fixed rowMap to copy slices instead of pass them in

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -103,7 +103,14 @@ func getApacheCassandraType(class string) Type {
 
 func (r *RowData) rowMap(m map[string]interface{}) {
 	for i, column := range r.Columns {
-		m[column] = dereference(r.Values[i])
+		val := dereference(r.Values[i])
+		if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice {
+			valCopy := reflect.MakeSlice(valVal.Type(), valVal.Len(), valVal.Cap())
+			reflect.Copy(valCopy, valVal)
+			m[column] = valCopy.Interface()
+		} else {
+			m[column] = val
+		}
 	}
 }
 


### PR DESCRIPTION
We were having issues where slices were getting refilled after the scan. This creates a new slice of the correct size and capacity and then copies the source slice into it.
