### PR TITLE
Consolidate new session

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -9,13 +9,18 @@ import (
 
 func TestSessionAPI(t *testing.T) {
 
-	cfg := ClusterConfig{}
-	pool, err := NewSimplePool(&cfg)
+	cfg := &ClusterConfig{}
+	pool, err := NewSimplePool(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s := NewSession(pool, cfg)
+	s := &Session{
+		Pool: pool,
+		cfg:  *cfg,
+		cons: Quorum,
+	}
+
 	defer s.Close()
 
 	s.SetConsistency(All)
@@ -154,14 +159,13 @@ func TestQueryShouldPrepare(t *testing.T) {
 
 func TestBatchBasicAPI(t *testing.T) {
 
-	cfg := ClusterConfig{}
+	cfg := NewCluster("127.0.0.1")
 	cfg.RetryPolicy = &SimpleRetryPolicy{NumRetries: 2}
-	pool, err := NewSimplePool(&cfg)
+
+	s, err := cfg.CreateSession()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	s := NewSession(pool, cfg)
 	defer s.Close()
 
 	b := s.NewBatch(UnloggedBatch)

--- a/session_test.go
+++ b/session_test.go
@@ -159,12 +159,16 @@ func TestQueryShouldPrepare(t *testing.T) {
 
 func TestBatchBasicAPI(t *testing.T) {
 
-	cfg := NewCluster("127.0.0.1")
-	cfg.RetryPolicy = &SimpleRetryPolicy{NumRetries: 2}
-
-	s, err := cfg.CreateSession()
+	cfg := &ClusterConfig{RetryPolicy: &SimpleRetryPolicy{NumRetries: 2}}
+	pool, err := NewSimplePool(cfg)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	s := &Session{
+		Pool: pool,
+		cfg:  *cfg,
+		cons: Quorum,
 	}
 	defer s.Close()
 


### PR DESCRIPTION
CreateSession on the cluster config is a helper method to setup
defaults for the session, but it also does a lot of the setup, such
as creating the connection pool and creating the host discovery
goroutine.

Move all this logic into NewSession so that CreateSession now just
returns NewSession.
