### PR TITLE
Handle UnmarshalCQL() in MapScan()

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -160,6 +160,12 @@ func (iter *Iter) MapScan(m map[string]interface{}) bool {
 	// Not checking for the error because we just did
 	rowData, _ := iter.RowData()
 
+	for i, col := range rowData.Columns {
+		if dest, ok := m[col]; ok {
+			rowData.Values[i] = dest
+		}
+	}
+
 	if iter.Scan(rowData.Values...) {
 		rowData.rowMap(m)
 		return true


### PR DESCRIPTION
Currently, as far as unmarshal concerned, `MapScan()` is not as flexible as `Scan()`.
Unlike `Scan()`, `MapScan()` can not handle `Unmarshaler` or any other smart unmarshal logics gocql equips.
It is because `MapScan()` can't receive arbitrary typed variables which you want to store columns into.
Actually, this limitation has bothered me for a long time. I would like to use `UnmarshalerCQL()`.

In this patch, I make `MapScan(map[string]interface{})` receive an map which contains reference variables in its elements. If a column name already has the ref-value, `MapScan()` set the value to the reference.
By this extension, `MapScan()` can handle arbitrary type conversion as well as `Scan()`.

Could you review this extension?

for example:

``` go
type FullName struct {
    FirstName string
    LastName  string
}
func (n *FullName) UnmarshalCQL(info *TypeInfo, data []byte) error {
    t := strings.SplitN(string(data), " ", 2)
    n.FirstName, n.LastName = t[0], t[1]
    return nil
}

var age int
var fullname FullName
// Set some references to this map before passes it to MapScan()
m := map[string]interface{} {
  "age": &age,
  "full_name": &fullname,
}
err := session.Query(`SELECT id,full_name,age,weight  FROM users limit where id='x'`).Iter().MapScan(m)
fmt.Printf("ID:%v, AGE:%v, FN:%v LN:%v W:%v¥n",
  m["id"],
  m["age"],
  m["full_name"].(FullName).FirstName,
  m["full_name"].(FullName).LastName,
  m["weight"]
)
```
