### PR TITLE
Fix bugs in Cassandra internal type resolution

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -97,9 +97,9 @@ func getApacheCassandraType(class string) Type {
 		case "MapType":
 			return TypeMap
 		case "ListType":
-			return TypeInet
+			return TypeList
 		case "SetType":
-			return TypeInet
+			return TypeSet
 		}
 	}
 	return TypeCustom

--- a/helpers.go
+++ b/helpers.go
@@ -82,7 +82,7 @@ func getApacheCassandraType(class string) Type {
 			return TypeFloat
 		case "Int32Type":
 			return TypeInt
-		case "DateType":
+		case "DateType", "TimestampType":
 			return TypeTimestamp
 		case "UUIDType":
 			return TypeUUID

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -659,6 +659,7 @@ var typeLookupTest = []struct {
 	{"FloatType", TypeFloat},
 	{"Int32Type", TypeInt},
 	{"DateType", TypeTimestamp},
+	{"TimestampType", TypeTimestamp},
 	{"UUIDType", TypeUUID},
 	{"UTF8Type", TypeVarchar},
 	{"IntegerType", TypeVarint},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -666,8 +666,8 @@ var typeLookupTest = []struct {
 	{"TimeUUIDType", TypeTimeUUID},
 	{"InetAddressType", TypeInet},
 	{"MapType", TypeMap},
-	{"ListType", TypeInet},
-	{"SetType", TypeInet},
+	{"ListType", TypeList},
+	{"SetType", TypeSet},
 	{"unknown", TypeCustom},
 }
 


### PR DESCRIPTION
There are a few bugs in the way that we resolve Apache Cassandra internal type names:

* TimestampType (successor to DateType) has no support - so we need to add this
* Sets and Lists were being incorrectly mapped to the inet type (as pointed out by @justinretailnext as part of #309)

So this patch attempts to clean up these errors irrespective of the development of #309.  