### PR TITLE
Fix unmarshal list and set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,4 +39,3 @@ Dean Elbaz <elbaz.dean@gmail.com>
 Mike Berman <evencode@gmail.com>
 Dmitriy Fedorenko <c0va23@gmail.com>
 Zach Marcantel <zmarcantel@gmail.com>
-James Maloney <jamessagan@gmail.com>

--- a/marshal.go
+++ b/marshal.go
@@ -853,10 +853,8 @@ func unmarshalList(info *TypeInfo, data []byte, value interface{}) error {
 			if rv.Len() != n {
 				return unmarshalErrorf("unmarshal list: array with wrong size")
 			}
-		} else if rv.Cap() < n {
-			rv.Set(reflect.MakeSlice(t, n, n))
 		} else {
-			rv.SetLen(n)
+			rv.Set(reflect.MakeSlice(t, n, n))
 		}
 		for i := 0; i < n; i++ {
 			if len(data) < 2 {

--- a/marshal.go
+++ b/marshal.go
@@ -54,6 +54,10 @@ func Marshal(info *TypeInfo, value interface{}) ([]byte, error) {
 		}
 	}
 
+	if v, ok := value.(Marshaler); ok {
+		return v.MarshalCQL(info)
+	}
+
 	switch info.Type {
 	case TypeVarchar, TypeAscii, TypeBlob:
 		return marshalVarchar(info, value)
@@ -156,8 +160,6 @@ func unmarshalNullable(info *TypeInfo, data []byte, value interface{}) error {
 
 func marshalVarchar(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case string:
 		return []byte(v), nil
 	case []byte:
@@ -216,8 +218,6 @@ func unmarshalVarchar(info *TypeInfo, data []byte, value interface{}) error {
 
 func marshalInt(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case int:
 		if v > math.MaxInt32 || v < math.MinInt32 {
 			return nil, marshalErrorf("marshal int: value %d out of range", v)
@@ -285,8 +285,6 @@ func decInt(x []byte) int32 {
 
 func marshalBigInt(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case int:
 		return encBigInt(int64(v)), nil
 	case uint:
@@ -561,8 +559,6 @@ func decBigInt(data []byte) int64 {
 
 func marshalBool(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case bool:
 		return encBool(v), nil
 	}
@@ -611,8 +607,6 @@ func decBool(v []byte) bool {
 
 func marshalFloat(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case float32:
 		return encInt(int32(math.Float32bits(v))), nil
 	}
@@ -647,8 +641,6 @@ func unmarshalFloat(info *TypeInfo, data []byte, value interface{}) error {
 
 func marshalDouble(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case float64:
 		return encBigInt(int64(math.Float64bits(v))), nil
 	}
@@ -683,8 +675,6 @@ func unmarshalDouble(info *TypeInfo, data []byte, value interface{}) error {
 
 func marshalDecimal(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case inf.Dec:
 		unscaled := encBigInt2C(v.UnscaledBig())
 		if unscaled == nil {
@@ -754,8 +744,6 @@ func encBigInt2C(n *big.Int) []byte {
 
 func marshalTimestamp(info *TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
-	case Marshaler:
-		return v.MarshalCQL(info)
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:

--- a/marshal.go
+++ b/marshal.go
@@ -47,6 +47,8 @@ func Marshal(info *TypeInfo, value interface{}) ([]byte, error) {
 	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
 		if valueRef.IsNil() {
 			return nil, nil
+		} else if v, ok := value.(Marshaler); ok {
+			return v.MarshalCQL(info)
 		} else {
 			return Marshal(info, valueRef.Elem().Interface())
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -40,10 +40,6 @@ func Marshal(info *TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
-	if v, ok := value.(Marshaler); ok {
-		return v.MarshalCQL(info)
-	}
-
 	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
 		if valueRef.IsNil() {
 			return nil, nil

--- a/marshal.go
+++ b/marshal.go
@@ -47,9 +47,7 @@ func Marshal(info *TypeInfo, value interface{}) ([]byte, error) {
 	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
 		if valueRef.IsNil() {
 			return nil, nil
-		} else if v, ok := value.(Marshaler); ok {
-			return v.MarshalCQL(info)
-		} else {
+		} else if _, ok := value.(Marshaler);  !ok {
 			return Marshal(info, valueRef.Elem().Interface())
 		}
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -461,6 +461,19 @@ var marshalTests = []struct {
 		[]byte(nil),
 		(*map[string]int)(nil),
 	},
+	{
+		&TypeInfo{Type: TypeVarchar},
+		[]byte("HELLO WORLD"),
+		func() *CustomString {
+			customString := CustomString("hello world")
+			return &customString
+		}(),
+	},
+	{
+		&TypeInfo{Type: TypeVarchar},
+		[]byte(nil),
+		(*CustomString)(nil),
+	},
 }
 
 func decimalize(s string) *inf.Dec {
@@ -596,6 +609,7 @@ type CustomString string
 func (c CustomString) MarshalCQL(info *TypeInfo) ([]byte, error) {
 	return []byte(strings.ToUpper(string(c))), nil
 }
+
 func (c *CustomString) UnmarshalCQL(info *TypeInfo, data []byte) error {
 	*c = CustomString(strings.ToLower(string(data)))
 	return nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -604,6 +604,61 @@ func TestMarshalVarint(t *testing.T) {
 	}
 }
 
+func equalStringSlice(leftList, rightList []string) bool {
+	if len(leftList) != len(rightList) {
+		return false
+	}
+	for index := range leftList {
+		if rightList[index] != leftList[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMarshalList(t *testing.T) {
+	typeInfo := &TypeInfo {
+		Type: TypeList,
+		Elem: &TypeInfo{
+			Type: TypeVarchar,
+		},
+	}
+
+	sourceLists := [][]string {
+		[]string{ "valueA" },
+		[]string{ "valueA", "valueB" },
+		[]string{ "valueB" },
+	}
+
+	listDatas := [][]byte{}
+
+	for _, list := range sourceLists {
+		listData, marshalErr := Marshal(typeInfo, list)
+		if nil != marshalErr {
+			t.Errorf("Error marshal %+v of type %+v: %s", list, typeInfo, marshalErr)
+		}
+		listDatas = append(listDatas, listData)
+	}
+
+	outputLists := [][]string{}
+
+	var outputList []string
+
+	for _, listData := range listDatas {
+		if unmarshalErr := Unmarshal(typeInfo, listData, &outputList); nil != unmarshalErr {
+			t.Error(unmarshalErr)
+		}
+		outputLists = append(outputLists, outputList)
+	}
+
+	for index, sourceList := range sourceLists {
+		outputList := outputLists[index]
+		if !equalStringSlice(sourceList, outputList) {
+			t.Errorf("Lists %+v not equal to lists %+v, but should", sourceList, outputList)
+		}
+	}
+}
+
 type CustomString string
 
 func (c CustomString) MarshalCQL(info *TypeInfo) ([]byte, error) {


### PR DESCRIPTION
This PR fix repeated unmarshaling of list into slice for case where second list less that first list.

For Example lists

- [valueA]
- [valueA valueB]
- [valueB]

unmarshaled to

- [valueA]
- [valueB valueB] <- bug here
- [valueB]

Complete example see into TestMarshalList(https://github.com/probkiizokna/gocql/compare/unmarshal_list_fix?expand=1#diff-e0406c3c675ff397bbcb989f434b7aacR619)