### PR TITLE
Added test case to validate issue #227

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -819,6 +819,28 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 	return stmt, conn
 }
 
+func TestMissingSchemaPrepare(t *testing.T) {
+	s := createSession(t)
+	conn := s.Pool.Pick(nil)
+	defer s.Close()
+
+	insertQry := &Query{stmt: "INSERT INTO invalidschemaprep (val) VALUES (?)", values: []interface{}{5}, cons: s.cons,
+		session: s, pageSize: s.pageSize, trace: s.trace,
+		prefetch: s.prefetch, rt: s.cfg.RetryPolicy}
+
+	if err := conn.executeQuery(insertQry).err; err == nil {
+		t.Fatal("expected error, but got nil.")
+	}
+
+	if err := createTable(s, "CREATE TABLE invalidschemaprep (val int, PRIMARY KEY (val))"); err != nil {
+		t.Fatal("create table:", err)
+	}
+
+	if err := conn.executeQuery(insertQry).err; err != nil {
+		t.Fatal(err) // unconfigured columnfamily
+	}
+}
+
 func TestReprepareStatement(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()


### PR DESCRIPTION
This test case demonstrates issue #227 by using a single connection for executing the query.
