### PR TITLE
conn: only setup the TLS config once

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -113,7 +113,10 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 		cfg.NumStreams = maxStreams
 	}
 
-	pool := cfg.ConnPoolType(cfg)
+	pool, err := cfg.ConnPoolType(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	//Adjust the size of the prepared statements cache to match the latest configuration
 	stmtsLRU.Lock()

--- a/conn.go
+++ b/conn.go
@@ -79,7 +79,7 @@ type ConnConfig struct {
 	Compressor    Compressor
 	Authenticator Authenticator
 	Keepalive     time.Duration
-	TLSConfig     *tls.Config
+	tlsConfig     *tls.Config
 }
 
 // Conn is a single connection to a Cassandra node. It can be used to execute
@@ -113,10 +113,10 @@ func Connect(addr string, cfg ConnConfig, pool ConnectionPool) (*Conn, error) {
 		conn net.Conn
 	)
 
-	if cfg.TLSConfig != nil {
+	if cfg.tlsConfig != nil {
 		// the TLS config is safe to be reused by connections but it must not
 		// be modified after being used.
-		if conn, err = tls.Dial("tcp", addr, cfg.TLSConfig); err != nil {
+		if conn, err = tls.Dial("tcp", addr, cfg.tlsConfig); err != nil {
 			return nil, err
 		}
 	} else if conn, err = net.DialTimeout("tcp", addr, cfg.Timeout); err != nil {

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -206,7 +206,7 @@ func (c *SimplePool) connect(addr string) error {
 		Compressor:    c.cfg.Compressor,
 		Authenticator: c.cfg.Authenticator,
 		Keepalive:     c.cfg.SocketKeepalive,
-		TLSConfig:     c.tlsConfig,
+		tlsConfig:     c.tlsConfig,
 	}
 
 	conn, err := Connect(addr, cfg, c)

--- a/session_test.go
+++ b/session_test.go
@@ -9,7 +9,10 @@ import (
 func TestSessionAPI(t *testing.T) {
 
 	cfg := ClusterConfig{}
-	pool := NewSimplePool(&cfg)
+	pool, err := NewSimplePool(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	s := NewSession(pool, cfg)
 
@@ -60,7 +63,7 @@ func TestSessionAPI(t *testing.T) {
 
 	testBatch := s.NewBatch(LoggedBatch)
 	testBatch.Query("test")
-	err := s.ExecuteBatch(testBatch)
+	err = s.ExecuteBatch(testBatch)
 
 	if err != ErrNoConnections {
 		t.Fatalf("expected session.ExecuteBatch to return '%v', got '%v'", ErrNoConnections, err)
@@ -151,7 +154,10 @@ func TestBatchBasicAPI(t *testing.T) {
 
 	cfg := ClusterConfig{}
 	cfg.RetryPolicy = &SimpleRetryPolicy{NumRetries: 2}
-	pool := NewSimplePool(&cfg)
+	pool, err := NewSimplePool(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	s := NewSession(pool, cfg)
 	b := s.NewBatch(UnloggedBatch)


### PR DESCRIPTION
we can reuse the TLS Config between connections, so avoid the
expensive read and cert parsing when dialing connections, instead
do this in the connection pool once during startup.