### PR TITLE
Token aware query routing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,5 @@ Zach Marcantel <zmarcantel@gmail.com>
 James Maloney <jamessagan@gmail.com>
 Ashwin Purohit <purohit@gmail.com>
 Dan Kinder <dkinder.is.me@gmail.com>
+Justin Corpron <justin@retailnext.com>
+

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1490,3 +1490,64 @@ func TestKeyspaceMetadata(t *testing.T) {
 	}
 }
 
+func TestRoutingKey(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE test_single_routing_key (first_id int, second_id int, PRIMARY KEY (first_id, second_id))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+	if err := createTable(session, "CREATE TABLE test_composite_routing_key (first_id int, second_id int, PRIMARY KEY ((first_id,second_id)))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+
+	routingKeyInfo := session.routingKeyInfo("SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?")
+	if routingKeyInfo == nil {
+		t.Fatal("Expected routing key info, but was nil")
+	}
+	if len(routingKeyInfo.indexes) != 1 {
+		t.Fatalf("Expected routing key indexes length to be 1 but was %d", len(routingKeyInfo.indexes))
+	}
+	if routingKeyInfo.indexes[0] != 1 {
+		t.Errorf("Expected routing key index[0] to be 1 but was %d", routingKeyInfo.indexes[0])
+	}
+	query := session.Query("SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?", 1, 2)
+	routingKey := query.GetRoutingKey()
+	expectedRoutingKey := []byte{0, 0, 0, 2}
+	if !reflect.DeepEqual(expectedRoutingKey, routingKey) {
+		t.Errorf("Expected routing key %v but was %v", expectedRoutingKey, routingKey)
+	}
+
+	// verify the cache is working
+	session.routingKeyInfo("SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?")
+	cacheSize := session.routingKeyInfoCache.lru.Len()
+	if cacheSize != 1 {
+		t.Errorf("Expected cache size to be 1 but was %d", cacheSize)
+	}
+
+	routingKeyInfo = session.routingKeyInfo("SELECT * FROM test_composite_routing_key WHERE second_id=? AND first_id=?")
+	if routingKeyInfo == nil {
+		t.Fatal("Expected routing key info, but was nil")
+	}
+	if len(routingKeyInfo.indexes) != 2 {
+		t.Fatalf("Expected routing key indexes length to be 2 but was %d", len(routingKeyInfo.indexes))
+	}
+	if routingKeyInfo.indexes[0] != 1 {
+		t.Errorf("Expected routing key index[0] to be 1 but was %d", routingKeyInfo.indexes[0])
+	}
+	if routingKeyInfo.indexes[1] != 0 {
+		t.Errorf("Expected routing key index[1] to be 0 but was %d", routingKeyInfo.indexes[1])
+	}
+	query = session.Query("SELECT * FROM test_composite_routing_key WHERE second_id=? AND first_id=?", 1, 2)
+	routingKey = query.GetRoutingKey()
+	expectedRoutingKey = []byte{0, 4, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 1, 0}
+	if !reflect.DeepEqual(expectedRoutingKey, routingKey) {
+		t.Errorf("Expected routing key %v but was %v", expectedRoutingKey, routingKey)
+	}
+
+	// verify the cache is working
+	cacheSize = session.routingKeyInfoCache.lru.Len()
+	if cacheSize != 2 {
+		t.Errorf("Expected cache size to be 2 but was %d", cacheSize)
+	}
+}

--- a/cluster.go
+++ b/cluster.go
@@ -45,41 +45,44 @@ type DiscoveryConfig struct {
 // behavior to fit the most common use cases. Applications that requre a
 // different setup must implement their own cluster.
 type ClusterConfig struct {
-	Hosts            []string      // addresses for the initial connections
-	CQLVersion       string        // CQL version (default: 3.0.0)
-	ProtoVersion     int           // version of the native protocol (default: 2)
-	Timeout          time.Duration // connection timeout (default: 600ms)
-	Port             int           // port (default: 9042)
-	Keyspace         string        // initial keyspace (optional)
-	NumConns         int           // number of connections per host (default: 2)
-	NumStreams       int           // number of streams per connection (default: 128)
-	Consistency      Consistency   // default consistency level (default: Quorum)
-	Compressor       Compressor    // compression algorithm (default: nil)
-	Authenticator    Authenticator // authenticator (default: nil)
-	RetryPolicy      RetryPolicy   // Default retry policy to use for queries (default: 0)
-	SocketKeepalive  time.Duration // The keepalive period to use, enabled if > 0 (default: 0)
-	ConnPoolType     NewPoolFunc   // The function used to create the connection pool for the session (default: NewSimplePool)
-	DiscoverHosts    bool          // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
-	MaxPreparedStmts int           // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
-	PageSize         int           // Default page size to use for created sessions (default: 0)
-	Discovery        DiscoveryConfig
-	SslOpts          *SslOptions
+	Hosts             []string      // addresses for the initial connections
+	CQLVersion        string        // CQL version (default: 3.0.0)
+	ProtoVersion      int           // version of the native protocol (default: 2)
+	Timeout           time.Duration // connection timeout (default: 600ms)
+	Port              int           // port (default: 9042)
+	Keyspace          string        // initial keyspace (optional)
+	NumConns          int           // number of connections per host (default: 2)
+	NumStreams        int           // number of streams per connection (default: 128)
+	Consistency       Consistency   // default consistency level (default: Quorum)
+	Compressor        Compressor    // compression algorithm (default: nil)
+	Authenticator     Authenticator // authenticator (default: nil)
+	RetryPolicy       RetryPolicy   // Default retry policy to use for queries (default: 0)
+	SocketKeepalive   time.Duration // The keepalive period to use, enabled if > 0 (default: 0)
+	ConnPoolType      NewPoolFunc   // The function used to create the connection pool for the session (default: NewSimplePool)
+	DiscoverHosts     bool          // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
+	MaxPreparedStmts  int           // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
+	MaxRoutingKeyInfo int           // Sets the maximum cache size for query info about statements for each session (default: 1000)
+	PageSize          int           // Default page size to use for created sessions (default: 0)
+	Discovery         DiscoveryConfig
+	SslOpts           *SslOptions
 }
 
 // NewCluster generates a new config for the default cluster implementation.
 func NewCluster(hosts ...string) *ClusterConfig {
 	cfg := &ClusterConfig{
-		Hosts:            hosts,
-		CQLVersion:       "3.0.0",
-		ProtoVersion:     2,
-		Timeout:          600 * time.Millisecond,
-		Port:             9042,
-		NumConns:         2,
-		NumStreams:       128,
-		Consistency:      Quorum,
-		ConnPoolType:     NewSimplePool,
-		DiscoverHosts:    false,
-		MaxPreparedStmts: 1000,
+		Hosts:             hosts,
+		CQLVersion:        "3.0.0",
+		ProtoVersion:      2,
+		Timeout:           600 * time.Millisecond,
+		Port:              9042,
+		NumConns:          2,
+		NumStreams:        128,
+		Consistency:       Quorum,
+		ConnPoolType:      NewSimplePool,
+		DiscoverHosts:     false,
+		MaxPreparedStmts:  1000,
+		MaxRoutingKeyInfo: 1000,
+		PageSize:          0,
 	}
 	return cfg
 }

--- a/connectionpool_systems_test.go
+++ b/connectionpool_systems_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// +build conn_pool
+
+package gocql
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// connection pool behavior test when nodes are removed from the cluster
+// to run this test, see connectionpool_systems_test.sh
+
+var (
+	flagCluster  = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
+	flagProto    = flag.Int("proto", 2, "protcol version")
+	flagCQL      = flag.String("cql", "3.0.0", "CQL version")
+	flagRF       = flag.Int("rf", 1, "replication factor for test keyspace")
+	clusterSize  = flag.Int("clusterSize", 1, "the expected size of the cluster")
+	nodesShut    = flag.Int("nodesShut", 1, "the number of nodes to shutdown during the test")
+	flagRetry    = flag.Int("retries", 5, "number of times to retry queries")
+	flagRunSsl   = flag.Bool("runssl", false, "Set to true to run ssl test")
+	clusterHosts []string
+)
+var initOnce sync.Once
+
+func init() {
+	flag.Parse()
+	clusterHosts = strings.Split(*flagCluster, ",")
+	log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
+func createTable(s *Session, table string) error {
+	err := s.Query(table).Consistency(All).Exec()
+	if *clusterSize > 1 {
+		// wait for table definition to propogate
+		time.Sleep(250 * time.Millisecond)
+	}
+	return err
+}
+
+func createCluster() *ClusterConfig {
+	cluster := NewCluster(clusterHosts...)
+	cluster.ProtoVersion = *flagProto
+	cluster.CQLVersion = *flagCQL
+	cluster.Timeout = 5 * time.Second
+	cluster.Consistency = Quorum
+	if *flagRetry > 0 {
+		cluster.RetryPolicy = &SimpleRetryPolicy{NumRetries: *flagRetry}
+	}
+	if *flagRunSsl {
+		cluster.SslOpts = &SslOptions{
+			CertPath:               "testdata/pki/gocql.crt",
+			KeyPath:                "testdata/pki/gocql.key",
+			CaPath:                 "testdata/pki/ca.crt",
+			EnableHostVerification: false,
+		}
+	}
+	return cluster
+}
+
+func createKeyspace(t testing.T, cluster *ClusterConfig, keyspace string) {
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal("createSession:", err)
+	}
+	if err = session.Query(`DROP KEYSPACE ` + keyspace).Exec(); err != nil {
+		t.Log("drop keyspace:", err)
+	}
+	err = session.Query(
+		fmt.Sprintf(
+			`
+			CREATE KEYSPACE %s
+			WITH replication = {
+				'class' : 'SimpleStrategy',
+				'replication_factor' : %d
+			}
+			`,
+			keyspace,
+			*flagRF,
+		),
+	).Consistency(All).Exec()
+	if err != nil {
+		t.Fatalf("error creating keyspace %s: %v", keyspace, err)
+	}
+	t.Logf("Created keyspace %s", keyspace)
+	session.Close()
+}
+
+func createSession(t testing.T) *Session {
+	cluster := createCluster()
+
+	// Drop and re-create the keyspace once. Different tests should use their own
+	// individual tables, but can assume that the table does not exist before.
+	initOnce.Do(func() {
+		createKeyspace(t, cluster, "gocql_test")
+	})
+
+	cluster.Keyspace = "gocql_test"
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal("createSession:", err)
+	}
+
+	return session
+}
+
+func TestSimplePool(t *testing.T) {
+	testConnPool(t, NewSimplePool)
+}
+
+func TestRRPolicyConnPool(t *testing.T) {
+	testConnPool(t, NewRoundRobinConnPool)
+}
+
+func TestTAPolicyConnPool(t *testing.T) {
+	testConnPool(t, NewTokenAwareConnPool)
+}
+
+func testConnPool(t *testing.T, connPoolType func(*ClusterConfig) ConnectionPool) {
+	var out []byte
+	var err error
+	log.SetFlags(log.Ltime)
+
+	// make sure the cluster is running
+	out, err = exec.Command("ccm", "start").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running ccm command: %v", err)
+		fmt.Printf("ccm output:\n%s", string(out))
+	}
+
+	time.Sleep(time.Duration(*clusterSize) * 1000 * time.Millisecond)
+
+	// fire up a session (no discovery)
+	cluster := createCluster()
+	cluster.ConnPoolType = connPoolType
+	cluster.DiscoverHosts = false
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("Error connecting to cluster: %v", err)
+	}
+	defer session.Close()
+
+	time.Sleep(time.Duration(*clusterSize) * 1000 * time.Millisecond)
+
+	if session.Pool.Size() != (*clusterSize)*cluster.NumConns {
+		t.Errorf(
+			"Expected %d pool size, but was %d",
+			(*clusterSize)*cluster.NumConns,
+			session.Pool.Size(),
+		)
+	}
+
+	// start some connection monitoring
+	nilCheckStop := false
+	nilCount := 0
+	nilCheck := func() {
+		// assert that all connections returned by the pool are non-nil
+		for !nilCheckStop {
+			actual := session.Pool.Pick(nil)
+			if actual == nil {
+				nilCount++
+			}
+		}
+	}
+	go nilCheck()
+
+	// shutdown some hosts
+	log.Println("shutdown some hosts")
+	for i := 0; i < *nodesShut; i++ {
+		out, err = exec.Command("ccm", "node"+strconv.Itoa(i+1), "stop").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error running ccm command: %v", err)
+			fmt.Printf("ccm output:\n%s", string(out))
+		}
+		time.Sleep(1500 * time.Millisecond)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	if session.Pool.Size() != ((*clusterSize)-(*nodesShut))*cluster.NumConns {
+		t.Errorf(
+			"Expected %d pool size, but was %d",
+			((*clusterSize)-(*nodesShut))*cluster.NumConns,
+			session.Pool.Size(),
+		)
+	}
+
+	// bringup the shutdown hosts
+	log.Println("bringup the shutdown hosts")
+	for i := 0; i < *nodesShut; i++ {
+		out, err = exec.Command("ccm", "node"+strconv.Itoa(i+1), "start").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error running ccm command: %v", err)
+			fmt.Printf("ccm output:\n%s", string(out))
+		}
+		time.Sleep(1500 * time.Millisecond)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	if session.Pool.Size() != (*clusterSize)*cluster.NumConns {
+		t.Errorf(
+			"Expected %d pool size, but was %d",
+			(*clusterSize)*cluster.NumConns,
+			session.Pool.Size(),
+		)
+	}
+
+	// assert that all connections returned by the pool are non-nil
+	if nilCount > 0 {
+		t.Errorf("%d nil connections returned from %T", nilCount, session.Pool)
+	}
+
+	// shutdown cluster
+	log.Println("shutdown cluster")
+	out, err = exec.Command("ccm", "stop").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running ccm command: %v", err)
+		fmt.Printf("ccm output:\n%s", string(out))
+	}
+	time.Sleep(2500 * time.Millisecond)
+
+	if session.Pool.Size() != 0 {
+		t.Errorf(
+			"Expected %d pool size, but was %d",
+			0,
+			session.Pool.Size(),
+		)
+	}
+
+	// start cluster
+	log.Println("start cluster")
+	out, err = exec.Command("ccm", "start").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running ccm command: %v", err)
+		fmt.Printf("ccm output:\n%s", string(out))
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// reset the count
+	nilCount = 0
+
+	time.Sleep(3000 * time.Millisecond)
+
+	if session.Pool.Size() != (*clusterSize)*cluster.NumConns {
+		t.Errorf(
+			"Expected %d pool size, but was %d",
+			(*clusterSize)*cluster.NumConns,
+			session.Pool.Size(),
+		)
+	}
+
+	// assert that all connections returned by the pool are non-nil
+	if nilCount > 0 {
+		t.Errorf("%d nil connections returned from %T", nilCount, session.Pool)
+	}
+	nilCheckStop = true
+}

--- a/connectionpool_systems_test.sh
+++ b/connectionpool_systems_test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+function run_tests() {
+	local clusterSize=5
+	local nodesShut=2
+	local version=$1
+
+	ccm remove test || true
+
+	ccm create test -v $version -n $clusterSize --vnodes -d --jvm_arg="-Xmx256m"
+	
+	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 2' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
+	ccm start -v
+	ccm status
+	ccm node1 nodetool status
+	
+	local proto=2
+	if [[ $version == 1.2.* ]]; then
+		proto=1
+	fi
+
+	go test -timeout 15m -tags conn_pool -v -runssl -proto=$proto -rf=3 -cluster=$(ccm liveset) -clusterSize=$clusterSize -nodesShut=$nodesShut ./... | tee results.txt
+
+	if [ ${PIPESTATUS[0]} -ne 0 ]; then 
+		echo "--- FAIL: ccm status follows:"
+		ccm status
+		ccm node1 nodetool status
+		ccm node1 showlog > status.log
+		cat status.log
+		echo "--- FAIL: Received a non-zero exit code from the go test execution, please investigate this"
+		exit 1
+	fi
+	ccm remove
+}
+run_tests $1

--- a/helpers.go
+++ b/helpers.go
@@ -97,9 +97,9 @@ func getApacheCassandraType(class string) Type {
 		case "MapType":
 			return TypeMap
 		case "ListType":
-			return TypeInet
+			return TypeList
 		case "SetType":
-			return TypeInet
+			return TypeSet
 		}
 	}
 	return TypeCustom

--- a/host_source.go
+++ b/host_source.go
@@ -16,28 +16,33 @@ type HostInfo struct {
 
 // Polls system.peers at a specific interval to find new hosts
 type ringDescriber struct {
-	dcFilter   string
-	rackFilter string
-	previous   []HostInfo
-	session    *Session
+	dcFilter        string
+	rackFilter      string
+	prevHosts       []*HostInfo
+	prevPartitioner string
+	session         *Session
 }
 
-func (r *ringDescriber) GetHosts() ([]HostInfo, error) {
+func (r *ringDescriber) GetHosts() (
+	hosts []*HostInfo,
+	partitioner string,
+	err error,
+) {
 	// we need conn to be the same because we need to query system.peers and system.local
 	// on the same node to get the whole cluster
 	conn := r.session.Pool.Pick(nil)
 	if conn == nil {
-		return r.previous, nil
+		return r.prevHosts, r.prevPartitioner, nil
 	}
 
-	query := r.session.Query("SELECT data_center, rack, host_id, tokens FROM system.local")
+	query := r.session.Query("SELECT data_center, rack, host_id, tokens, partitioner FROM system.local")
 	iter := conn.executeQuery(query)
 
 	host := &HostInfo{}
-	iter.Scan(&host.DataCenter, &host.Rack, &host.HostId, &host.Tokens)
+	iter.Scan(&host.DataCenter, &host.Rack, &host.HostId, &host.Tokens, &partitioner)
 
-	if err := iter.Close(); err != nil {
-		return nil, err
+	if err = iter.Close(); err != nil {
+		return nil, "", err
 	}
 
 	addr, _, err := net.SplitHostPort(conn.Address())
@@ -49,24 +54,28 @@ func (r *ringDescriber) GetHosts() ([]HostInfo, error) {
 
 	host.Peer = addr
 
-	hosts := []HostInfo{*host}
+	hosts = []*HostInfo{host}
 
 	query = r.session.Query("SELECT peer, data_center, rack, host_id, tokens FROM system.peers")
 	iter = conn.executeQuery(query)
 
+	host = &HostInfo{}
 	for iter.Scan(&host.Peer, &host.DataCenter, &host.Rack, &host.HostId, &host.Tokens) {
 		if r.matchFilter(host) {
-			hosts = append(hosts, *host)
+			hosts = append(hosts,
+				host)
 		}
+		host = &HostInfo{}
 	}
 
-	if err := iter.Close(); err != nil {
-		return nil, err
+	if err = iter.Close(); err != nil {
+		return nil, "", err
 	}
 
-	r.previous = hosts
+	r.prevHosts = hosts
+	r.prevPartitioner = partitioner
 
-	return hosts, nil
+	return hosts, partitioner, nil
 }
 
 func (r *ringDescriber) matchFilter(host *HostInfo) bool {
@@ -92,11 +101,11 @@ func (h *ringDescriber) run(sleep time.Duration) {
 		// attempt to reconnect to the cluster otherwise we would never find
 		// downed hosts again, could possibly have an optimisation to only
 		// try to add new hosts if GetHosts didnt error and the hosts didnt change.
-		hosts, err := h.GetHosts()
+		hosts, partitioner, err := h.GetHosts()
 		if err != nil {
 			log.Println("RingDescriber: unable to get ring topology:", err)
 		} else {
-			h.session.Pool.SetHosts(hosts)
+			h.session.Pool.SetHosts(hosts, partitioner)
 		}
 
 		time.Sleep(sleep)

--- a/marshal.go
+++ b/marshal.go
@@ -1123,7 +1123,7 @@ type TypeInfo struct {
 	Type   Type
 	Key    *TypeInfo // only used for TypeMap
 	Elem   *TypeInfo // only used for TypeMap, TypeList and TypeSet
-	Custom string    // only used for TypeCostum
+	Custom string    // only used for TypeCustom
 }
 
 // String returns a human readable name for the Cassandra datatype
@@ -1154,6 +1154,7 @@ const (
 	TypeDouble    Type = 0x0007
 	TypeFloat     Type = 0x0008
 	TypeInt       Type = 0x0009
+	TypeText      Type = 0x000A
 	TypeTimestamp Type = 0x000B
 	TypeUUID      Type = 0x000C
 	TypeVarchar   Type = 0x000D
@@ -1163,6 +1164,8 @@ const (
 	TypeList      Type = 0x0020
 	TypeMap       Type = 0x0021
 	TypeSet       Type = 0x0022
+	TypeUDT       Type = 0x0030
+	TypeTuple     Type = 0x0031
 )
 
 // String returns the name of the identifier.
@@ -1188,12 +1191,16 @@ func (t Type) String() string {
 		return "float"
 	case TypeInt:
 		return "int"
+	case TypeText:
+		return "text"
 	case TypeTimestamp:
 		return "timestamp"
 	case TypeUUID:
 		return "uuid"
 	case TypeVarchar:
 		return "varchar"
+	case TypeVarint:
+		return "varint"
 	case TypeTimeUUID:
 		return "timeuuid"
 	case TypeInet:
@@ -1204,8 +1211,10 @@ func (t Type) String() string {
 		return "map"
 	case TypeSet:
 		return "set"
-	case TypeVarint:
-		return "varint"
+	case TypeUDT:
+		return "udt"
+	case TypeTuple:
+		return "tuple"
 	default:
 		return "unknown"
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -665,8 +665,8 @@ var typeLookupTest = []struct {
 	{"TimeUUIDType", TypeTimeUUID},
 	{"InetAddressType", TypeInet},
 	{"MapType", TypeMap},
-	{"ListType", TypeInet},
-	{"SetType", TypeInet},
+	{"ListType", TypeList},
+	{"SetType", TypeSet},
 	{"unknown", TypeCustom},
 }
 

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,785 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocql
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// schema metadata for a keyspace
+type KeyspaceMetadata struct {
+	Name            string
+	DurableWrites   bool
+	StrategyClass   string
+	StrategyOptions map[string]interface{}
+	Tables          map[string]*TableMetadata
+}
+
+// schema metadata for a table (a.k.a. column family)
+type TableMetadata struct {
+	Keyspace          string
+	Name              string
+	KeyValidator      string
+	Comparator        string
+	DefaultValidator  string
+	KeyAliases        []string
+	ColumnAliases     []string
+	ValueAlias        string
+	PartitionKey      []*ColumnMetadata
+	ClusteringColumns []*ColumnMetadata
+	Columns           map[string]*ColumnMetadata
+}
+
+// schema metadata for a column
+type ColumnMetadata struct {
+	Keyspace       string
+	Table          string
+	Name           string
+	Kind           string
+	ComponentIndex int
+	Type           TypeInfo
+	Order          ColumnOrder
+	Index          ColumnIndexMetadata
+}
+
+// the ordering of the column with regard to its comparator
+type ColumnOrder bool
+
+const (
+	ASC  ColumnOrder = false
+	DESC             = true
+)
+
+type ColumnIndexMetadata struct {
+	Name    string
+	Type    string
+	Options map[string]interface{}
+}
+
+// Column kind values
+const (
+	PARTITION_KEY  = "partition_key"
+	CLUSTERING_KEY = "clustering_key"
+	REGULAR        = "regular"
+	COMPACT_VALUE  = "compact_value"
+	STATIC         = "static"
+)
+
+// column index type values
+const (
+	KEYS   = "KEYS"
+	CUSTOM = "CUSTOM"
+)
+
+// default alias values
+const (
+	DEFAULT_KEY_ALIAS    = "key"
+	DEFAULT_COLUMN_ALIAS = "column"
+	DEFAULT_VALUE_ALIAS  = "value"
+)
+
+// queries the cluster for schema information for a specific keyspace
+type schemaDescriber struct {
+	session  *Session
+	mu       sync.Mutex
+	lazyInit sync.Once
+
+	current *KeyspaceMetadata
+	err     error
+}
+
+func (s *schemaDescriber) init() {
+	s.err = s.RefreshSchema()
+}
+
+func (s *schemaDescriber) GetSchema() (*KeyspaceMetadata, error) {
+	// lazily-initialize the schema the first time
+	s.lazyInit.Do(s.init)
+
+	// TODO handle schema change events
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.current, s.err
+}
+
+func (s *schemaDescriber) RefreshSchema() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var err error
+
+	keyspace, err := s.getKeyspaceMetadata()
+
+	tables, err := s.getTableMetadata()
+	if err != nil {
+		return err
+	}
+	columns, err := s.getColumnMetadata()
+	if err != nil {
+		return err
+	}
+	s.compileMetadata(keyspace, tables, columns)
+
+	// update the current
+	s.current = keyspace
+	s.err = nil
+
+	return nil
+}
+
+func (s *schemaDescriber) compileMetadata(
+	keyspace *KeyspaceMetadata,
+	tables []*TableMetadata,
+	columns []*ColumnMetadata,
+) {
+	keyspace.Tables = make(map[string]*TableMetadata)
+	for _, table := range tables {
+		keyspace.Tables[table.Name] = table
+	}
+
+	// add columns from the schema data
+	for _, column := range columns {
+		table := keyspace.Tables[column.Table]
+		table.Columns[column.Name] = column
+	}
+
+	for _, table := range tables {
+		// decode the key validator
+		keyValidatorParsed := parseType(table.KeyValidator)
+		// decode the comparator
+		comparatorParsed := parseType(table.Comparator)
+		// decode the default validator
+		defaultValidatorParsed := parseType(table.DefaultValidator)
+
+		// the partition key length is the same as the number of types in the
+		// key validator
+		table.PartitionKey = make([]*ColumnMetadata, len(keyValidatorParsed.types))
+
+		if s.session.cfg.ProtoVersion == 1 {
+			// V1 protocol only returns "regular" columns from
+			// system.schema_columns so the alias information is used to
+			// create the partition key and clustering columns
+
+			// construct the partition key from the alias
+			for i := range table.PartitionKey {
+				var alias string
+				if len(table.KeyAliases) > i {
+					alias = table.KeyAliases[i]
+				} else if i == 0 {
+					alias = DEFAULT_KEY_ALIAS
+				} else {
+					alias = DEFAULT_KEY_ALIAS + strconv.Itoa(i+1)
+				}
+
+				column := &ColumnMetadata{
+					Keyspace: s.session.cfg.Keyspace,
+					Table:    table.Name,
+					Name:     alias,
+					Type:     keyValidatorParsed.types[i],
+				}
+
+				table.PartitionKey[i] = column
+				table.Columns[alias] = column
+			}
+
+			// determine the number of clustering columns
+			size := len(comparatorParsed.types)
+			if comparatorParsed.isComposite &&
+				(len(comparatorParsed.collections) > 0 ||
+					(len(table.ColumnAliases) == size-1 &&
+						comparatorParsed.types[size-1].Type == TypeVarchar)) {
+
+				size = size - 1
+			} else if len(table.ColumnAliases) == 0 && len(table.Columns) > 0 {
+				// only regular columns
+				size = 0
+			}
+			table.ClusteringColumns = make([]*ColumnMetadata, size)
+
+			for i := range table.ClusteringColumns {
+				var alias string
+				if len(table.ColumnAliases) > i {
+					alias = table.ColumnAliases[i]
+				} else if i == 0 {
+					alias = DEFAULT_COLUMN_ALIAS
+				} else {
+					alias = DEFAULT_COLUMN_ALIAS + strconv.Itoa(i+1)
+				}
+
+				order := ASC
+				if comparatorParsed.reversed[i] {
+					order = DESC
+				}
+
+				column := &ColumnMetadata{
+					Keyspace: s.session.cfg.Keyspace,
+					Table:    table.Name,
+					Name:     alias,
+					Type:     comparatorParsed.types[i],
+					Order:    order,
+				}
+
+				table.ClusteringColumns[i] = column
+				table.Columns[alias] = column
+			}
+
+			if size != len(comparatorParsed.types)-1 {
+				alias := DEFAULT_VALUE_ALIAS
+				if len(table.ValueAlias) > 0 {
+					alias = table.ValueAlias
+				}
+				column := &ColumnMetadata{
+					Keyspace: s.session.cfg.Keyspace,
+					Table:    table.Name,
+					Name:     alias,
+					Type:     defaultValidatorParsed.types[0],
+				}
+				table.Columns[alias] = column
+			}
+		} else {
+			// V2+
+
+			// find the largest index in the clustering key columns
+			maxIndex := -1
+			for _, column := range table.Columns {
+				if column.Kind == CLUSTERING_KEY &&
+					column.ComponentIndex > maxIndex {
+
+					maxIndex = column.ComponentIndex
+				}
+			}
+			table.ClusteringColumns = make([]*ColumnMetadata, maxIndex+1)
+
+			for _, column := range table.Columns {
+				if column.Kind == PARTITION_KEY {
+					table.PartitionKey[column.ComponentIndex] = column
+				} else if column.Kind == CLUSTERING_KEY {
+					table.ClusteringColumns[column.ComponentIndex] = column
+				}
+			}
+		}
+
+	}
+}
+
+func (s *schemaDescriber) getKeyspaceMetadata() (*KeyspaceMetadata, error) {
+	query := s.session.Query(
+		`
+		SELECT durable_writes, strategy_class, strategy_options
+		FROM system.schema_keyspaces
+		WHERE keyspace_name = ?
+		`,
+		s.session.cfg.Keyspace,
+	)
+	// set a routing key to avoid a token aware policy from creating a call loop.
+	// TODO use a separate connection (pool) for system keyspace queries.
+	query.RoutingKey([]byte{})
+
+	keyspace := &KeyspaceMetadata{Name: s.session.cfg.Keyspace}
+	var strategyOptionsJSON []byte
+
+	err := query.Scan(
+		&keyspace.DurableWrites,
+		&keyspace.StrategyClass,
+		&strategyOptionsJSON,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Error querying keyspace schema: %v", err)
+	}
+
+	err = json.Unmarshal(strategyOptionsJSON, &keyspace.StrategyOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyspace, nil
+}
+
+func (s *schemaDescriber) getTableMetadata() ([]*TableMetadata, error) {
+	query := s.session.Query(
+		`
+		SELECT
+			columnfamily_name,
+			key_validator,
+			comparator,
+			default_validator,
+			key_aliases,
+			column_aliases,
+			value_alias
+		FROM system.schema_columnfamilies
+		WHERE keyspace_name = ?
+		`,
+		s.session.cfg.Keyspace,
+	)
+	// set a routing key to avoid a token aware policy from creating a call loop.
+	// TODO use a separate connection (pool) for system keyspace queries.
+	query.RoutingKey([]byte{})
+	iter := query.Iter()
+
+	tables := []*TableMetadata{}
+
+	table := &TableMetadata{Keyspace: s.session.cfg.Keyspace}
+	var keyAliasesJSON []byte
+	var columnAliasesJSON []byte
+	for iter.Scan(
+		&table.Name,
+		&table.KeyValidator,
+		&table.Comparator,
+		&table.DefaultValidator,
+		&keyAliasesJSON,
+		&columnAliasesJSON,
+		&table.ValueAlias,
+	) {
+		var err error
+
+		table.Columns = make(map[string]*ColumnMetadata)
+
+		// decode the key aliases
+		if keyAliasesJSON != nil {
+			table.KeyAliases = []string{}
+			err = json.Unmarshal(keyAliasesJSON, &table.KeyAliases)
+			if err != nil {
+				iter.Close()
+				return nil, err
+			}
+		}
+
+		// decode the column aliases
+		if columnAliasesJSON != nil {
+			table.ColumnAliases = []string{}
+			err = json.Unmarshal(columnAliasesJSON, &table.ColumnAliases)
+			if err != nil {
+				iter.Close()
+				return nil, err
+			}
+		}
+
+		tables = append(tables, table)
+
+		table = &TableMetadata{Keyspace: s.session.cfg.Keyspace}
+	}
+
+	err := iter.Close()
+	if err != nil && err != ErrNotFound {
+		return nil, fmt.Errorf("Error querying table schema: %v", err)
+	}
+
+	return tables, nil
+}
+
+func (s *schemaDescriber) getColumnMetadata() ([]*ColumnMetadata, error) {
+	stmt := `
+		SELECT
+			columnfamily_name,
+			column_name,
+			component_index,
+			validator,
+			index_name,
+			index_type,
+			index_options,
+			type
+		FROM system.schema_columns
+		WHERE keyspace_name = ?
+		`
+	if s.session.cfg.ProtoVersion == 1 {
+		// V1 does not support the type column
+		stmt = `
+		SELECT
+			columnfamily_name,
+			column_name,
+			component_index,
+			validator,
+			index_name,
+			index_type,
+			index_options
+		FROM system.schema_columns
+		WHERE keyspace_name = ?
+		`
+	}
+	query := s.session.Query(
+		stmt,
+		s.session.cfg.Keyspace,
+	)
+	// set a routing key to avoid a token aware policy from creating a call loop.
+	// TODO use a separate connection (pool) for system keyspace queries.
+	query.RoutingKey([]byte{})
+	iter := query.Iter()
+
+	columns := []*ColumnMetadata{}
+
+	column := &ColumnMetadata{Keyspace: s.session.cfg.Keyspace}
+	var validator string
+	var indexOptionsJSON []byte
+	scan := func() bool {
+		return iter.Scan(
+			&column.Table,
+			&column.Name,
+			&column.ComponentIndex,
+			&validator,
+			&column.Index.Name,
+			&column.Index.Type,
+			&indexOptionsJSON,
+			&column.Kind,
+		)
+	}
+	if s.session.cfg.ProtoVersion == 1 {
+		// V1 does not support the type column
+		scan = func() bool {
+			return iter.Scan(
+				&column.Table,
+				&column.Name,
+				&column.ComponentIndex,
+				&validator,
+				&column.Index.Name,
+				&column.Index.Type,
+				&indexOptionsJSON,
+			)
+		}
+	}
+	for scan() {
+		var err error
+
+		// decode the validator
+		validatorParsed := parseType(validator)
+
+		// decode the index options
+		if indexOptionsJSON != nil {
+			err = json.Unmarshal(indexOptionsJSON, &column.Index.Options)
+			if err != nil {
+				iter.Close()
+				return nil, err
+			}
+		}
+
+		column.Type = validatorParsed.types[0]
+		column.Order = ASC
+		if validatorParsed.reversed[0] {
+			column.Order = DESC
+		}
+
+		columns = append(columns, column)
+
+		column = &ColumnMetadata{Keyspace: s.session.cfg.Keyspace}
+	}
+
+	err := iter.Close()
+	if err != nil && err != ErrNotFound {
+		return nil, fmt.Errorf("Error querying column schema: %v", err)
+	}
+
+	return columns, nil
+}
+
+// type definition parser state
+type typeParser struct {
+	input string
+	index int
+}
+
+// the type definition parser result
+type typeParserResult struct {
+	isComposite bool
+	types       []TypeInfo
+	reversed    []bool
+	collections map[string]TypeInfo
+}
+
+// Parse the type definition used for validator and comparator schema data
+func parseType(def string) typeParserResult {
+	parser := &typeParser{input: def}
+	return parser.parse()
+}
+
+const (
+	REVERSED_TYPE   = "org.apache.cassandra.db.marshal.ReversedType"
+	COMPOSITE_TYPE  = "org.apache.cassandra.db.marshal.CompositeType"
+	COLLECTION_TYPE = "org.apache.cassandra.db.marshal.ColumnToCollectionType"
+	LIST_TYPE       = "org.apache.cassandra.db.marshal.ListType"
+	SET_TYPE        = "org.apache.cassandra.db.marshal.SetType"
+	MAP_TYPE        = "org.apache.cassandra.db.marshal.MapType"
+	UDT_TYPE        = "org.apache.cassandra.db.marshal.UserType"
+	TUPLE_TYPE      = "org.apache.cassandra.db.marshal.TupleType"
+)
+
+// represents a class specification in the type def AST
+type typeParserClassNode struct {
+	name   string
+	params []typeParserParamNode
+	// this is the segment of the input string that defined this node
+	input string
+}
+
+// represents a class parameter in the type def AST
+type typeParserParamNode struct {
+	name  *string
+	class typeParserClassNode
+}
+
+func (t *typeParser) parse() typeParserResult {
+	// parse the AST
+	ast, ok := t.parseClassNode()
+	if !ok {
+		// treat this is a custom type
+		return typeParserResult{
+			isComposite: false,
+			types: []TypeInfo{
+				TypeInfo{
+					Type:   TypeCustom,
+					Custom: t.input,
+				},
+			},
+			reversed:    []bool{false},
+			collections: nil,
+		}
+	}
+
+	// interpret the AST
+	if strings.HasPrefix(ast.name, COMPOSITE_TYPE) {
+		count := len(ast.params)
+
+		// look for a collections param
+		last := ast.params[count-1]
+		collections := map[string]TypeInfo{}
+		if strings.HasPrefix(last.class.name, COLLECTION_TYPE) {
+			count--
+
+			for _, param := range last.class.params {
+				// decode the name
+				var name string
+				decoded, err := hex.DecodeString(*param.name)
+				if err != nil {
+					log.Printf(
+						"Error parsing type '%s', contains collection name '%s' with an invalid format: %v",
+						t.input,
+						*param.name,
+						err,
+					)
+					// just use the provided name
+					name = *param.name
+				} else {
+					name = string(decoded)
+				}
+				collections[name] = param.class.asTypeInfo()
+			}
+		}
+
+		types := make([]TypeInfo, count)
+		reversed := make([]bool, count)
+
+		for i, param := range ast.params[:count] {
+			class := param.class
+			reversed[i] = strings.HasPrefix(class.name, REVERSED_TYPE)
+			if reversed[i] {
+				class = class.params[0].class
+			}
+			types[i] = class.asTypeInfo()
+		}
+
+		return typeParserResult{
+			isComposite: true,
+			types:       types,
+			reversed:    reversed,
+			collections: collections,
+		}
+	} else {
+		// not composite, so one type
+		class := *ast
+		reversed := strings.HasPrefix(class.name, REVERSED_TYPE)
+		if reversed {
+			class = class.params[0].class
+		}
+		typeInfo := class.asTypeInfo()
+
+		return typeParserResult{
+			isComposite: false,
+			types:       []TypeInfo{typeInfo},
+			reversed:    []bool{reversed},
+		}
+	}
+}
+
+func (class *typeParserClassNode) asTypeInfo() TypeInfo {
+	if strings.HasPrefix(class.name, LIST_TYPE) {
+		elem := class.params[0].class.asTypeInfo()
+		return TypeInfo{
+			Type: TypeList,
+			Elem: &elem,
+		}
+	}
+	if strings.HasPrefix(class.name, SET_TYPE) {
+		elem := class.params[0].class.asTypeInfo()
+		return TypeInfo{
+			Type: TypeSet,
+			Elem: &elem,
+		}
+	}
+	if strings.HasPrefix(class.name, MAP_TYPE) {
+		key := class.params[0].class.asTypeInfo()
+		elem := class.params[1].class.asTypeInfo()
+		return TypeInfo{
+			Type: TypeMap,
+			Key:  &key,
+			Elem: &elem,
+		}
+	}
+	// TODO handle UDT types
+	// TODO handle Tuple types
+
+	// must be a simple type or custom type
+	info := TypeInfo{Type: getApacheCassandraType(class.name)}
+	if info.Type == TypeCustom {
+		// add the entire class definition
+		info.Custom = class.input
+	}
+	return info
+}
+
+// CLASS := ID [ PARAMS ]
+func (t *typeParser) parseClassNode() (node *typeParserClassNode, ok bool) {
+	t.skipWhitespace()
+
+	startIndex := t.index
+
+	name, ok := t.nextIdentifier()
+	if !ok {
+		return nil, false
+	}
+
+	params, ok := t.parseParamNodes()
+	if !ok {
+		return nil, false
+	}
+
+	endIndex := t.index
+
+	node = &typeParserClassNode{
+		name:   name,
+		params: params,
+		input:  t.input[startIndex:endIndex],
+	}
+	return node, true
+}
+
+// PARAMS := "(" PARAM { "," PARAM } ")"
+// PARAM := [ PARAM_NAME ":" ] CLASS
+// PARAM_NAME := ID
+func (t *typeParser) parseParamNodes() (params []typeParserParamNode, ok bool) {
+	t.skipWhitespace()
+
+	// the params are optional
+	if t.index == len(t.input) || t.input[t.index] != '(' {
+		return nil, true
+	}
+
+	params = []typeParserParamNode{}
+
+	// consume the '('
+	t.index++
+
+	t.skipWhitespace()
+
+	for t.input[t.index] != ')' {
+		// look for a named param, but if no colon, then we want to backup
+		backupIndex := t.index
+
+		// name will be a hex encoded version of a utf-8 string
+		name, ok := t.nextIdentifier()
+		if !ok {
+			return nil, false
+		}
+		hasName := true
+
+		// TODO handle '=>' used for DynamicCompositeType
+
+		t.skipWhitespace()
+
+		if t.input[t.index] == ':' {
+			// there is a name for this parameter
+
+			// consume the ':'
+			t.index++
+
+			t.skipWhitespace()
+		} else {
+			// no name, backup
+			hasName = false
+			t.index = backupIndex
+		}
+
+		// parse the next full parameter
+		classNode, ok := t.parseClassNode()
+		if !ok {
+			return nil, false
+		}
+
+		if hasName {
+			params = append(
+				params,
+				typeParserParamNode{name: &name, class: *classNode},
+			)
+		} else {
+			params = append(
+				params,
+				typeParserParamNode{class: *classNode},
+			)
+		}
+
+		t.skipWhitespace()
+
+		if t.input[t.index] == ',' {
+			// consume the comma
+			t.index++
+
+			t.skipWhitespace()
+		}
+	}
+
+	// consume the ')'
+	t.index++
+
+	return params, true
+}
+
+func (t *typeParser) skipWhitespace() {
+	for t.index < len(t.input) && isWhitespaceChar(t.input[t.index]) {
+		t.index++
+	}
+}
+
+func isWhitespaceChar(c byte) bool {
+	return c == ' ' || c == '\n' || c == '\t'
+}
+
+// ID := LETTER { LETTER }
+// LETTER := "0"..."9" | "a"..."z" | "A"..."Z" | "-" | "+" | "." | "_" | "&"
+func (t *typeParser) nextIdentifier() (id string, found bool) {
+	startIndex := t.index
+	for t.index < len(t.input) && isIdentifierChar(t.input[t.index]) {
+		t.index++
+	}
+	if startIndex == t.index {
+		return "", false
+	}
+	return t.input[startIndex:t.index], true
+}
+
+func isIdentifierChar(c byte) bool {
+	return (c >= '0' && c <= '9') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		c == '-' ||
+		c == '+' ||
+		c == '.' ||
+		c == '_' ||
+		c == '&'
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocql
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestTypeParser(t *testing.T) {
+	// native type
+	assertParseNonCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.UTF8Type",
+		assertTypeInfo{Type: TypeVarchar},
+	)
+
+	// reversed
+	assertParseNonCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.UUIDType)",
+		assertTypeInfo{Type: TypeUUID, Reversed: true},
+	)
+
+	// set
+	assertParseNonCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.Int32Type)",
+		assertTypeInfo{
+			Type: TypeSet,
+			Elem: &assertTypeInfo{Type: TypeInt},
+		},
+	)
+
+	// map
+	assertParseNonCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.BytesType)",
+		assertTypeInfo{
+			Type: TypeMap,
+			Key:  &assertTypeInfo{Type: TypeUUID},
+			Elem: &assertTypeInfo{Type: TypeBlob},
+		},
+	)
+
+	// custom
+	assertParseNonCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.DynamicCompositeType(u=>org.apache.cassandra.db.marshal.UUIDType,d=>org.apache.cassandra.db.marshal.DateType,t=>org.apache.cassandra.db.marshal.TimeUUIDType,b=>org.apache.cassandra.db.marshal.BytesType,s=>org.apache.cassandra.db.marshal.UTF8Type,B=>org.apache.cassandra.db.marshal.BooleanType,a=>org.apache.cassandra.db.marshal.AsciiType,l=>org.apache.cassandra.db.marshal.LongType,i=>org.apache.cassandra.db.marshal.IntegerType,x=>org.apache.cassandra.db.marshal.LexicalUUIDType)",
+		assertTypeInfo{Type: TypeCustom, Custom: "org.apache.cassandra.db.marshal.DynamicCompositeType(u=>org.apache.cassandra.db.marshal.UUIDType,d=>org.apache.cassandra.db.marshal.DateType,t=>org.apache.cassandra.db.marshal.TimeUUIDType,b=>org.apache.cassandra.db.marshal.BytesType,s=>org.apache.cassandra.db.marshal.UTF8Type,B=>org.apache.cassandra.db.marshal.BooleanType,a=>org.apache.cassandra.db.marshal.AsciiType,l=>org.apache.cassandra.db.marshal.LongType,i=>org.apache.cassandra.db.marshal.IntegerType,x=>org.apache.cassandra.db.marshal.LexicalUUIDType)"},
+	)
+
+	// composite defs
+	assertParseCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type)",
+		[]assertTypeInfo{
+			assertTypeInfo{Type: TypeVarchar},
+		},
+		nil,
+	)
+	assertParseCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.DateType,org.apache.cassandra.db.marshal.UTF8Type)",
+		[]assertTypeInfo{
+			assertTypeInfo{Type: TypeTimestamp},
+			assertTypeInfo{Type: TypeVarchar},
+		},
+		nil,
+	)
+	assertParseCompositeType(
+		t,
+		"org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(726f77735f6d6572676564:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.LongType)))",
+		[]assertTypeInfo{
+			assertTypeInfo{Type: TypeVarchar},
+		},
+		map[string]assertTypeInfo{
+			"rows_merged": assertTypeInfo{
+				Type: TypeMap,
+				Key:  &assertTypeInfo{Type: TypeInt},
+				Elem: &assertTypeInfo{Type: TypeBigInt},
+			},
+		},
+	)
+}
+
+//---------------------------------------
+// some code to assert the parser result
+//---------------------------------------
+
+type assertTypeInfo struct {
+	Type     Type
+	Reversed bool
+	Elem     *assertTypeInfo
+	Key      *assertTypeInfo
+	Custom   string
+}
+
+func assertParseNonCompositeType(
+	t *testing.T,
+	def string,
+	typeExpected assertTypeInfo,
+) {
+
+	result := parseType(def)
+	if len(result.reversed) != 1 {
+		t.Errorf("%s expected %d reversed values but there were %d", def, 1, len(result.reversed))
+	}
+
+	assertParseNonCompositeTypes(
+		t,
+		def,
+		[]assertTypeInfo{typeExpected},
+		result.types,
+	)
+
+	// expect no composite part of the result
+	if result.isComposite {
+		t.Errorf("%s: Expected not composite", def)
+	}
+	if result.collections != nil {
+		t.Errorf("%s: Expected nil collections: %v", def, result.collections)
+	}
+}
+
+func assertParseCompositeType(
+	t *testing.T,
+	def string,
+	typesExpected []assertTypeInfo,
+	collectionsExpected map[string]assertTypeInfo,
+) {
+
+	result := parseType(def)
+	if len(result.reversed) != len(typesExpected) {
+		t.Errorf("%s expected %d reversed values but there were %d", def, len(typesExpected), len(result.reversed))
+	}
+
+	assertParseNonCompositeTypes(
+		t,
+		def,
+		typesExpected,
+		result.types,
+	)
+
+	// expect composite part of the result
+	if !result.isComposite {
+		t.Errorf("%s: Expected composite", def)
+	}
+	if result.collections == nil {
+		t.Errorf("%s: Expected non-nil collections: %v", def, result.collections)
+	}
+
+	for name, typeExpected := range collectionsExpected {
+		// check for an actual type for this name
+		typeActual, found := result.collections[name]
+		if !found {
+			t.Errorf("%s.tcollections: Expected param named %s but there wasn't", def, name)
+		} else {
+			// remove the actual from the collection so we can detect extras
+			delete(result.collections, name)
+
+			// check the type
+			assertParseNonCompositeTypes(
+				t,
+				def+"collections["+name+"]",
+				[]assertTypeInfo{typeExpected},
+				[]TypeInfo{typeActual},
+			)
+		}
+	}
+
+	if len(result.collections) != 0 {
+		t.Errorf("%s.collections: Expected no more types in collections, but there was %v", def, result.collections)
+	}
+}
+
+func assertParseNonCompositeTypes(
+	t *testing.T,
+	context string,
+	typesExpected []assertTypeInfo,
+	typesActual []TypeInfo,
+) {
+	if len(typesActual) != len(typesExpected) {
+		t.Errorf("%s: Expected %d types, but there were %d", context, len(typesExpected), len(typesActual))
+	}
+
+	for i := range typesExpected {
+		typeExpected := typesExpected[i]
+		typeActual := typesActual[i]
+
+		// shadow copy the context for local modification
+		context := context
+		if len(typesExpected) > 1 {
+			context = context + "[" + strconv.Itoa(i) + "]"
+		}
+
+		// check the type
+		if typeActual.Type != typeExpected.Type {
+			t.Errorf("%s: Expected to parse Type to %s but was %s", context, typeExpected.Type, typeActual.Type)
+		}
+		// check the custom
+		if typeActual.Custom != typeExpected.Custom {
+			t.Errorf("%s: Expected to parse Custom %s but was %s", context, typeExpected.Custom, typeActual.Custom)
+		}
+		// check the elem
+		if typeActual.Elem == nil && typeExpected.Elem != nil {
+			t.Errorf("%s: Expected to parse Elem, but was nil ", context)
+		} else if typeExpected.Elem == nil && typeActual.Elem != nil {
+			t.Errorf("%s: Expected to not parse Elem, but was %+v", context, typeActual.Elem)
+		} else if typeActual.Elem != nil && typeExpected.Elem != nil {
+			assertParseNonCompositeTypes(
+				t,
+				context+".Elem",
+				[]assertTypeInfo{*typeExpected.Elem},
+				[]TypeInfo{*typeActual.Elem},
+			)
+		}
+		// check the key
+		if typeActual.Key == nil && typeExpected.Key != nil {
+			t.Errorf("%s: Expected to parse Key, but was nil ", context)
+		} else if typeExpected.Key == nil && typeActual.Key != nil {
+			t.Errorf("%s: Expected to not parse Key, but was %+v", context, typeActual.Key)
+		} else if typeActual.Key != nil && typeExpected.Key != nil {
+			assertParseNonCompositeTypes(
+				t,
+				context+".Key",
+				[]assertTypeInfo{*typeExpected.Key},
+				[]TypeInfo{*typeActual.Key},
+			)
+		}
+	}
+}

--- a/policies.go
+++ b/policies.go
@@ -4,6 +4,12 @@
 //This file will be the future home for more policies
 package gocql
 
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
 //RetryableQuery is an interface that represents a query or batch statement that
 //exposes the correct functions for the retry policy logic to evaluate correctly.
 type RetryableQuery interface {
@@ -41,4 +47,160 @@ type SimpleRetryPolicy struct {
 // than the NumRetries defined in the policy.
 func (s *SimpleRetryPolicy) Attempt(q RetryableQuery) bool {
 	return q.Attempts() <= s.NumRetries
+}
+
+//HostSelectionPolicy is an interface for selecting
+//the most appropriate host to execute a given query.
+type HostSelectionPolicy interface {
+	//SetHosts notifies this policy of the current hosts in the cluster
+	SetHosts(hosts []*HostInfo, partitioner string)
+	//Pick returns an iteration function over selected hosts
+	Pick(*Query) NextHost
+}
+
+//NextHost is an iteration function over picked hosts
+type NextHost func() *HostInfo
+
+//NewRoundRobinHostPolicy is a round-robin load balancing policy
+func NewRoundRobinHostPolicy() HostSelectionPolicy {
+	return &roundRobinHostPolicy{hosts: []*HostInfo{}}
+}
+
+type roundRobinHostPolicy struct {
+	hosts []*HostInfo
+	pos   uint32
+	mu    sync.RWMutex
+}
+
+func (r *roundRobinHostPolicy) SetHosts(hosts []*HostInfo, partitioner string) {
+	r.mu.Lock()
+	r.hosts = hosts
+	r.mu.Unlock()
+}
+
+func (r *roundRobinHostPolicy) Pick(qry *Query) NextHost {
+	pos := atomic.AddUint32(&r.pos, 1)
+	var i uint32 = 0
+	return func() *HostInfo {
+		var host *HostInfo
+		r.mu.RLock()
+		if len(r.hosts) > 0 && int(i) < len(r.hosts) {
+			host = r.hosts[(pos+i)%uint32(len(r.hosts))]
+			i++
+		}
+		r.mu.RUnlock()
+		return host
+	}
+}
+
+//NewTokenAwareHostPolicy is a token aware host selection policy
+func NewTokenAwareHostPolicy(fallback HostSelectionPolicy) HostSelectionPolicy {
+	return &tokenAwareHostPolicy{fallback: fallback}
+}
+
+type tokenAwareHostPolicy struct {
+	mu        sync.RWMutex
+	tokenRing *TokenRing
+	fallback  HostSelectionPolicy
+}
+
+func (t *tokenAwareHostPolicy) SetHosts(hosts []*HostInfo, partitioner string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// always update the fallback
+	t.fallback.SetHosts(hosts, partitioner)
+
+	if partitioner == "" {
+		// partitioner not yet set
+		return
+	}
+
+	// create a new token ring
+	tokenRing, err := NewTokenRing(partitioner, hosts)
+	if err != nil {
+		log.Printf("Unable to update the token ring due to error: %s", err)
+		return
+	}
+
+	// replace the token ring
+	t.tokenRing = tokenRing
+}
+
+func (t *tokenAwareHostPolicy) Pick(qry *Query) NextHost {
+	if qry == nil {
+		return t.fallback.Pick(qry)
+	}
+
+	routingKey := qry.GetRoutingKey()
+
+	if routingKey == nil {
+		return t.fallback.Pick(qry)
+	}
+
+	var host *HostInfo
+
+	t.mu.RLock()
+	if t.tokenRing != nil {
+		host = t.tokenRing.GetHostForPartitionKey(routingKey)
+	}
+	t.mu.RUnlock()
+
+	if host == nil {
+		return t.fallback.Pick(qry)
+	}
+
+	var hostReturned bool = false
+	var once sync.Once
+	var fallbackIter NextHost
+	return func() *HostInfo {
+		if !hostReturned {
+			hostReturned = true
+			return host
+		}
+
+		// fallback
+		once.Do(func() { fallbackIter = t.fallback.Pick(qry) })
+
+		fallbackHost := fallbackIter()
+		if fallbackHost == host {
+			fallbackHost = fallbackIter()
+		}
+
+		return fallbackHost
+	}
+}
+
+//ConnSelectionPolicy is an interface for selecting an
+//appropriate connection for executing a query
+type ConnSelectionPolicy interface {
+	SetConns(conns []*Conn)
+	Pick(*Query) *Conn
+}
+
+type roundRobinConnPolicy struct {
+	conns []*Conn
+	pos   uint32
+	mu    sync.RWMutex
+}
+
+func NewRoundRobinConnPolicy() ConnSelectionPolicy {
+	return &roundRobinConnPolicy{conns: []*Conn{}}
+}
+
+func (r *roundRobinConnPolicy) SetConns(conns []*Conn) {
+	r.mu.Lock()
+	r.conns = conns
+	r.mu.Unlock()
+}
+
+func (r *roundRobinConnPolicy) Pick(qry *Query) *Conn {
+	pos := atomic.AddUint32(&r.pos, 1)
+	var conn *Conn
+	r.mu.RLock()
+	if len(r.conns) > 0 {
+		conn = r.conns[pos%uint32(len(r.conns))]
+	}
+	r.mu.RUnlock()
+	return conn
 }

--- a/policies_test.go
+++ b/policies_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocql
+
+import "testing"
+
+func TestRoundRobinHostPolicy(t *testing.T) {
+	policy := NewRoundRobinHostPolicy()
+
+	hosts := []*HostInfo{
+		&HostInfo{HostId: "0"},
+		&HostInfo{HostId: "1"},
+	}
+
+	policy.SetHosts(hosts, "")
+
+	// the first host selected is actually at [1], but this is ok for RR
+	iter := policy.Pick(nil)
+	if actual := iter(); actual != hosts[1] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.HostId)
+	}
+	if actual := iter(); actual != hosts[0] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.HostId)
+	}
+	iter = policy.Pick(nil)
+	if actual := iter(); actual != hosts[0] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.HostId)
+	}
+	if actual := iter(); actual != hosts[1] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.HostId)
+	}
+	iter = policy.Pick(nil)
+	if actual := iter(); actual != hosts[1] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.HostId)
+	}
+	if actual := iter(); actual != hosts[0] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.HostId)
+	}
+}
+
+func TestTokenAwareHostPolicy(t *testing.T) {
+	policy := NewTokenAwareHostPolicy(NewRoundRobinHostPolicy())
+
+	hosts := []*HostInfo{
+		&HostInfo{HostId: "0", Peer: "0", Tokens: []string{"00"}},
+		&HostInfo{HostId: "1", Peer: "1", Tokens: []string{"25"}},
+		&HostInfo{HostId: "2", Peer: "2", Tokens: []string{"50"}},
+		&HostInfo{HostId: "3", Peer: "3", Tokens: []string{"75"}},
+	}
+
+	policy.SetHosts(hosts, "OrderedPartitioner")
+
+	query := &Query{}
+	query.RoutingKey([]byte("30"))
+
+	if actual := policy.Pick(query)(); actual != hosts[2] {
+		t.Errorf("Expected hosts[2] but was hosts[%s]", actual.HostId)
+	}
+}
+
+func TestRoundRobinConnPolicy(t *testing.T) {
+	policy := NewRoundRobinConnPolicy()
+
+	conn0 := &Conn{}
+	conn1 := &Conn{}
+	conn := []*Conn{
+		conn0,
+		conn1,
+	}
+
+	policy.SetConns(conn)
+
+	// the first conn selected is actually at [1], but this is ok for RR
+	if actual := policy.Pick(nil); actual != conn1 {
+		t.Error("Expected conn1")
+	}
+	if actual := policy.Pick(nil); actual != conn0 {
+		t.Error("Expected conn0")
+	}
+	if actual := policy.Pick(nil); actual != conn1 {
+		t.Error("Expected conn1")
+	}
+}

--- a/session.go
+++ b/session.go
@@ -5,6 +5,8 @@
 package gocql
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +14,8 @@ import (
 	"sync"
 	"time"
 	"unicode"
+
+	"github.com/golang/groupcache/lru"
 )
 
 // Session is the interface used by users to interact with the database.
@@ -24,13 +28,14 @@ import (
 // and automatically sets a default consinstency level on all operations
 // that do not have a consistency level set.
 type Session struct {
-	Pool            ConnectionPool
-	cons            Consistency
-	pageSize        int
-	prefetch        float64
-	schemaDescriber *schemaDescriber
-	trace           Tracer
-	mu              sync.RWMutex
+	Pool                ConnectionPool
+	cons                Consistency
+	pageSize            int
+	prefetch            float64
+	routingKeyInfoCache routingKeyInfoLRU
+	schemaDescriber     *schemaDescriber
+	trace               Tracer
+	mu                  sync.RWMutex
 
 	cfg ClusterConfig
 
@@ -40,7 +45,12 @@ type Session struct {
 
 // NewSession wraps an existing Node.
 func NewSession(p ConnectionPool, c ClusterConfig) *Session {
-	return &Session{Pool: p, cons: Quorum, prefetch: 0.25, cfg: c}
+	session := &Session{Pool: p, cons: Quorum, prefetch: 0.25, cfg: c}
+
+	// create the query info cache
+	session.routingKeyInfoCache.lru = lru.New(c.MaxRoutingKeyInfo)
+
+	return session
 }
 
 // SetConsistency sets the default consistency level for this session. This
@@ -175,6 +185,104 @@ func (s *Session) KeyspaceMetadata() (*KeyspaceMetadata, error) {
 	return s.schemaDescriber.GetSchema()
 }
 
+// returns routing key indexes and type info
+func (s *Session) routingKeyInfo(stmt string) *routingKeyInfo {
+	s.routingKeyInfoCache.mu.Lock()
+	cacheKey := s.cfg.Keyspace + stmt
+	entry, cached := s.routingKeyInfoCache.lru.Get(cacheKey)
+	if cached {
+		// done accessing the cache
+		s.routingKeyInfoCache.mu.Unlock()
+		// the entry is an inflight struct similiar to that used by
+		// Conn to prepare statements
+		inflight := entry.(*inflightCachedEntry)
+		// wait for any inflight work
+		inflight.wg.Wait()
+
+		if inflight.err != nil {
+			// return nil for any error
+			return nil
+		}
+
+		return inflight.value.(*routingKeyInfo)
+	}
+
+	// create a new inflight entry while the data is created
+	inflight := new(inflightCachedEntry)
+	inflight.wg.Add(1)
+	defer inflight.wg.Done()
+	s.routingKeyInfoCache.lru.Add(cacheKey, inflight)
+	s.routingKeyInfoCache.mu.Unlock()
+
+	var queryInfo *QueryInfo
+	var partitionKey []*ColumnMetadata
+
+	// get the query info for the statement
+	conn := s.Pool.Pick(nil)
+	if conn != nil {
+		queryInfo, inflight.err = conn.prepareStatement(stmt, s.trace)
+		if inflight.err == nil {
+			if len(queryInfo.Args) == 0 {
+				// no arguments, no routing key, and no error
+				return nil
+			}
+
+			// get the table metadata
+			table := queryInfo.Args[0].Table
+			var keyspaceMetadata *KeyspaceMetadata
+			keyspaceMetadata, inflight.err = s.KeyspaceMetadata()
+			if inflight.err == nil {
+				tableMetadata, found := keyspaceMetadata.Tables[table]
+				if !found {
+					inflight.err = ErrNoMetadata
+				}
+
+				partitionKey = tableMetadata.PartitionKey
+			}
+		}
+	} else {
+		// no connections
+		inflight.err = ErrNoConnections
+	}
+
+	if inflight.err != nil {
+		// remove from the cache
+		s.routingKeyInfoCache.mu.Lock()
+		s.routingKeyInfoCache.lru.Remove(cacheKey)
+		s.routingKeyInfoCache.mu.Unlock()
+		return nil
+	}
+
+	size := len(partitionKey)
+	routingKeyInfo := &routingKeyInfo{
+		indexes: make([]int, size),
+		types:   make([]*TypeInfo, size),
+	}
+	for i, keyColumn := range partitionKey {
+		routingKeyInfo.indexes[i] = -1
+		// find the column in the query info
+		for j, boundColumn := range queryInfo.Args {
+			if keyColumn.Name == boundColumn.Name {
+				// there may be many such columns, pick the first
+				routingKeyInfo.indexes[i] = j
+				routingKeyInfo.types[i] = boundColumn.TypeInfo
+				break
+			}
+		}
+
+		if routingKeyInfo.indexes[i] == -1 {
+			// missing a routing key column mapping
+			// no error, but cache a nil result
+			return nil
+		}
+	}
+
+	// cache this result
+	inflight.value = routingKeyInfo
+
+	return routingKeyInfo
+}
+
 // ExecuteBatch executes a batch operation and returns nil if successful
 // otherwise an error is returned describing the failure.
 func (s *Session) ExecuteBatch(batch *Batch) error {
@@ -224,6 +332,7 @@ type Query struct {
 	values       []interface{}
 	cons         Consistency
 	pageSize     int
+	routingKey   []byte
 	pageState    []byte
 	prefetch     float64
 	trace        Tracer
@@ -275,6 +384,58 @@ func (q *Query) Trace(trace Tracer) *Query {
 func (q *Query) PageSize(n int) *Query {
 	q.pageSize = n
 	return q
+}
+
+// RoutingKey sets the routing key to use when a token aware connection
+// pool is used to optimize the routing of this query.
+func (q *Query) RoutingKey(routingKey []byte) *Query {
+	q.routingKey = routingKey
+	return q
+}
+
+// GetRoutingKey gets the routing key to use for routing this query. If
+// a routing key has not been explicitly set, then the routing key will
+// be constructed if possible using the keyspace's schema and the query
+// info for this query statement.
+func (q *Query) GetRoutingKey() []byte {
+	if q.routingKey != nil {
+		return q.routingKey
+	}
+
+	// try to determine the routing key
+	routingKeyInfo := q.session.routingKeyInfo(q.stmt)
+	if routingKeyInfo == nil {
+		return nil
+	}
+
+	if len(routingKeyInfo.indexes) == 1 {
+		// single column routing key
+		routingKey, err := Marshal(
+			routingKeyInfo.types[0],
+			q.values[routingKeyInfo.indexes[0]],
+		)
+		if err != nil {
+			return nil
+		}
+		return routingKey
+	}
+
+	// composite routing key
+	buf := &bytes.Buffer{}
+	for i := range routingKeyInfo.indexes {
+		encoded, err := Marshal(
+			routingKeyInfo.types[i],
+			q.values[routingKeyInfo.indexes[i]],
+		)
+		if err != nil {
+			return nil
+		}
+		binary.Write(buf, binary.BigEndian, int16(len(encoded)))
+		buf.Write(encoded)
+		buf.WriteByte(0x00)
+	}
+	routingKey := buf.Bytes()
+	return routingKey
 }
 
 func (q *Query) shouldPrepare() bool {
@@ -600,6 +761,34 @@ type ColumnInfo struct {
 	TypeInfo *TypeInfo
 }
 
+// routing key indexes LRU cache
+type routingKeyInfoLRU struct {
+	lru *lru.Cache
+	mu  sync.Mutex
+}
+
+type routingKeyInfo struct {
+	indexes []int
+	types   []*TypeInfo
+}
+
+//Max adjusts the maximum size of the cache and cleans up the oldest records if
+//the new max is lower than the previous value. Not concurrency safe.
+func (q *routingKeyInfoLRU) Max(max int) {
+	q.mu.Lock()
+	for q.lru.Len() > max {
+		q.lru.RemoveOldest()
+	}
+	q.lru.MaxEntries = max
+	q.mu.Unlock()
+}
+
+type inflightCachedEntry struct {
+	wg    sync.WaitGroup
+	err   error
+	value interface{}
+}
+
 // Tracer is the interface implemented by query tracers. Tracers have the
 // ability to obtain a detailed event log of all events that happened during
 // the execution of a query from Cassandra. Gathering this information might
@@ -671,6 +860,7 @@ var (
 	ErrUseStmt       = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
 	ErrSessionClosed = errors.New("session has been closed")
 	ErrNoConnections = errors.New("no connections available")
+	ErrNoMetadata    = errors.New("no metadata available")
 )
 
 type ErrProtocol struct{ error }

--- a/token.go
+++ b/token.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocql
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spaolacci/murmur3"
+)
+
+// a token partitioner
+type Partitioner interface {
+	Hash([]byte) Token
+	ParseString(string) Token
+}
+
+// a token
+type Token interface {
+	fmt.Stringer
+	Less(Token) bool
+}
+
+// murmur3 partitioner and token
+type Murmur3Partitioner struct{}
+type Murmur3Token int64
+
+func (p Murmur3Partitioner) Hash(partitionKey []byte) Token {
+	hash := murmur3.New128()
+	hash.Write(partitionKey)
+	// cassandra only uses h1
+	h1, _ := hash.Sum128()
+	return Murmur3Token(int64(h1))
+}
+
+func (p Murmur3Partitioner) ParseString(str string) Token {
+	val, _ := strconv.ParseInt(str, 10, 64)
+	return Murmur3Token(val)
+}
+
+func (m Murmur3Token) String() string {
+	return strconv.FormatInt(int64(m), 10)
+}
+
+func (m Murmur3Token) Less(token Token) bool {
+	return m < token.(Murmur3Token)
+}
+
+// order preserving partitioner and token
+type OrderPreservingPartitioner struct{}
+type OrderPreservingToken []byte
+
+func (p OrderPreservingPartitioner) Hash(partitionKey []byte) Token {
+	// the partition key is the token
+	return OrderPreservingToken(partitionKey)
+}
+
+func (p OrderPreservingPartitioner) ParseString(str string) Token {
+	return OrderPreservingToken([]byte(str))
+}
+
+func (o OrderPreservingToken) String() string {
+	return string([]byte(o))
+}
+
+func (o OrderPreservingToken) Less(token Token) bool {
+	return -1 == bytes.Compare(o, token.(OrderPreservingToken))
+}
+
+// random partitioner and token
+type RandomPartitioner struct{}
+type RandomToken struct {
+	*big.Int
+}
+
+func (p RandomPartitioner) Hash(partitionKey []byte) Token {
+	hash := md5.New()
+	sum := hash.Sum(partitionKey)
+
+	val := new(big.Int)
+	val = val.SetBytes(sum)
+	val = val.Abs(val)
+
+	return RandomToken{val}
+}
+
+func (p RandomPartitioner) ParseString(str string) Token {
+	val := new(big.Int)
+	val.SetString(str, 10)
+	return RandomToken{val}
+}
+
+func (r RandomToken) Less(token Token) bool {
+	return -1 == r.Int.Cmp(token.(RandomToken).Int)
+}
+
+// a data structure for organizing the relationship between tokens and hosts
+type TokenRing struct {
+	partitioner Partitioner
+	tokens      []Token
+	hosts       []*HostInfo
+}
+
+func NewTokenRing(partitioner string, hosts []*HostInfo) (*TokenRing, error) {
+	tokenRing := &TokenRing{
+		tokens: []Token{},
+		hosts:  []*HostInfo{},
+	}
+
+	if strings.HasSuffix(partitioner, "Murmur3Partitioner") {
+		tokenRing.partitioner = Murmur3Partitioner{}
+	} else if strings.HasSuffix(partitioner, "OrderedPartitioner") {
+		tokenRing.partitioner = OrderPreservingPartitioner{}
+	} else if strings.HasSuffix(partitioner, "RandomPartitioner") {
+		tokenRing.partitioner = RandomPartitioner{}
+	} else {
+		return nil, fmt.Errorf("Unsupported partitioner '%s'", partitioner)
+	}
+
+	for _, host := range hosts {
+		for _, strToken := range host.Tokens {
+			token := tokenRing.partitioner.ParseString(strToken)
+			tokenRing.tokens = append(tokenRing.tokens, token)
+			tokenRing.hosts = append(tokenRing.hosts, host)
+		}
+	}
+
+	sort.Sort(tokenRing)
+
+	return tokenRing, nil
+}
+
+func (t *TokenRing) Len() int {
+	return len(t.tokens)
+}
+
+func (t *TokenRing) Less(i, j int) bool {
+	return t.tokens[i].Less(t.tokens[j])
+}
+
+func (t *TokenRing) Swap(i, j int) {
+	t.tokens[i], t.hosts[i], t.tokens[j], t.hosts[j] =
+		t.tokens[j], t.hosts[j], t.tokens[i], t.hosts[i]
+}
+
+func (t *TokenRing) String() string {
+	buf := &bytes.Buffer{}
+	buf.WriteString("TokenRing={")
+	sep := ""
+	for i := range t.tokens {
+		buf.WriteString(sep)
+		sep = ","
+		buf.WriteString("\n\t[")
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString("]")
+		buf.WriteString(t.tokens[i].String())
+		buf.WriteString(":")
+		buf.WriteString(t.hosts[i].Peer)
+	}
+	buf.WriteString("\n}")
+	return string(buf.Bytes())
+}
+
+func (t *TokenRing) GetHostForPartitionKey(partitionKey []byte) *HostInfo {
+	token := t.partitioner.Hash(partitionKey)
+	return t.GetHostForToken(token)
+}
+
+func (t *TokenRing) GetHostForToken(token Token) *HostInfo {
+	// find the primary repica
+	ringIndex := sort.Search(
+		len(t.tokens),
+		func(i int) bool {
+			return !t.tokens[i].Less(token)
+		},
+	)
+	if ringIndex == len(t.tokens) {
+		// wrap around to the first in the ring
+		ringIndex = 0
+	}
+	host := t.hosts[ringIndex]
+	return host
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2015 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gocql
+
+import (
+	"math/big"
+	"strconv"
+	"testing"
+)
+
+func TestMurmur3Partitioner(t *testing.T) {
+	token := Murmur3Partitioner{}.ParseString("-1053604476080545076")
+
+	if "-1053604476080545076" != token.String() {
+		t.Errorf("Expected '-1053604476080545076' but was '%s'", token)
+	}
+
+	// at least verify that the partitioner
+	// doesn't return nil
+	pk, _ := marshalInt(nil, 1)
+	token = Murmur3Partitioner{}.Hash(pk)
+	if token == nil {
+		t.Fatal("token was nil")
+	}
+}
+
+func TestMurmur3Token(t *testing.T) {
+	if Murmur3Token(42).Less(Murmur3Token(42)) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+	if !Murmur3Token(-42).Less(Murmur3Token(42)) {
+		t.Errorf("Expected Less to return true, but was false")
+	}
+	if Murmur3Token(42).Less(Murmur3Token(-42)) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+}
+
+func TestOrderPreservingPartitioner(t *testing.T) {
+	// at least verify that the partitioner
+	// doesn't return nil
+	pk, _ := marshalInt(nil, 1)
+	token := OrderPreservingPartitioner{}.Hash(pk)
+	if token == nil {
+		t.Fatal("token was nil")
+	}
+}
+
+func TestOrderPreservingToken(t *testing.T) {
+	if OrderPreservingToken([]byte{0, 0, 4, 2}).Less(OrderPreservingToken([]byte{0, 0, 4, 2})) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+	if !OrderPreservingToken([]byte{0, 0, 3}).Less(OrderPreservingToken([]byte{0, 0, 4, 2})) {
+		t.Errorf("Expected Less to return true, but was false")
+	}
+	if OrderPreservingToken([]byte{0, 0, 4, 2}).Less(OrderPreservingToken([]byte{0, 0, 3})) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+}
+
+func TestRandomPartitioner(t *testing.T) {
+	// at least verify that the partitioner
+	// doesn't return nil
+	pk, _ := marshalInt(nil, 1)
+	token := RandomPartitioner{}.Hash(pk)
+	if token == nil {
+		t.Fatal("token was nil")
+	}
+}
+
+func TestRandomToken(t *testing.T) {
+	if (RandomToken{big.NewInt(42)}).Less(RandomToken{big.NewInt(42)}) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+	if !(RandomToken{big.NewInt(41)}).Less(RandomToken{big.NewInt(42)}) {
+		t.Errorf("Expected Less to return true, but was false")
+	}
+	if (RandomToken{big.NewInt(42)}).Less(RandomToken{big.NewInt(41)}) {
+		t.Errorf("Expected Less to return false, but was true")
+	}
+}
+
+type IntToken int
+
+func (i IntToken) String() string {
+	return strconv.Itoa(int(i))
+}
+
+func (i IntToken) Less(token Token) bool {
+	return i < token.(IntToken)
+}
+
+func TestIntTokenRing(t *testing.T) {
+	// test based on example at the start of this page of documentation:
+	// http://www.datastax.com/docs/0.8/cluster_architecture/partitioning
+	host0 := &HostInfo{}
+	host25 := &HostInfo{}
+	host50 := &HostInfo{}
+	host75 := &HostInfo{}
+	tokenRing := &TokenRing{
+		partitioner: nil,
+		tokens: []Token{
+			IntToken(0),
+			IntToken(25),
+			IntToken(50),
+			IntToken(75),
+		},
+		hosts: []*HostInfo{
+			host0,
+			host25,
+			host50,
+			host75,
+		},
+	}
+
+	if tokenRing.GetHostForToken(IntToken(0)) != host0 {
+		t.Error("Expected host 0 for token 0")
+	}
+	if tokenRing.GetHostForToken(IntToken(1)) != host25 {
+		t.Error("Expected host 25 for token 1")
+	}
+	if tokenRing.GetHostForToken(IntToken(24)) != host25 {
+		t.Error("Expected host 25 for token 24")
+	}
+	if tokenRing.GetHostForToken(IntToken(25)) != host25 {
+		t.Error("Expected host 25 for token 25")
+	}
+	if tokenRing.GetHostForToken(IntToken(26)) != host50 {
+		t.Error("Expected host 50 for token 26")
+	}
+	if tokenRing.GetHostForToken(IntToken(49)) != host50 {
+		t.Error("Expected host 50 for token 49")
+	}
+	if tokenRing.GetHostForToken(IntToken(50)) != host50 {
+		t.Error("Expected host 50 for token 50")
+	}
+	if tokenRing.GetHostForToken(IntToken(51)) != host75 {
+		t.Error("Expected host 75 for token 51")
+	}
+	if tokenRing.GetHostForToken(IntToken(74)) != host75 {
+		t.Error("Expected host 75 for token 74")
+	}
+	if tokenRing.GetHostForToken(IntToken(75)) != host75 {
+		t.Error("Expected host 75 for token 75")
+	}
+	if tokenRing.GetHostForToken(IntToken(76)) != host0 {
+		t.Error("Expected host 0 for token 76")
+	}
+	if tokenRing.GetHostForToken(IntToken(99)) != host0 {
+		t.Error("Expected host 0 for token 99")
+	}
+	if tokenRing.GetHostForToken(IntToken(100)) != host0 {
+		t.Error("Expected host 0 for token 100")
+	}
+}


### PR DESCRIPTION
Adds a new connection pool implementation and supporting functionality to optionally route queries using a token aware policy. 

The new connection pool implementation (policyConnPool) is a factoring of SimplePool which splits the code for managing a pool of connections for a single host into an independent struct (hostConnPool) from the higher level multi-host connection pool. It also introduces two policy interfaces HostSelectionPolicy and ConnSelectionPolicy for selecting a prioritized list of hosts for a query and for selecting a connection for a host respectively.

I have added a ccm based test script connectionpool_systems_test.sh and a go test connectionpool_systems_test.go which test the behaviors of SimplePool and policyConnPool independently when nodes are stopped and started. This test demonstrates some situations where SimplePool will return a nil *Conn from Pick when nodes are stopped.

Note that I have left SimplePool in place as-is, though the NewRoundRobinConnPool function returns an equivalent connection pool.

This pull request also introduces a new dependency on github.com/spaolacci/murmur3 (BSD-like licence) for the Murmur3 Partitioner, though if desired this dependency could be replaced by simply including the Murmur3 128-bit algorithm directly in Murmur3Partitioner which is what the DataStacks Java driver does.