### PR TITLE
Fix bug fetching out unset timestamp values.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -752,7 +752,7 @@ func marshalTimestamp(info *TypeInfo, value interface{}) ([]byte, error) {
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:
-		x := v.In(time.UTC).UnixNano() / int64(time.Millisecond)
+		x := v.UnixNano() / int64(1000000)
 		return encBigInt(x), nil
 	}
 	rv := reflect.ValueOf(value)
@@ -773,6 +773,9 @@ func unmarshalTimestamp(info *TypeInfo, data []byte, value interface{}) error {
 		*v = decBigInt(data)
 		return nil
 	case *time.Time:
+		if len(data) == 0 {
+			return nil
+		}
 		x := decBigInt(data)
 		sec := x / 1000
 		nsec := (x - sec*1000) * 1000000


### PR DESCRIPTION
If your row exists but has an empty timestamp column, your time.Time
bind variable was being initialized to epoch time 0. Now it returns
early and does not modify the bind variable. I considered having it
instead set the bind variable to the go zero time.Time value, but
since that is techincally a legitimate time value as well it still
doesn't solve the semipredicate problem.

I tweaked the timestamp marshal code to do "val.UnixNano() / 1000000"
instead of "val.UnixNano() / time.Millisecond" because it doesn't make
sense to do operations directly between integers and time.Duration values.
The latter only works because the base unit for time.Duration happens to
be nanoseconds.
