### PR TITLE
Always set the number of values in a batch

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -1087,11 +1087,11 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame) error {
 		if len(b.preparedID) == 0 {
 			f.writeByte(0)
 			f.writeLongString(b.statement)
-			continue
+		} else {
+			f.writeByte(1)
+			f.writeShortBytes(b.preparedID)
 		}
 
-		f.writeByte(1)
-		f.writeShortBytes(b.preparedID)
 		f.writeShort(uint16(len(b.values)))
 		for j := range b.values {
 			col := &b.values[j]


### PR DESCRIPTION
A batch must always set the number of values even if the statement
is not prepraed and has no values, such is the case when using
counters.

Fixes #364