### PR TITLE
Added AvailableStreams function to Conn structure.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -48,9 +48,9 @@ func (p PasswordAuthenticator) Success(data []byte) error {
 }
 
 type SslOptions struct {
-	CertPath               string
-	KeyPath                string
-	CaPath                 string //optional depending on server config
+	CertPath string
+	KeyPath  string
+	CaPath   string //optional depending on server config
 	// If you want to verify the hostname and server cert (like a wildcard for cass cluster) then you should turn this on
 	// This option is basically the inverse of InSecureSkipVerify
 	// See InSecureSkipVerify in http://golang.org/pkg/crypto/tls/ for more info
@@ -503,6 +503,10 @@ func (c *Conn) Close() {
 
 func (c *Conn) Address() string {
 	return c.addr
+}
+
+func (c *Conn) AvailableStreams() int {
+	return len(c.uniq)
 }
 
 func (c *Conn) UseKeyspace(keyspace string) error {


### PR DESCRIPTION
This exports the amount of Available Streams a connection has to user code. 

I am in need of this API as I am planning on creating a new host and connection pool in my gocql-contrib that will allow me to begin work on the host selection pipeline.

Specifically I am creating a connection pool for all the connections belonging to a host. I need this API so when I am picking a connection I can distribute queries to connections that are not maxed out.
