### PR TITLE
Added code to pass on flight.err to err 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -338,6 +338,7 @@ func (c *Conn) prepareStatement(stmt string, trace Tracer) (*QueryInfo, error) {
 		default:
 			flight.err = NewErrProtocol("Unknown type in response to prepare frame: %s", x)
 		}
+		err = flight.err
 	}
 
 	flight.wg.Done()


### PR DESCRIPTION
The flight.err was not seen by the logic in prepareStatement to purge the statement from the cache in the event the prepare statement query returned an error.

This is any attempt to resolve issue #227.
