### PR TITLE
Simplify cluster config

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -6,12 +6,30 @@ function run_tests() {
 	local clusterSize=3
 	local version=$1
 
+	local keypath="$(pwd)/testdata/pki"
+
+	local conf=(
+	    "client_encryption_options.enabled: true"
+	    "client_encryption_options.keystore: $keypath/.keystore"
+	    "client_encryption_options.keystore_password: cassandra"
+	    "client_encryption_options.require_client_auth: true"
+	    "client_encryption_options.truststore: $keypath/.truststore"
+	    "client_encryption_options.truststore_password: cassandra"
+	    "concurrent_reads: 2"
+	    "concurrent_writes: 2"
+	    "rpc_server_type: sync"
+	    "rpc_min_threads: 2"
+	    "rpc_max_threads: 2"
+	    "write_request_timeout_in_ms: 5000"
+	    "read_request_timeout_in_ms: 5000"
+	)
+
 	ccm create test -v binary:$version -n $clusterSize -d --vnodes
+    ccm updateconf "${conf[@]}"
 
 	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="256M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
 
-	ccm updateconf 'client_encryption_options.enabled: true' 'client_encryption_options.keystore: testdata/pki/.keystore' 'client_encryption_options.keystore_password: cassandra' 'client_encryption_options.require_client_auth: true' 'client_encryption_options.truststore: testdata/pki/.truststore' 'client_encryption_options.truststore_password: cassandra' 'concurrent_reads: 2' 'concurrent_writes: 2' 'rpc_server_type: sync' 'rpc_min_threads: 2' 'rpc_max_threads: 2' 'write_request_timeout_in_ms: 5000' 'read_request_timeout_in_ms: 5000'
 	ccm start -v
 	ccm status
 	ccm node1 nodetool status


### PR DESCRIPTION
Simplify how the cluster config is setup using ccm.

Pass an absolute path for the keystore, fixes #345