### PR TITLE
Use HSHA, tweak rpc_min/max_threads

### DIFF
--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestProto1BatchInsert(t *testing.T) {
 	session := createSession(t)
+	defer session.Close()
+
 	if err := session.Query("CREATE TABLE large (id int primary key)").Exec(); err != nil {
 		t.Fatal("create table:", err)
 	}

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -68,6 +68,7 @@ func createCluster() *ClusterConfig {
 	cluster.CQLVersion = *flagCQL
 	cluster.Timeout = 5 * time.Second
 	cluster.Consistency = Quorum
+	cluster.NumStreams = 1
 	if *flagRetry > 0 {
 		cluster.RetryPolicy = &SimpleRetryPolicy{NumRetries: *flagRetry}
 	}

--- a/integration.sh
+++ b/integration.sh
@@ -28,7 +28,6 @@ function run_tests() {
 		"write_request_timeout_in_ms: 5000"
 		"read_request_timeout_in_ms: 5000"
 		"compaction_throughput_mb_per_sec: 0"
-		"in_memory_compaction_limit_in_mb: 1"
 	)
 
 	for f in "${conf[@]}"; do
@@ -48,6 +47,8 @@ function run_tests() {
 	local tmp=$(mktemp)
 	echo 'SELECT peer, data_center, rack FROM system.peers' > $tmp	
 	cqlsh -f $tmp 127.0.0.1
+
+	sleep 3
 
 	go test -timeout 5m -tags integration -cover -v -runssl -proto=$proto -rf=3 -cluster=$(ccm liveset) -clusterSize=$clusterSize -autowait=2000ms ./... | tee results.txt
 

--- a/integration.sh
+++ b/integration.sh
@@ -60,8 +60,10 @@ function run_tests() {
 		echo "--- FAIL: ccm status follows:"
 		ccm status
 		ccm node1 nodetool status
-		ccm node1 showlog > status.log
-		cat status.log
+		ccm node1 showlog
+		ccm node2 showlog
+		ccm node3 showlog
+
 		echo "--- FAIL: Received a non-zero exit code from the go test execution, please investigate this"
 		exit 1
 	fi

--- a/integration.sh
+++ b/integration.sh
@@ -46,7 +46,7 @@ function run_tests() {
 
 	local tmp=$(mktemp)
 	echo 'SELECT peer, data_center, rack FROM system.peers' > $tmp	
-	cqlsh -f $tmp 127.0.0.1
+	ccm node1 cqlsh -f $tmp 127.0.0.1
 
 	sleep 3
 

--- a/integration.sh
+++ b/integration.sh
@@ -32,7 +32,7 @@ function run_tests() {
 	)
 
 	for f in "${conf[@]}"; do
-		ccm updateconf "'$f'"
+		ccm updateconf "$f"
 	done
 
 	ccm start -v

--- a/integration.sh
+++ b/integration.sh
@@ -5,6 +5,7 @@ set -e
 function run_tests() {
 	local clusterSize=3
 	local version=$1
+	java -version
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
 	

--- a/integration.sh
+++ b/integration.sh
@@ -45,6 +45,10 @@ function run_tests() {
 		proto=1
 	fi
 
+	local tmp=$(mktemp)
+	echo 'SELECT peer, data_center, rack FROM system.peers' > $tmp	
+	cqlsh -f $tmp 127.0.0.1
+
 	go test -timeout 5m -tags integration -cover -v -runssl -proto=$proto -rf=3 -cluster=$(ccm liveset) -clusterSize=$clusterSize -autowait=2000ms ./... | tee results.txt
 
 	if [ ${PIPESTATUS[0]} -ne 0 ]; then 

--- a/integration.sh
+++ b/integration.sh
@@ -60,9 +60,10 @@ function run_tests() {
 		echo "--- FAIL: ccm status follows:"
 		ccm status
 		ccm node1 nodetool status
-		ccm node1 showlog
-		ccm node2 showlog
-		ccm node3 showlog
+		ccm node1 showlog > status
+		ccm node2 showlog >> status
+		ccm node3 showlog >> status
+		cat status
 
 		echo "--- FAIL: Received a non-zero exit code from the go test execution, please investigate this"
 		exit 1

--- a/integration.sh
+++ b/integration.sh
@@ -12,27 +12,29 @@ function run_tests() {
 	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="32M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
 	local conf=(
-		'client_encryption_options.enabled: true'
-		'client_encryption_options.keystore: testdata/pki/.keystore'
-		'client_encryption_options.keystore_password: cassandra'
-		'client_encryption_options.require_client_auth: true'
-		'client_encryption_options.truststore: testdata/pki/.truststore'
-		'client_encryption_options.truststore_password: cassandra'
-		'concurrent_reads: 2'
-		'concurrent_writes: 2'
-		'rpc_server_type: hsha'
-		'rpc_min_threads: 1'
-		'rpc_max_threads: 1'
-		'write_request_timeout_in_ms: 5000'
-		'read_request_timeout_in_ms: 5000'
-		'compaction_throughput_mb_per_sec: 0'
-		'in_memory_compaction_limit_in_mb: 1'
-		'reduce_cache_sizes_at: 0'
-		'reduce_cache_capacity_to: 0'
-
+		"client_encryption_options.enabled: true"
+		"client_encryption_options.keystore: testdata/pki/.keystore"
+		"client_encryption_options.keystore_password: cassandra"
+		"client_encryption_options.require_client_auth: true"
+		"client_encryption_options.truststore: testdata/pki/.truststore"
+		"client_encryption_options.truststore_password: cassandra"
+		"concurrent_reads: 2"
+		"concurrent_writes: 2"
+		"rpc_server_type: hsha"
+		"rpc_min_threads: 1"
+		"rpc_max_threads: 1"
+		"write_request_timeout_in_ms: 5000"
+		"read_request_timeout_in_ms: 5000"
+		"compaction_throughput_mb_per_sec: 0"
+		"in_memory_compaction_limit_in_mb: 1"
+		"reduce_cache_sizes_at: 0"
+		"reduce_cache_capacity_to: 0"
 	)
 
-	ccm updateconf ${conf[@]}
+	for f in "${conf[@]}"; do
+		ccm updateconf "'$f'"
+	done
+
 	ccm start -v
 	ccm status
 	ccm node1 nodetool status

--- a/integration.sh
+++ b/integration.sh
@@ -46,7 +46,7 @@ function run_tests() {
 
 	local tmp=$(mktemp)
 	echo 'SELECT peer, data_center, rack FROM system.peers' > $tmp	
-	ccm node1 cqlsh -f $tmp 127.0.0.1
+	ccm node1 cqlsh -f $tmp
 
 	sleep 3
 

--- a/integration.sh
+++ b/integration.sh
@@ -8,8 +8,8 @@ function run_tests() {
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
 	
-	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="512M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
-	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="32M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="720M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="200M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
 	free -mt
 

--- a/integration.sh
+++ b/integration.sh
@@ -27,8 +27,6 @@ function run_tests() {
 		"read_request_timeout_in_ms: 5000"
 		"compaction_throughput_mb_per_sec: 0"
 		"in_memory_compaction_limit_in_mb: 1"
-		"reduce_cache_sizes_at: 0"
-		"reduce_cache_capacity_to: 0"
 	)
 
 	for f in "${conf[@]}"; do

--- a/integration.sh
+++ b/integration.sh
@@ -45,8 +45,12 @@ function run_tests() {
 	fi
 
 	local tmp=$(mktemp)
-	echo 'SELECT peer, data_center, rack FROM system.peers;' > $tmp	
+	echo 'SELECT peer, data_center, rack, release_version FROM system.peers;' > $tmp	
 	ccm node1 cqlsh -f $tmp
+	local tmp=$(mktemp)
+	echo 'SELECT bootstrapped, cluster_name, cql_version, data_center, release_version FROM system.local;' > $tmp	
+	ccm node1 cqlsh -f $tmp
+
 
 	sleep 3
 

--- a/integration.sh
+++ b/integration.sh
@@ -45,7 +45,7 @@ function run_tests() {
 	fi
 
 	local tmp=$(mktemp)
-	echo 'SELECT peer, data_center, rack FROM system.peers' > $tmp	
+	echo 'SELECT peer, data_center, rack FROM system.peers;' > $tmp	
 	ccm node1 cqlsh -f $tmp
 
 	sleep 3

--- a/integration.sh
+++ b/integration.sh
@@ -5,11 +5,10 @@ set -e
 function run_tests() {
 	local clusterSize=3
 	local version=$1
-	java -version
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
 	
-	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="256M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="512M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
 	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: hsha' 'rpc_min_threads: 1' 'rpc_max_threads: 8' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'

--- a/integration.sh
+++ b/integration.sh
@@ -8,10 +8,31 @@ function run_tests() {
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
 	
-	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="512M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
-	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="128M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="32M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
-	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: hsha' 'rpc_min_threads: 1' 'rpc_max_threads: 8' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
+	local conf=(
+		'client_encryption_options.enabled: true'
+		'client_encryption_options.keystore: testdata/pki/.keystore'
+		'client_encryption_options.keystore_password: cassandra'
+		'client_encryption_options.require_client_auth: true'
+		'client_encryption_options.truststore: testdata/pki/.truststore'
+		'client_encryption_options.truststore_password: cassandra'
+		'concurrent_reads: 2'
+		'concurrent_writes: 2'
+		'rpc_server_type: hsha'
+		'rpc_min_threads: 1'
+		'rpc_max_threads: 1'
+		'write_request_timeout_in_ms: 5000'
+		'read_request_timeout_in_ms: 5000'
+		'compaction_throughput_mb_per_sec: 0'
+		'in_memory_compaction_limit_in_mb: 1'
+		'reduce_cache_sizes_at: 0'
+		'reduce_cache_capacity_to: 0'
+
+	)
+
+	ccm updateconf ${conf[@]}
 	ccm start -v
 	ccm status
 	ccm node1 nodetool status

--- a/integration.sh
+++ b/integration.sh
@@ -8,8 +8,10 @@ function run_tests() {
 
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
 	
-	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="128M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="512M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="32M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+
+	free -mt
 
 	local conf=(
 		"client_encryption_options.enabled: true"
@@ -35,6 +37,7 @@ function run_tests() {
 
 	ccm start -v
 	ccm status
+	free -mt
 	ccm node1 nodetool status
 	
 	local proto=2

--- a/integration.sh
+++ b/integration.sh
@@ -11,7 +11,7 @@ function run_tests() {
 	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="256M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
-	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 2' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
+	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: hsha' 'rpc_min_threads: 1' 'rpc_max_threads: 8' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
 	ccm start -v
 	ccm status
 	ccm node1 nodetool status


### PR DESCRIPTION
Use HSHA instead of the SYNC connection pool for the RPC threads,
allow a max of 8 threads which is the default in the cluster config