### PR TITLE
When the hostpool is empty dont block in fill

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -679,7 +679,8 @@ func (pool *hostConnPool) Pick(qry *Query) *Conn {
 
 	if empty {
 		// try to fill the empty pool
-		pool.fill()
+		go pool.fill()
+		return nil
 	}
 
 	return pool.policy.Pick(qry)


### PR DESCRIPTION
If the host is down and its connect blocks until timeout the
caller should not be blocked because it may be coming from a call
to execute a query.