### PR TITLE
Eagerly infer the last component of a column family

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -37,7 +37,6 @@ type TableMetadata struct {
 	PartitionKey      []*ColumnMetadata
 	ClusteringColumns []*ColumnMetadata
 	Columns           map[string]*ColumnMetadata
-	LastComponent     *ColumnMetadata
 }
 
 // schema metadata for a column
@@ -46,6 +45,7 @@ type ColumnMetadata struct {
 	Table          string
 	Name           string
 	ComponentIndex int
+	LastComponent  bool
 	Kind           string
 	Validator      string
 	Type           TypeInfo
@@ -192,14 +192,14 @@ func compileMetadata(
 }
 
 func indexLastComponent(t *TableMetadata) {
-	var reversed []*ColumnMetadata
 	if len(t.ClusteringColumns) > 0 {
-		reversed = reverseClone(t.ClusteringColumns)
-	} else {
-		reversed = reverseClone(t.PartitionKey)
+		clustered := reverseClone(t.ClusteringColumns)
+		lastClustered := clustered[0]
+		t.Columns[lastClustered.Name].LastComponent = true
 	}
-	lastComponent := reversed[0]
-	t.LastComponent = t.Columns[lastComponent.Name]
+	partitioned := reverseClone(t.PartitionKey)
+	lastParitioned := partitioned[0]
+	t.Columns[lastParitioned.Name].LastComponent = true
 }
 
 func reverseClone(cols []*ColumnMetadata) []*ColumnMetadata {

--- a/metadata.go
+++ b/metadata.go
@@ -187,19 +187,23 @@ func compileMetadata(
 	}
 
 	for i := range keyspace.Tables {
-		indexLastComponent(keyspace.Tables[i])
+		indexLastComponents(keyspace.Tables[i])
 	}
 }
 
-func indexLastComponent(t *TableMetadata) {
+func indexLastComponents(t *TableMetadata) {
 	if len(t.ClusteringColumns) > 0 {
-		clustered := reverseClone(t.ClusteringColumns)
-		lastClustered := clustered[0]
-		t.Columns[lastClustered.Name].LastComponent = true
+		col := lastComponentName(t.ClusteringColumns)
+		t.Columns[col].LastComponent = true
 	}
-	partitioned := reverseClone(t.PartitionKey)
-	lastParitioned := partitioned[0]
-	t.Columns[lastParitioned.Name].LastComponent = true
+	col := lastComponentName(t.PartitionKey)
+	t.Columns[col].LastComponent = true
+}
+
+func lastComponentName(cols []*ColumnMetadata) string {
+	reversed := reverseClone(cols)
+	last := reversed[0]
+	return last.Name
 }
 
 func reverseClone(cols []*ColumnMetadata) []*ColumnMetadata {

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -95,6 +95,9 @@ func TestCompileMetadata(t *testing.T) {
 							Type: TypeInfo{Type: TypeBlob},
 						},
 					},
+					LastComponent: &ColumnMetadata{
+						Name: "key",
+					},
 					ClusteringColumns: []*ColumnMetadata{},
 					Columns: map[string]*ColumnMetadata{
 						"key": &ColumnMetadata{
@@ -122,6 +125,9 @@ func TestCompileMetadata(t *testing.T) {
 							Type:  TypeInfo{Type: TypeInt},
 							Order: ASC,
 						},
+					},
+					LastComponent: &ColumnMetadata{
+						Name: "message_version",
 					},
 					Columns: map[string]*ColumnMetadata{
 						"target_id": &ColumnMetadata{
@@ -155,6 +161,9 @@ func TestCompileMetadata(t *testing.T) {
 							Type: TypeInfo{Type: TypeInet},
 						},
 					},
+					LastComponent: &ColumnMetadata{
+						Name: "peer",
+					},
 					ClusteringColumns: []*ColumnMetadata{},
 					Columns: map[string]*ColumnMetadata{
 						"peer": &ColumnMetadata{
@@ -184,6 +193,9 @@ func TestCompileMetadata(t *testing.T) {
 							Type:  TypeInfo{Type: TypeVarchar},
 							Order: ASC,
 						},
+					},
+					LastComponent: &ColumnMetadata{
+						Name: "index_name",
 					},
 					Columns: map[string]*ColumnMetadata{
 						"table_name": &ColumnMetadata{
@@ -216,6 +228,9 @@ func TestCompileMetadata(t *testing.T) {
 							Type:  TypeInfo{Type: TypeTimeUUID},
 							Order: ASC,
 						},
+					},
+					LastComponent: &ColumnMetadata{
+						Name: "revid",
 					},
 					Columns: map[string]*ColumnMetadata{
 						"title": &ColumnMetadata{
@@ -293,6 +308,9 @@ func TestCompileMetadata(t *testing.T) {
 						},
 					},
 					ClusteringColumns: []*ColumnMetadata{},
+					LastComponent: &ColumnMetadata{
+						Name: "Key1",
+					},
 					Columns: map[string]*ColumnMetadata{
 						"Key1": &ColumnMetadata{
 							Name: "Key1",
@@ -313,6 +331,9 @@ func TestCompileMetadata(t *testing.T) {
 							Name: "Column2",
 							Type: TypeInfo{Type: TypeVarchar},
 						},
+					},
+					LastComponent: &ColumnMetadata{
+						Name: "Column2",
 					},
 					Columns: map[string]*ColumnMetadata{
 						"Column1": &ColumnMetadata{
@@ -401,6 +422,10 @@ func assertKeyspaceMetadata(t *testing.T, actual, expected *KeyspaceMetadata) {
 						t.Errorf("Expected %s.Tables[%s].ClusteringColumns[%d].Kind to be '%v' but was '%v'", expected.Name, keyT, i, CLUSTERING_KEY, at.ClusteringColumns[i].Kind)
 					}
 				}
+			}
+
+			if et.LastComponent.Name != at.LastComponent.Name {
+				t.Errorf("Expected %s.Tables[%s].LastComponent.Name to be '%v' but was '%v'", expected.Name, keyT, et.LastComponent.Name, at.LastComponent.Name)
 			}
 			if len(et.Columns) != len(at.Columns) {
 				eKeys := make([]string, 0, len(et.Columns))

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -95,15 +95,13 @@ func TestCompileMetadata(t *testing.T) {
 							Type: TypeInfo{Type: TypeBlob},
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "key",
-					},
 					ClusteringColumns: []*ColumnMetadata{},
 					Columns: map[string]*ColumnMetadata{
 						"key": &ColumnMetadata{
-							Name: "key",
-							Type: TypeInfo{Type: TypeBlob},
-							Kind: PARTITION_KEY,
+							Name:          "key",
+							Type:          TypeInfo{Type: TypeBlob},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 					},
 				},
@@ -126,14 +124,12 @@ func TestCompileMetadata(t *testing.T) {
 							Order: ASC,
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "message_version",
-					},
 					Columns: map[string]*ColumnMetadata{
 						"target_id": &ColumnMetadata{
-							Name: "target_id",
-							Type: TypeInfo{Type: TypeUUID},
-							Kind: PARTITION_KEY,
+							Name:          "target_id",
+							Type:          TypeInfo{Type: TypeUUID},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 						"hint_id": &ColumnMetadata{
 							Name:  "hint_id",
@@ -142,10 +138,11 @@ func TestCompileMetadata(t *testing.T) {
 							Kind:  CLUSTERING_KEY,
 						},
 						"message_version": &ColumnMetadata{
-							Name:  "message_version",
-							Type:  TypeInfo{Type: TypeInt},
-							Order: ASC,
-							Kind:  CLUSTERING_KEY,
+							Name:          "message_version",
+							Type:          TypeInfo{Type: TypeInt},
+							Order:         ASC,
+							Kind:          CLUSTERING_KEY,
+							LastComponent: true,
 						},
 						"mutation": &ColumnMetadata{
 							Name: "mutation",
@@ -161,15 +158,13 @@ func TestCompileMetadata(t *testing.T) {
 							Type: TypeInfo{Type: TypeInet},
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "peer",
-					},
 					ClusteringColumns: []*ColumnMetadata{},
 					Columns: map[string]*ColumnMetadata{
 						"peer": &ColumnMetadata{
-							Name: "peer",
-							Type: TypeInfo{Type: TypeInet},
-							Kind: PARTITION_KEY,
+							Name:          "peer",
+							Type:          TypeInfo{Type: TypeInet},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 						"data_center":     &ColumnMetadata{Keyspace: "V1Keyspace", Table: "peers", Kind: REGULAR, Name: "data_center", ComponentIndex: 0, Validator: "org.apache.cassandra.db.marshal.UTF8Type", Type: TypeInfo{Type: TypeVarchar}},
 						"host_id":         &ColumnMetadata{Keyspace: "V1Keyspace", Table: "peers", Kind: REGULAR, Name: "host_id", ComponentIndex: 0, Validator: "org.apache.cassandra.db.marshal.UUIDType", Type: TypeInfo{Type: TypeUUID}},
@@ -194,19 +189,18 @@ func TestCompileMetadata(t *testing.T) {
 							Order: ASC,
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "index_name",
-					},
 					Columns: map[string]*ColumnMetadata{
 						"table_name": &ColumnMetadata{
-							Name: "table_name",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: PARTITION_KEY,
+							Name:          "table_name",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 						"index_name": &ColumnMetadata{
-							Name: "index_name",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: CLUSTERING_KEY,
+							Name:          "index_name",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          CLUSTERING_KEY,
+							LastComponent: true,
 						},
 						"value": &ColumnMetadata{
 							Name: "value",
@@ -229,19 +223,18 @@ func TestCompileMetadata(t *testing.T) {
 							Order: ASC,
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "revid",
-					},
 					Columns: map[string]*ColumnMetadata{
 						"title": &ColumnMetadata{
-							Name: "title",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: PARTITION_KEY,
+							Name:          "title",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 						"revid": &ColumnMetadata{
-							Name: "revid",
-							Type: TypeInfo{Type: TypeTimeUUID},
-							Kind: CLUSTERING_KEY,
+							Name:          "revid",
+							Type:          TypeInfo{Type: TypeTimeUUID},
+							Kind:          CLUSTERING_KEY,
+							LastComponent: true,
 						},
 					},
 				},
@@ -308,14 +301,12 @@ func TestCompileMetadata(t *testing.T) {
 						},
 					},
 					ClusteringColumns: []*ColumnMetadata{},
-					LastComponent: &ColumnMetadata{
-						Name: "Key1",
-					},
 					Columns: map[string]*ColumnMetadata{
 						"Key1": &ColumnMetadata{
-							Name: "Key1",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: PARTITION_KEY,
+							Name:          "Key1",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 					},
 				},
@@ -332,19 +323,18 @@ func TestCompileMetadata(t *testing.T) {
 							Type: TypeInfo{Type: TypeVarchar},
 						},
 					},
-					LastComponent: &ColumnMetadata{
-						Name: "Column2",
-					},
 					Columns: map[string]*ColumnMetadata{
 						"Column1": &ColumnMetadata{
-							Name: "Column1",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: PARTITION_KEY,
+							Name:          "Column1",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          PARTITION_KEY,
+							LastComponent: true,
 						},
 						"Column2": &ColumnMetadata{
-							Name: "Column2",
-							Type: TypeInfo{Type: TypeVarchar},
-							Kind: CLUSTERING_KEY,
+							Name:          "Column2",
+							Type:          TypeInfo{Type: TypeVarchar},
+							Kind:          CLUSTERING_KEY,
+							LastComponent: true,
 						},
 						"Column3": &ColumnMetadata{
 							Name: "Column3",
@@ -423,10 +413,6 @@ func assertKeyspaceMetadata(t *testing.T, actual, expected *KeyspaceMetadata) {
 					}
 				}
 			}
-
-			if et.LastComponent.Name != at.LastComponent.Name {
-				t.Errorf("Expected %s.Tables[%s].LastComponent.Name to be '%v' but was '%v'", expected.Name, keyT, et.LastComponent.Name, at.LastComponent.Name)
-			}
 			if len(et.Columns) != len(at.Columns) {
 				eKeys := make([]string, 0, len(et.Columns))
 				for key := range et.Columns {
@@ -462,6 +448,9 @@ func assertKeyspaceMetadata(t *testing.T, actual, expected *KeyspaceMetadata) {
 						}
 						if ec.Kind != ac.Kind {
 							t.Errorf("Expected %s.Tables[%s].Columns[%s].Kind to be '%v' but was '%v'", expected.Name, keyT, keyC, ec.Kind, ac.Kind)
+						}
+						if ec.LastComponent != ac.LastComponent {
+							t.Errorf("Expected %s.Tables[%s].Columns[%s].LastComponent to be '%v' but was '%v'", expected.Name, keyT, keyC, ec.LastComponent, ac.LastComponent)
 						}
 					}
 				}


### PR DESCRIPTION
This patch adds some more metadata to the schema at compile time. The motivation behind this is to be able to infer the relative position of a column that forms either part of the partition key or clustering key. This can already be achieved using the current API, but that information needs to be computed on a per-column basis multiple times if this processing takes place in a client application. By moving this inference into the compilation phase, this computation is only done once. It also makes the metadata API richer.