### PR TITLE
Enhancements to integration.sh for ease-of-use in development

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -24,11 +24,10 @@ function run_tests() {
 	    "read_request_timeout_in_ms: 5000"
 	)
 
-	ccm create test -v binary:$version -n $clusterSize -d --vnodes
-    ccm updateconf "${conf[@]}"
+	ccm remove test || true
 
-	sed -i '/#MAX_HEAP_SIZE/c\MAX_HEAP_SIZE="256M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
-	sed -i '/#HEAP_NEWSIZE/c\HEAP_NEWSIZE="100M"' ~/.ccm/repository/$version/conf/cassandra-env.sh
+	ccm create test -v binary:$version -n $clusterSize -d --vnodes --jvm_arg="-Xmx256m -XX:NewSize=100m"
+    ccm updateconf "${conf[@]}"
 
 	ccm start -v
 	ccm status
@@ -59,7 +58,7 @@ function run_tests() {
 		echo "--- FAIL: expected coverage of at least 60 %, but coverage was $cover %"
 		exit 1
 	fi
-	ccm clear
+	ccm remove
 }
 
 run_tests $1


### PR DESCRIPTION
I've found that while testing changes locally that these changes simplify running integration.sh.

- Replaced the sed commands with usage of the --jvm_arg parameter of 'ccm create' for GC tuning
- Added 'ccm remove test' command as an optional step to remove the previous test cluster if it
already exists
- Changed the 'ccm clear' command to 'ccm remove'

YMMV, and I understand this is for travis builds too testing so not sure if they're the best generic changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gocql/gocql/349)
<!-- Reviewable:end -->
