### PR TITLE
Add support for UDT's

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -612,6 +612,22 @@ func (f *framer) readTypeInfo() TypeInfo {
 
 		return tuple
 
+	case TypeUDT:
+		udt := UDTTypeInfo{
+			NativeType: simple,
+		}
+		udt.KeySpace = f.readString()
+		udt.Name = f.readString()
+
+		n := f.readShort()
+		udt.Elements = make([]UDTField, n)
+		for i := 0; i < int(n); i++ {
+			field := &udt.Elements[i]
+			field.Name = f.readString()
+			field.Type = f.readTypeInfo()
+		}
+
+		return udt
 	case TypeMap, TypeList, TypeSet:
 		collection := CollectionType{
 			NativeType: simple,

--- a/marshal.go
+++ b/marshal.go
@@ -1225,6 +1225,8 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 	udt := info.(UDTTypeInfo)
 
 	switch v := value.(type) {
+	case Marshaler:
+		return v.MarshalCQL(info)
 	case UDTMarshaler:
 		var buf []byte
 		for _, e := range udt.Elements {

--- a/session.go
+++ b/session.go
@@ -660,8 +660,8 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 			continue
 		}
 
-		// how can we allow users to pass in a single struct to unmarshal into
-		if col.TypeInfo.Type() == TypeTuple {
+		switch col.TypeInfo.Type() {
+		case TypeTuple:
 			// this will panic, actually a bug, please report
 			tuple := col.TypeInfo.(TupleTypeInfo)
 
@@ -669,18 +669,15 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 			// here we pass in a slice of the struct which has the number number of
 			// values as elements in the tuple
 			iter.err = Unmarshal(col.TypeInfo, iter.rows[iter.pos][c], dest[i:i+count])
-			if iter.err != nil {
-				return false
-			}
 			i += count
-			continue
+		default:
+			iter.err = Unmarshal(col.TypeInfo, iter.rows[iter.pos][c], dest[i])
+			i++
 		}
 
-		iter.err = Unmarshal(col.TypeInfo, iter.rows[iter.pos][c], dest[i])
 		if iter.err != nil {
 			return false
 		}
-		i++
 	}
 
 	iter.pos++

--- a/udt_test.go
+++ b/udt_test.go
@@ -8,35 +8,35 @@ import (
 )
 
 type position struct {
-	lat int
-	lon int
+	Lat int
+	Lon int
 }
 
 // NOTE: due to current implementation details it is not currently possible to use
 // a pointer receiver type for the UDTMarshaler interface to handle UDT's
-func (p position) EncodeUDTField(name string, info TypeInfo) ([]byte, error) {
+func (p position) MarshalUDT(name string, info TypeInfo) ([]byte, error) {
 	switch name {
 	case "lat":
-		return Marshal(info, p.lat)
+		return Marshal(info, p.Lat)
 	case "lon":
-		return Marshal(info, p.lon)
+		return Marshal(info, p.Lon)
 	default:
 		return nil, fmt.Errorf("unknown column for position: %q", name)
 	}
 }
 
-func (p *position) DecodeUDTField(name string, info TypeInfo, data []byte) error {
+func (p *position) UnmarshalUDT(name string, info TypeInfo, data []byte) error {
 	switch name {
 	case "lat":
-		return Unmarshal(info, data, &p.lat)
+		return Unmarshal(info, data, &p.Lat)
 	case "lon":
-		return Unmarshal(info, data, &p.lon)
+		return Unmarshal(info, data, &p.Lon)
 	default:
 		return fmt.Errorf("unknown column for position: %q", name)
 	}
 }
 
-func TestUDT(t *testing.T) {
+func TestUDT_Marshaler(t *testing.T) {
 	if *flagProto < protoVersion3 {
 		t.Skip("UDT are only available on protocol >= 3")
 	}
@@ -79,10 +79,10 @@ func TestUDT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pos.lat != expLat {
-		t.Errorf("expeceted lat to be be %d got %d", expLat, pos.lat)
+	if pos.Lat != expLat {
+		t.Errorf("expeceted lat to be be %d got %d", expLat, pos.Lat)
 	}
-	if pos.lon != expLon {
-		t.Errorf("expeceted lon to be be %d got %d", expLon, pos.lon)
+	if pos.Lon != expLon {
+		t.Errorf("expeceted lon to be be %d got %d", expLon, pos.Lon)
 	}
 }

--- a/udt_test.go
+++ b/udt_test.go
@@ -1,0 +1,88 @@
+// +build all integration
+
+package gocql
+
+import (
+	"fmt"
+	"testing"
+)
+
+type position struct {
+	lat int
+	lon int
+}
+
+// NOTE: due to current implementation details it is not currently possible to use
+// a pointer receiver type for the UDTMarshaler interface to handle UDT's
+func (p position) EncodeUDTField(name string, info TypeInfo) ([]byte, error) {
+	switch name {
+	case "lat":
+		return Marshal(info, p.lat)
+	case "lon":
+		return Marshal(info, p.lon)
+	default:
+		return nil, fmt.Errorf("unknown column for position: %q", name)
+	}
+}
+
+func (p *position) DecodeUDTField(name string, info TypeInfo, data []byte) error {
+	switch name {
+	case "lat":
+		return Unmarshal(info, data, &p.lat)
+	case "lon":
+		return Unmarshal(info, data, &p.lon)
+	default:
+		return fmt.Errorf("unknown column for position: %q", name)
+	}
+}
+
+func TestUDT(t *testing.T) {
+	if *flagProto < protoVersion3 {
+		t.Skip("UDT are only available on protocol >= 3")
+	}
+
+	session := createSession(t)
+	defer session.Close()
+
+	err := createTable(session, `CREATE TYPE position(
+		lat int,
+		lon int);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, `CREATE TABLE houses(
+		id int,
+		name text,
+		loc frozen<position>,
+
+		primary key(id)
+	);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		expLat = -1
+		expLon = 2
+	)
+
+	err = session.Query("INSERT INTO houses(id, name, loc) VALUES(?, ?, ?)", 1, "test", &position{expLat, expLon}).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pos := &position{}
+
+	err = session.Query("SELECT loc FROM houses WHERE id = ?", 1).Scan(pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pos.lat != expLat {
+		t.Errorf("expeceted lat to be be %d got %d", expLat, pos.lat)
+	}
+	if pos.lon != expLon {
+		t.Errorf("expeceted lon to be be %d got %d", expLon, pos.lon)
+	}
+}

--- a/udt_test.go
+++ b/udt_test.go
@@ -113,8 +113,8 @@ func TestUDT_Reflect(t *testing.T) {
 	}
 
 	type horse struct {
-		Name  string
-		Owner string
+		Name  string `cql:"name"`
+		Owner string `cql:"owner"`
 	}
 
 	insertedHorse := &horse{


### PR DESCRIPTION
Add support to read and write UDT's at the framing and scanning level.

To scan or marshal a UDT type the type must implement the Marshal/
UnmarshalUDT type.

Fixes #175