### PR TITLE
lock mu when checking if the pool is closed

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -291,7 +291,10 @@ func (c *SimplePool) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 	c.removeConn(conn)
-	if !c.quit {
+	c.mu.Lock()
+	poolClosed := c.quit
+	c.mu.Unlock()
+	if !poolClosed {
 		go c.fillPool() // top off pool.
 	}
 }


### PR DESCRIPTION
This patches a bug whereby a closed pool could be refilled during a race condition. It also makes access the the `quit` flag more consistent with other access paths. 