### PR TITLE
Default a Session's consistency to that of its ClusterConfig

### DIFF
--- a/session.go
+++ b/session.go
@@ -40,7 +40,7 @@ type Session struct {
 
 // NewSession wraps an existing Node.
 func NewSession(p ConnectionPool, c ClusterConfig) *Session {
-	return &Session{Pool: p, cons: Quorum, prefetch: 0.25, cfg: c}
+	return &Session{Pool: p, cons: c.Consistency, prefetch: 0.25, cfg: c}
 }
 
 // SetConsistency sets the default consistency level for this session. This


### PR DESCRIPTION
I'm not 100% sure whether this is technically a bug or not (please close if not), but it seems to me that when constructing a `Session` with `NewSession`, its consistency level should be defaulted to that of its `ClusterConfig`.