### PR TITLE
keepalive - idle, interval and count

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -40,6 +40,12 @@ type DiscoveryConfig struct {
 	Sleep time.Duration
 }
 
+type KeepaliveConfig struct {
+	Interval 	time.Duration
+	Idle 		time.Duration
+	Count 		int
+}
+
 // ClusterConfig is a struct to configure the default cluster implementation
 // of gocoql. It has a varity of attributes that can be used to modify the
 // behavior to fit the most common use cases. Applications that requre a
@@ -57,7 +63,7 @@ type ClusterConfig struct {
 	Compressor       Compressor    // compression algorithm (default: nil)
 	Authenticator    Authenticator // authenticator (default: nil)
 	RetryPolicy      RetryPolicy   // Default retry policy to use for queries (default: 0)
-	SocketKeepalive  time.Duration // The keepalive period to use, enabled if > 0 (default: 0)
+	Keepalive  		 *KeepaliveConfig // The keepalive period to use, enabled if > 0 (default: 0)
 	ConnPoolType     NewPoolFunc   // The function used to create the connection pool for the session (default: NewSimplePool)
 	DiscoverHosts    bool          // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
 	MaxPreparedStmts int           // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -35,7 +35,7 @@ Example of Single Connection Pool:
 			NumStreams:    cfg.NumStreams,
 			Compressor:    cfg.Compressor,
 			Authenticator: cfg.Authenticator,
-			Keepalive:     cfg.SocketKeepalive,
+			KeepaliveCfg:  cfg.Keepalive
 		}
 		pool := SingleConnection{cfg:cfg}
 		pool.conn = Connect(addr,connCfg,pool)
@@ -51,7 +51,7 @@ Example of Single Connection Pool:
 				NumStreams:    cfg.NumStreams,
 				Compressor:    cfg.Compressor,
 				Authenticator: cfg.Authenticator,
-				Keepalive:     cfg.SocketKeepalive,
+				KeepaliveCfg:  cfg.Keepalive,
 			}
 			s.conn = Connect(conn.Address(),connCfg,s)
 		}
@@ -161,7 +161,7 @@ func (c *SimplePool) connect(addr string) error {
 		NumStreams:    c.cfg.NumStreams,
 		Compressor:    c.cfg.Compressor,
 		Authenticator: c.cfg.Authenticator,
-		Keepalive:     c.cfg.SocketKeepalive,
+		KeepaliveCfg:  c.cfg.Keepalive,
 		SslOpts:       c.cfg.SslOpts,
 	}
 


### PR DESCRIPTION
We use tcp keepalive a lot in our env. So I though that it would be nice to have all keepalive options configurable. 
Previously one could only specify KeepAlivePeriod. In that case other two settings (idle and count) will have default values. And for my desktop ubuntu it's 2 hours and 9 tries respectfully. These timings are huge and we want to be able to set them appropriate to the needs. 