### PR TITLE
When initially filling the host pool do it sync.

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -762,6 +762,18 @@ func (pool *hostConnPool) fill() {
 
 		// filled one
 		fillCount--
+
+		// connect all connections to this host in sync
+		for fillCount > 0 {
+			err := pool.connect()
+			pool.logConnectErr(err)
+
+			// decrement, even on error
+			fillCount--
+		}
+
+		go pool.fillingStopped()
+		return
 	}
 
 	// fill the rest of the pool asynchronously


### PR DESCRIPTION
This fixes a test flake which expects that when creating a pool returns
that it has the correct number of connections in it, which is not the
case for the Policy based pool which will connect a single connection
synchronously then do the rest async. Change it so that it now when
doing an initial fill will do the whole fill synchronously.