### PR TITLE
Upgrade CI build to Cassandra 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
 env:
   - CASS=1.2.19
   - CASS=2.0.11
-  - CASS=2.1.1
+  - CASS=2.1.2
 
 go:
   - 1.2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Supported Versions
 
 The following matrix shows the versions of Go and Cassandra that are tested with the integration test suite as part of the CI build:
 
-Go/Cassandra | 1.2.19 | 2.0.11 | 2.1.1
+Go/Cassandra | 1.2.19 | 2.0.11 | 2.1.2
 -------------| -------| ------| ---------
 1.2  | yes | yes | yes
 1.3  | yes | yes | yes


### PR DESCRIPTION
This just sets the current Travis build version to 2.1.2 on the 2.1.x series.