### PR TITLE
Reduced threads and memory used by cassandra instances in travis.

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -7,7 +7,11 @@ function run_tests() {
 	local version=$1
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
-	ccm updateconf 'concurrent_reads: 8' 'concurrent_writes: 32' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 8' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
+	
+	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="256M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+
+	ccm updateconf 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 2' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
 	ccm start
 	ccm status
 


### PR DESCRIPTION
This PR is an attempt to reduce the build errors experienced by users submitting PRs. The errors seem to be related to resource starvation in the travis instance.
