### PR TITLE
ensure that the value asertion does not panic

### DIFF
--- a/session.go
+++ b/session.go
@@ -223,7 +223,9 @@ func (s *Session) routingKeyInfo(stmt string) (*routingKeyInfo, error) {
 			return nil, inflight.err
 		}
 
-		return inflight.value.(*routingKeyInfo), nil
+		key, _ := inflight.value.(*routingKeyInfo)
+
+		return key, nil
 	}
 
 	// create a new inflight entry while the data is created


### PR DESCRIPTION
If there is no routing key available then the function will
return `nil, nil` and release the waitgroup. The waiters will
then type assert `inflight.value` which is a nil interface
value which then panics. In this case we should just return
nil as the originating function did.