### PR TITLE
Support latest releases from Apache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 env:
-  - CASS=1.2.18
-  - CASS=2.0.9
+  - CASS=1.2.19
+  - CASS=2.0.10
 
 go:
   - 1.2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported Versions
 
 The following matrix shows the versions of Go and Cassandra that are tested with the integration test suite as part of the CI build:
 
-Go/Cassandra | 1.2.18 | 2.0.9 | 2.1.0-RC5
+Go/Cassandra | 1.2.19 | 2.0.10 | 2.1.0
 -------------| -------| ------| ---------
 1.2  | yes | yes | partial
 1.3  | yes | yes | partial


### PR DESCRIPTION
This is a tiny patch to bump the version of the server that we support in the ccm run.
