### PR TITLE
Ensure we hold a read lock to check hosts

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -87,12 +87,13 @@ func (r *roundRobinHostPolicy) Pick(qry *Query) NextHost {
 	// to the number of hosts known to this policy
 	var i uint32 = 0
 	return func() *HostInfo {
+		r.mu.RLock()
 		if len(r.hosts) == 0 {
+			r.mu.RUnlock()
 			return nil
 		}
 
 		var host *HostInfo
-		r.mu.RLock()
 		// always increment pos to evenly distribute traffic in case of
 		// failures
 		pos := atomic.AddUint32(&r.pos, 1)


### PR DESCRIPTION
When the policy is checking the length of the host list in
roundRobinHostPolicy ensure that we hold the read lock so that
if SetHosts is called we dont data race.