### PR TITLE
refactor all framing protocol code into frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Project Website: http://gocql.github.io/<br>
 API documentation: http://godoc.org/github.com/gocql/gocql<br>
 Discussions: https://groups.google.com/forum/#!forum/gocql
 
+Production Stability
+---------
+The underlying framing code was rewritten as part of #339 and as such may have
+unforseen bugs. If you run into a bug related to wire framing, please raise a ticket and we will try to resolve this as soon as we can. If you require a stable version to pin your production app against, we have tagged the previous stable version in source code, so you can build against this. The tag is called 1st_gen_framing (180456fef0a3c6d02c51dc7211f49b55e9315867). This note will be removed as the new generation framing code base matures
+
 Supported Versions
 ------------------
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -86,11 +86,13 @@ func createCluster() *ClusterConfig {
 }
 
 func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
+	log.Println("CREATE KEYSPACE", keyspace)
 	session, err := cluster.CreateSession()
 	if err != nil {
 		tb.Fatal("createSession:", err)
 	}
-	if err = session.Query(`DROP KEYSPACE ` + keyspace).Exec(); err != nil {
+	defer session.Close()
+	if err = session.Query(`DROP KEYSPACE IF EXISTS ` + keyspace).Exec(); err != nil {
 		tb.Log("drop keyspace:", err)
 	}
 	if err := session.Query(fmt.Sprintf(`CREATE KEYSPACE %s
@@ -101,7 +103,6 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
 		tb.Fatalf("error creating keyspace %s: %v", keyspace, err)
 	}
 	tb.Logf("Created keyspace %s", keyspace)
-	session.Close()
 }
 
 func createSession(tb testing.TB) *Session {
@@ -973,16 +974,19 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 	stmtsLRU.Lock()
 	stmtsLRU.lru.Add(conn.addr+stmt, flight)
 	stmtsLRU.Unlock()
-	flight.info = &QueryInfo{
-		Id: []byte{'f', 'o', 'o', 'b', 'a', 'r'},
-		Args: []ColumnInfo{ColumnInfo{
-			Keyspace: "gocql_test",
-			Table:    table,
-			Name:     "foo",
-			TypeInfo: &TypeInfo{
-				Type: TypeVarchar,
-			},
-		}},
+	flight.info = &resultPreparedFrame{
+		preparedID: []byte{'f', 'o', 'o', 'b', 'a', 'r'},
+		reqMeta: resultMetadata{
+			columns: []ColumnInfo{
+				{
+					Keyspace: "gocql_test",
+					Table:    table,
+					Name:     "foo",
+					TypeInfo: &TypeInfo{
+						Type: TypeVarchar,
+					},
+				},
+			}},
 	}
 	return stmt, conn
 }
@@ -1045,13 +1049,13 @@ func TestQueryInfo(t *testing.T) {
 		t.Fatalf("Failed to execute query for preparing statement: %v", err)
 	}
 
-	if len(info.Args) != 1 {
-		t.Fatalf("Was not expecting meta data for %d query arguments, but got %d\n", 1, len(info.Args))
+	if len(info.reqMeta.columns) != 1 {
+		t.Fatalf("Was not expecting meta data for %d query arguments, but got %d\n", 1, len(info.reqMeta.columns))
 	}
 
 	if *flagProto > 1 {
-		if len(info.Rval) != 2 {
-			t.Fatalf("Was not expecting meta data for %d result columns, but got %d\n", 2, len(info.Rval))
+		if len(info.respMeta.columns) != 2 {
+			t.Fatalf("Was not expecting meta data for %d result columns, but got %d\n", 2, len(info.respMeta.columns))
 		}
 	}
 }

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -86,7 +86,6 @@ func createCluster() *ClusterConfig {
 }
 
 func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
-	log.Println("CREATE KEYSPACE", keyspace)
 	session, err := cluster.CreateSession()
 	if err != nil {
 		tb.Fatal("createSession:", err)

--- a/conn.go
+++ b/conn.go
@@ -255,12 +255,12 @@ func (c *Conn) authenticateHandshake(authFrame *authenticateFrame) error {
 		switch v := frame.(type) {
 		case error:
 			return v
-		case authSuccessFrame:
+		case *authSuccessFrame:
 			if challenger != nil {
 				return challenger.Success(v.data)
 			}
 			return nil
-		case authChallengeFrame:
+		case *authChallengeFrame:
 			resp, challenger, err = challenger.Challenge(v.data)
 			if err != nil {
 				return err

--- a/conn.go
+++ b/conn.go
@@ -336,8 +336,6 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	}
 
 	// resp is basically a waiting semaphore protecting the framer
-
-	// log.Printf("%v: OUT stream=%d (%T) req=%v\n", c.conn.LocalAddr(), stream, req, req)
 	framer := newFramer(c, c, c.compressor, c.version)
 	defer framerPool.Put(framer)
 
@@ -348,7 +346,7 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	}
 
 	// there is a race that we can read and write to the same buffer, I dont think
-	// the data will actually corrupt but to be safe and apepase the race detector gods,
+	// the data will actually corrupt but to be safe and appease the race detector gods,
 	// guard it.
 	// We could fix this by using seperate read and write buffers, which may end up
 	// being faster and easier to reason about.
@@ -376,7 +374,6 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	if len(framer.traceID) > 0 {
 		tracer.Trace(framer.traceID)
 	}
-	// log.Printf("%v: IN stream=%d (%T) resp=%v\n", c.conn.LocalAddr(), stream, frame, frame)
 
 	return frame, nil
 }
@@ -414,7 +411,6 @@ func (c *Conn) prepareStatement(stmt string, trace Tracer) (*resultPreparedFrame
 
 	switch x := resp.(type) {
 	case *resultPreparedFrame:
-		// log.Printf("prepared %q => %x\n", stmt, x.preparedID)
 		flight.info = x
 	case error:
 		flight.err = x
@@ -444,7 +440,6 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 	if qry.pageSize > 0 {
 		params.pageSize = qry.pageSize
 	}
-	// log.Printf("%+#v\n", qry)
 
 	var frame frameWriter
 	if qry.shouldPrepare() {
@@ -502,8 +497,6 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 		return &Iter{err: err}
 	}
 
-	// log.Printf("resp=%T\n", resp)
-
 	switch x := resp.(type) {
 	case *resultVoidFrame:
 		return &Iter{}
@@ -513,7 +506,6 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 			rows:    x.rows,
 		}
 
-		// log.Printf("result meta=%v\n", x.meta)
 		if len(x.meta.pagingState) > 0 {
 			iter.next = &nextIter{
 				qry: *qry,

--- a/conn.go
+++ b/conn.go
@@ -263,6 +263,8 @@ func (c *Conn) authenticateHandshake(authFrame *authenticateFrame) error {
 			req = &writeAuthResponseFrame{
 				data: resp,
 			}
+		default:
+			return fmt.Errorf("unknown frame response during authentication: %v", v)
 		}
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -518,7 +518,6 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 			return c.executeQuery(qry)
 		}
 		stmtsLRU.Unlock()
-		panic(x)
 		return &Iter{err: x}
 	case error:
 		return &Iter{err: x}

--- a/conn.go
+++ b/conn.go
@@ -18,12 +18,6 @@ import (
 	"time"
 )
 
-const (
-	defaultFrameSize = 4096
-	flagResponse     = 0x80
-	maskVersion      = 0x7F
-)
-
 //JoinHostPort is a utility to return a address string that can be used
 //gocql.Conn to form a connection with a host.
 func JoinHostPort(addr string, port int) string {

--- a/conn.go
+++ b/conn.go
@@ -270,7 +270,6 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	}
 
 	resp := <-call.resp
-	call.resp = nil
 	if resp.err != nil {
 		return nil, resp.err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -438,13 +438,14 @@ func NewSSLTestServer(t testing.TB, protocol uint8) *TestServer {
 }
 
 type TestServer struct {
-	Address  string
-	t        testing.TB
-	nreq     uint64
-	listen   net.Listener
-	nKillReq int64
+	Address    string
+	t          testing.TB
+	nreq       uint64
+	listen     net.Listener
+	nKillReq   int64
+	compressor Compressor
 
-	protocol   uint8
+	protocol   byte
 	headerSize int
 }
 
@@ -458,16 +459,19 @@ func (srv *TestServer) serve() {
 		go func(conn net.Conn) {
 			defer conn.Close()
 			for {
-				frame, err := srv.readFrame(conn)
-				if err == io.EOF {
-					return
-				} else if err != nil {
+				framer, err := srv.readFrame(conn)
+				if err != nil {
+					if err == io.EOF {
+						return
+					}
+
 					srv.t.Error(err)
-					continue
+					return
 				}
 
 				atomic.AddUint64(&srv.nreq, 1)
-				go srv.process(frame, conn)
+
+				go srv.process(framer)
 			}
 		}(conn)
 	}
@@ -477,24 +481,21 @@ func (srv *TestServer) Stop() {
 	srv.listen.Close()
 }
 
-func (srv *TestServer) process(f frame, conn net.Conn) {
-	headerSize := headerProtoSize[srv.protocol]
-	stream := f.Stream(srv.protocol)
+func (srv *TestServer) process(f *framer) {
+	head := f.header
+	if head == nil {
+		srv.t.Error("process frame with a nil header")
+		return
+	}
 
-	switch f.Op(srv.protocol) {
+	switch head.op {
 	case opStartup:
-		f = f[:headerSize]
-		f.setHeader(protoDirectionMask|srv.protocol, 0, stream, opReady)
+		f.writeHeader(0, opReady, head.stream)
 	case opOptions:
-		f = f[:headerSize]
-		f.setHeader(protoDirectionMask|srv.protocol, 0, stream, opSupported)
+		f.writeHeader(0, opSupported, head.stream)
 		f.writeShort(0)
 	case opQuery:
-		input := f
-		input.skipHeader(srv.protocol)
-		query := strings.TrimSpace(input.readLongString())
-		f = f[:headerSize]
-		f.setHeader(protoDirectionMask|srv.protocol, 0, stream, opResult)
+		query := f.readLongString()
 		first := query
 		if n := strings.Index(query, " "); n > 0 {
 			first = first[:n]
@@ -502,62 +503,63 @@ func (srv *TestServer) process(f frame, conn net.Conn) {
 		switch strings.ToLower(first) {
 		case "kill":
 			atomic.AddInt64(&srv.nKillReq, 1)
-			f = f[:headerSize]
-			f.setHeader(protoDirectionMask|srv.protocol, 0, stream, opError)
+			f.writeHeader(0, opError, head.stream)
 			f.writeInt(0x1001)
 			f.writeString("query killed")
 		case "slow":
 			go func() {
 				<-time.After(1 * time.Second)
+				f.writeHeader(0, opResult, head.stream)
+				f.buf[0] = srv.protocol | 0x80
 				f.writeInt(resultKindVoid)
-				f.setLength(len(f)-headerSize, srv.protocol)
-				if _, err := conn.Write(f); err != nil {
-					return
+				if err := f.finishWrite(); err != nil {
+					srv.t.Error(err)
 				}
 			}()
+
 			return
 		case "use":
-			f.writeInt(3)
+			f.writeInt(resultKindKeyspace)
 			f.writeString(strings.TrimSpace(query[3:]))
 		case "void":
+			f.writeHeader(0, opResult, head.stream)
 			f.writeInt(resultKindVoid)
 		default:
+			f.writeHeader(0, opResult, head.stream)
 			f.writeInt(resultKindVoid)
 		}
 	default:
-		f = f[:headerSize]
-		f.setHeader(protoDirectionMask|srv.protocol, 0, stream, opError)
+		f.writeHeader(0, opError, head.stream)
 		f.writeInt(0)
 		f.writeString("not supported")
 	}
 
-	f.setLength(len(f)-headerSize, srv.protocol)
-	if _, err := conn.Write(f); err != nil {
-		srv.t.Log(err)
-		return
+	f.buf[0] = srv.protocol | 0x80
+
+	if err := f.finishWrite(); err != nil {
+		srv.t.Error(err)
 	}
 }
 
-func (srv *TestServer) readFrame(conn net.Conn) (frame, error) {
-	frame := make(frame, srv.headerSize, srv.headerSize+512)
-	if _, err := io.ReadFull(conn, frame); err != nil {
+func (srv *TestServer) readFrame(conn net.Conn) (*framer, error) {
+	buf := make([]byte, srv.headerSize)
+	head, err := readHeader(conn, buf)
+	if err != nil {
+		return nil, err
+	}
+	framer := newFramer(conn, conn, nil, srv.protocol)
+
+	err = framer.readFrame(&head)
+	if err != nil {
 		return nil, err
 	}
 
 	// should be a request frame
-	if frame[0]&protoDirectionMask != 0 {
-		return nil, fmt.Errorf("expected to read a request frame got version: 0x%x", frame[0])
-	}
-	if v := frame[0] & protoVersionMask; v != srv.protocol {
-		return nil, fmt.Errorf("expected to read protocol version 0x%x got 0x%x", srv.protocol, v)
-	}
-
-	if n := frame.Length(srv.protocol); n > 0 {
-		frame.grow(n)
-		if _, err := io.ReadFull(conn, frame[srv.headerSize:]); err != nil {
-			return nil, err
-		}
+	if head.version.response() {
+		return nil, fmt.Errorf("expected to read a request frame got version: %v", head.version)
+	} else if head.version.version() != srv.protocol {
+		return nil, fmt.Errorf("expected to read protocol version 0x%x got 0x%x", srv.protocol, head.version.version())
 	}
 
-	return frame, nil
+	return framer, nil
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -510,7 +510,7 @@ func (srv *TestServer) process(f *framer) {
 			go func() {
 				<-time.After(1 * time.Second)
 				f.writeHeader(0, opResult, head.stream)
-				f.buf[0] = srv.protocol | 0x80
+				f.wbuf[0] = srv.protocol | 0x80
 				f.writeInt(resultKindVoid)
 				if err := f.finishWrite(); err != nil {
 					srv.t.Error(err)
@@ -534,7 +534,7 @@ func (srv *TestServer) process(f *framer) {
 		f.writeString("not supported")
 	}
 
-	f.buf[0] = srv.protocol | 0x80
+	f.wbuf[0] = srv.protocol | 0x80
 
 	if err := f.finishWrite(); err != nil {
 		srv.t.Error(err)

--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,7 @@
 package gocql
 
+import "fmt"
+
 const (
 	errServer        = 0x0000
 	errProtocol      = 0x000A
@@ -25,6 +27,8 @@ type RequestError interface {
 }
 
 type errorFrame struct {
+	frameHeader
+
 	code    int
 	message string
 }
@@ -41,11 +45,19 @@ func (e errorFrame) Error() string {
 	return e.Message()
 }
 
+func (e errorFrame) String() string {
+	return fmt.Sprintf("[error code=%x message=%q]", e.code, e.message)
+}
+
 type RequestErrUnavailable struct {
 	errorFrame
 	Consistency Consistency
 	Required    int
 	Alive       int
+}
+
+func (e *RequestErrUnavailable) String() string {
+	return fmt.Sprintf("[request_error_unavailable consistency=%s required=%d alive=%d]", e.Consistency, e.Required, e.Alive)
 }
 
 type RequestErrWriteTimeout struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -18,7 +18,7 @@ func TestErrorsParse(t *testing.T) {
 		t.Fatal("Should have gotten already exists error from cassandra server.")
 	} else {
 		switch e := err.(type) {
-		case RequestErrAlreadyExists:
+		case *RequestErrAlreadyExists:
 			if e.Table != "errors_parse" {
 				t.Fatal("Failed to parse error response from cassandra for ErrAlreadyExists.")
 			}

--- a/frame.go
+++ b/frame.go
@@ -18,9 +18,6 @@ const (
 	protoVersion1      = 0x01
 	protoVersion2      = 0x02
 	protoVersion3      = 0x03
-
-	protoVersionRequest  = 0x00
-	protoVersionResponse = 0x80
 )
 
 type protoVersion byte
@@ -1317,18 +1314,4 @@ func (f *framer) writeStringMap(m map[string]string) {
 		f.writeString(k)
 		f.writeString(v)
 	}
-}
-
-var consistencyCodes = []uint16{
-	Any:         0x0000,
-	One:         0x0001,
-	Two:         0x0002,
-	Three:       0x0003,
-	Quorum:      0x0004,
-	All:         0x0005,
-	LocalQuorum: 0x0006,
-	EachQuorum:  0x0007,
-	Serial:      0x0008,
-	LocalSerial: 0x0009,
-	LocalOne:    0x000A,
 }

--- a/frame.go
+++ b/frame.go
@@ -219,10 +219,12 @@ func (f frameHeader) Header() frameHeader {
 	return f
 }
 
+const defaultBufSize = 128
+
 var framerPool = sync.Pool{
 	New: func() interface{} {
 		return &framer{
-			buf: make([]byte, 0, 4096),
+			buf: make([]byte, defaultBufSize),
 		}
 	},
 }
@@ -367,7 +369,7 @@ func (f *framer) parseFrame() (frame, error) {
 		return nil, NewErrProtocol("unknown op in frame header: %s", f.header.op)
 	}
 
-	f.buf = make([]byte, 1024)
+	f.buf = make([]byte, defaultBufSize)
 
 	return frame, err
 }

--- a/frame.go
+++ b/frame.go
@@ -365,6 +365,10 @@ func (f *framer) parseFrame() (frame, error) {
 		frame = f.parseSupportedFrame()
 	case opAuthenticate:
 		frame = f.parseAuthenticateFrame()
+	case opAuthChallenge:
+		frame = f.parseAuthChallengeFrame()
+	case opAuthSuccess:
+		frame = f.parseAuthSuccessFrame()
 	default:
 		return nil, NewErrProtocol("unknown op in frame header: %s", f.header.op)
 	}

--- a/frame.go
+++ b/frame.go
@@ -253,6 +253,8 @@ func newFramer(r io.Reader, w io.Writer, compressor Compressor, version byte) *f
 		flags |= flagCompress
 	}
 
+	version &= protoVersionMask
+
 	headSize := 8
 	if version > protoVersion2 {
 		headSize = 9

--- a/frame.go
+++ b/frame.go
@@ -130,14 +130,8 @@ const (
 	flagWithNameValues             = 0x40
 
 	// header flags
-	flagCompression byte = 0x01
-	flagTracing          = 0x02
-
-	flagQueryValues byte = 1
-	flagCompress         = 1
-	flagTrace            = 2
-	flagPageState        = 8
-	flagHasMore          = 2
+	flagCompress byte = 0x01
+	flagTracing       = 0x02
 )
 
 type Consistency uint16
@@ -865,7 +859,7 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 
 	var flags byte
 	if len(opts.values) > 0 {
-		flags |= flagQueryValues
+		flags |= flagValues
 	}
 	if opts.skipMeta {
 		flags |= flagSkipMetaData
@@ -874,7 +868,7 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 		flags |= flagPageSize
 	}
 	if len(opts.pagingState) > 0 {
-		flags |= flagPageState
+		flags |= flagWithPagingState
 	}
 	if opts.serialConsistency > 0 {
 		flags |= flagWithSerialConsistency

--- a/frame.go
+++ b/frame.go
@@ -301,6 +301,11 @@ func readHeader(r io.Reader, p []byte) (frameHeader, error) {
 	return head, nil
 }
 
+// explicitly enables tracing for the framers outgoing requests
+func (f *framer) trace() {
+	f.flags |= flagTracing
+}
+
 // reads a frame form the wire into the framers buffer
 func (f *framer) readFrame(head *frameHeader) error {
 	// assume the underlying reader takes care of timeouts and retries

--- a/frame.go
+++ b/frame.go
@@ -175,7 +175,7 @@ func (c Consistency) String() string {
 	case LocalOne:
 		return "LOCAL_ONE"
 	default:
-		return fmt.Sprintf("UNKNOWN_CONS_0x%x", c)
+		return fmt.Sprintf("UNKNOWN_CONS_0x%x", uint16(c))
 	}
 }
 

--- a/frame.go
+++ b/frame.go
@@ -479,7 +479,6 @@ func (f *framer) setLength(length int) {
 }
 
 func (f *framer) finishWrite() error {
-	length := len(f.buf) - f.headSize
 	if f.buf[1]&flagCompress == flagCompress {
 		if f.compres == nil {
 			panic("compress flag set with no compressor")
@@ -491,10 +490,9 @@ func (f *framer) finishWrite() error {
 			return err
 		}
 
-		// assuming that len(compressed) < len(f.buf)
-		length = copy(f.buf[f.headSize:], compressed)
-		f.buf = f.buf[:f.headSize+length]
+		f.buf = append(f.buf[:f.headSize], compressed...)
 	}
+	length := len(f.buf) - f.headSize
 	f.setLength(length)
 
 	_, err := f.w.Write(f.buf)

--- a/frame.go
+++ b/frame.go
@@ -811,6 +811,10 @@ type authenticateFrame struct {
 	class string
 }
 
+func (a *authenticateFrame) String() string {
+	return fmt.Sprintf("[authenticate class=%q]", a.class)
+}
+
 func (f *framer) parseAuthenticateFrame() frame {
 	return &authenticateFrame{
 		frameHeader: *f.header,
@@ -824,6 +828,10 @@ type authSuccessFrame struct {
 	data []byte
 }
 
+func (a *authSuccessFrame) String() string {
+	return fmt.Sprintf("[auth_success data=%q]", a.data)
+}
+
 func (f *framer) parseAuthSuccessFrame() frame {
 	return &authSuccessFrame{
 		frameHeader: *f.header,
@@ -835,6 +843,10 @@ type authChallengeFrame struct {
 	frameHeader
 
 	data []byte
+}
+
+func (a *authChallengeFrame) String() string {
+	return fmt.Sprintf("[auth_challenge data=%q]", a.data)
 }
 
 func (f *framer) parseAuthChallengeFrame() frame {

--- a/frame.go
+++ b/frame.go
@@ -484,7 +484,6 @@ func (f *framer) finishWrite() error {
 	f.setLength(length)
 
 	_, err := f.w.Write(f.buf)
-	// log.Printf("OUT wrote=%d header=% X\n", n, f.buf[:f.headSize])
 
 	f.buf = f.buf[:0]
 	if err != nil {
@@ -633,7 +632,6 @@ func (f *framer) parseResultMetadata() resultMetadata {
 		table = f.readString()
 	}
 
-	// log.Printf("flags=% X keyspace=%s table=%s\n", meta.flags, keyspace, table)
 	cols := make([]ColumnInfo, colCount)
 
 	for i := 0; i < colCount; i++ {
@@ -691,12 +689,11 @@ type resultRowsFrame struct {
 }
 
 func (f *resultRowsFrame) String() string {
-	return "[result_rows]"
+	return fmt.Sprintf("[result_rows meta=%v]", f.meta)
 }
 
 func (f *framer) parseResultRows() frame {
 	meta := f.parseResultMetadata()
-	// log.Printf("parsed meta=%v\n", meta)
 
 	numRows := f.readInt()
 	colCount := len(meta.columns)

--- a/marshal.go
+++ b/marshal.go
@@ -1176,24 +1176,24 @@ type Type int
 
 const (
 	TypeCustom    Type = 0x0000
-	TypeAscii     Type = 0x0001
-	TypeBigInt    Type = 0x0002
-	TypeBlob      Type = 0x0003
-	TypeBoolean   Type = 0x0004
-	TypeCounter   Type = 0x0005
-	TypeDecimal   Type = 0x0006
-	TypeDouble    Type = 0x0007
-	TypeFloat     Type = 0x0008
-	TypeInt       Type = 0x0009
-	TypeTimestamp Type = 0x000B
-	TypeUUID      Type = 0x000C
-	TypeVarchar   Type = 0x000D
-	TypeVarint    Type = 0x000E
-	TypeTimeUUID  Type = 0x000F
-	TypeInet      Type = 0x0010
-	TypeList      Type = 0x0020
-	TypeMap       Type = 0x0021
-	TypeSet       Type = 0x0022
+	TypeAscii          = 0x0001
+	TypeBigInt         = 0x0002
+	TypeBlob           = 0x0003
+	TypeBoolean        = 0x0004
+	TypeCounter        = 0x0005
+	TypeDecimal        = 0x0006
+	TypeDouble         = 0x0007
+	TypeFloat          = 0x0008
+	TypeInt            = 0x0009
+	TypeTimestamp      = 0x000B
+	TypeUUID           = 0x000C
+	TypeVarchar        = 0x000D
+	TypeVarint         = 0x000E
+	TypeTimeUUID       = 0x000F
+	TypeInet           = 0x0010
+	TypeList           = 0x0020
+	TypeMap            = 0x0021
+	TypeSet            = 0x0022
 )
 
 // String returns the name of the identifier.
@@ -1238,7 +1238,7 @@ func (t Type) String() string {
 	case TypeVarint:
 		return "varint"
 	default:
-		return "unknown"
+		return fmt.Sprintf("unkown_type_%d", t)
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -368,9 +368,6 @@ type Query struct {
 	binding      func(q *QueryInfo) ([]interface{}, error)
 	attempts     int
 	totalLatency int64
-
-	// v3+ send client timestamp in query
-	sendTimestamp bool
 }
 
 //Attempts returns the number of times the query was executed.
@@ -513,13 +510,6 @@ func (q *Query) RetryPolicy(r RetryPolicy) *Query {
 // to an existing query instance.
 func (q *Query) Bind(v ...interface{}) *Query {
 	q.values = v
-	return q
-}
-
-// SendTimestamp will send the current time on the client when sending the query
-// on protocol3 and above. This allows
-func (q *Query) SendTimestamp(b bool) *Query {
-	q.sendTimestamp = b
 	return q
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -222,18 +222,17 @@ func TestBatchBasicAPI(t *testing.T) {
 
 func TestConsistencyNames(t *testing.T) {
 	names := map[Consistency]string{
-		0:           "default",
-		Any:         "any",
-		One:         "one",
-		Two:         "two",
-		Three:       "three",
-		Quorum:      "quorum",
-		All:         "all",
-		LocalQuorum: "localquorum",
-		EachQuorum:  "eachquorum",
-		Serial:      "serial",
-		LocalSerial: "localserial",
-		LocalOne:    "localone",
+		Any:         "ANY",
+		One:         "ONE",
+		Two:         "TWO",
+		Three:       "THREE",
+		Quorum:      "QUORUM",
+		All:         "ALL",
+		LocalQuorum: "LOCAL_QUORUM",
+		EachQuorum:  "EACH_QUORUM",
+		Serial:      "SERIAL",
+		LocalSerial: "LOCAL_SERIAL",
+		LocalOne:    "LOCAL_ONE",
 	}
 
 	for k, v := range names {


### PR DESCRIPTION
Simplify the protocol implementation so that all the logic for handling different protocol versions is now handled inside frame.go. This should make it easier to improve and change the protocols going forward without having to make lots of changes elsewhere.