### PR TITLE
Re-order ccm commands

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -4,9 +4,10 @@ set -e
 
 function run_tests() {
 	local version=$1
-	ccm create test -v binary:$version -n 3 -s -d --vnodes
-	ccm status
+	ccm create test -v binary:$version -n 3 -d --vnodes
 	ccm updateconf 'concurrent_reads: 8' 'concurrent_writes: 32' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 8' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
+	ccm start
+	ccm status
 
 	local proto=2
 	if [[ $version == 1.2.* ]]; then


### PR DESCRIPTION
This is an attempt to reduce timeouts when booting ccm - see [this discussion](https://github.com/pcmanus/ccm/issues/148) for more details.
