### PR TITLE
Reduce lock use when updating host pools

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -476,6 +477,7 @@ type policyConnPool struct {
 	numConns int
 	connCfg  ConnConfig
 	keyspace string
+	filling  int32
 
 	mu            sync.RWMutex
 	hostPolicy    HostSelectionPolicy
@@ -534,7 +536,13 @@ func NewPolicyConnPool(
 }
 
 func (p *policyConnPool) SetHosts(hosts []HostInfo) {
-	p.mu.Lock()
+	if !atomic.CompareAndSwapInt32(&p.filling, 0, 1) {
+		return
+	}
+	defer atomic.StoreInt32(&p.filling, 0)
+
+	// SetHosts calcuates the new set of hosts which should be inside the pool
+	p.mu.RLock()
 
 	toRemove := make(map[string]struct{})
 	for addr := range p.hostConnPools {
@@ -544,35 +552,50 @@ func (p *policyConnPool) SetHosts(hosts []HostInfo) {
 	// TODO connect to hosts in parallel, but wait for pools to be
 	// created before returning
 
+	// the old pool, retain a reference because we will replace this with the
+	// new pool later. This is essential now a copy on write map, when we drop
+	// support for 1.3 we can use atomic.Value to implement this without locks.
+	existingPool := p.hostConnPools
+
+	// new host pool which will be set once it has connected to the hosts
+	hostPool := make(map[string]*hostConnPool)
+
 	for i := range hosts {
-		pool, exists := p.hostConnPools[hosts[i].Peer]
+		addr := hosts[i].Peer
+		pool, exists := p.hostConnPools[addr]
 		if !exists {
+			// TODO: do this async
 			// create a connection pool for the host
 			pool = newHostConnPool(
-				hosts[i].Peer,
+				addr,
 				p.port,
 				p.numConns,
 				p.connCfg,
 				p.keyspace,
 				p.connPolicy(),
 			)
-			p.hostConnPools[hosts[i].Peer] = pool
+			hostPool[addr] = pool
 		} else {
+			hostPool[addr] = pool
 			// still have this host, so don't remove it
-			delete(toRemove, hosts[i].Peer)
+			delete(toRemove, addr)
 		}
 	}
+	p.mu.RUnlock()
 
+	p.mu.Lock()
+	p.hostConnPools = hostPool
+	p.mu.Unlock()
+
+	// we dont need to hold a lock to this pool as we are the only one with a refernce
+	// to it.
 	for addr := range toRemove {
-		pool := p.hostConnPools[addr]
-		delete(p.hostConnPools, addr)
+		pool := existingPool[addr]
 		pool.Close()
 	}
 
 	// update the policy
 	p.hostPolicy.SetHosts(hosts)
-
-	p.mu.Unlock()
 }
 
 func (p *policyConnPool) SetPartitioner(partitioner string) {
@@ -594,15 +617,20 @@ func (p *policyConnPool) Pick(qry *Query) *Conn {
 	nextHost := p.hostPolicy.Pick(qry)
 
 	p.mu.RLock()
-	var host *HostInfo
-	var conn *Conn
+	var (
+		host *HostInfo
+		conn *Conn
+	)
+
 	for conn == nil {
 		host = nextHost()
 		if host == nil {
 			break
 		}
+
 		conn = p.hostConnPools[host.Peer].Pick(qry)
 	}
+
 	p.mu.RUnlock()
 	return conn
 }
@@ -635,7 +663,7 @@ type hostConnPool struct {
 	mu      sync.RWMutex
 	conns   []*Conn
 	closed  bool
-	filling bool
+	filling int32
 }
 
 func newHostConnPool(
@@ -656,7 +684,6 @@ func newHostConnPool(
 		keyspace: keyspace,
 		policy:   policy,
 		conns:    make([]*Conn, 0, size),
-		filling:  false,
 		closed:   false,
 	}
 
@@ -709,9 +736,17 @@ func (pool *hostConnPool) Close() {
 
 // Fill the connection pool
 func (pool *hostConnPool) fill() {
+	if !atomic.CompareAndSwapInt32(&pool.filling, 0, 1) {
+		// already filling
+		return
+	}
+	defer func() {
+		go pool.fillingStopped()
+	}()
+
 	pool.mu.RLock()
-	// avoid filling a closed pool, or concurrent filling
-	if pool.closed || pool.filling {
+	// avoid filling a closed pool
+	if pool.closed {
 		pool.mu.RUnlock()
 		return
 	}
@@ -719,76 +754,26 @@ func (pool *hostConnPool) fill() {
 	// determine the filling work to be done
 	startCount := len(pool.conns)
 	fillCount := pool.size - startCount
+	pool.mu.RUnlock()
 
 	// avoid filling a full (or overfull) pool
 	if fillCount <= 0 {
-		pool.mu.RUnlock()
 		return
 	}
 
-	// switch from read to write lock
-	pool.mu.RUnlock()
-	pool.mu.Lock()
-
-	// double check everything since the lock was released
-	startCount = len(pool.conns)
-	fillCount = pool.size - startCount
-	if pool.closed || pool.filling || fillCount <= 0 {
-		// looks like another goroutine already beat this
-		// goroutine to the filling
-		pool.mu.Unlock()
-		return
-	}
-
-	// ok fill the pool
-	pool.filling = true
-
-	// allow others to access the pool while filling
-	pool.mu.Unlock()
 	// only this goroutine should make calls to fill/empty the pool at this
 	// point until after this routine or its subordinates calls
 	// fillingStopped
 
-	// fill only the first connection synchronously
-	if startCount == 0 {
+	for fillCount > 0 {
 		err := pool.connect()
+		// TODO(zariel): if err != nil mark host DOWN so that we dont try to connect again
+		// for a period of time.
 		pool.logConnectErr(err)
 
-		if err != nil {
-			// probably unreachable host
-			go pool.fillingStopped()
-			return
-		}
-
-		// filled one
+		// decrement, even on error
 		fillCount--
-
-		// connect all connections to this host in sync
-		for fillCount > 0 {
-			err := pool.connect()
-			pool.logConnectErr(err)
-
-			// decrement, even on error
-			fillCount--
-		}
-
-		go pool.fillingStopped()
-		return
 	}
-
-	// fill the rest of the pool asynchronously
-	go func() {
-		for fillCount > 0 {
-			err := pool.connect()
-			pool.logConnectErr(err)
-
-			// decrement, even on error
-			fillCount--
-		}
-
-		// mark the end of filling
-		pool.fillingStopped()
-	}()
 }
 
 func (pool *hostConnPool) logConnectErr(err error) {
@@ -807,10 +792,7 @@ func (pool *hostConnPool) fillingStopped() {
 	// this provides some time between failed attempts
 	// to fill the pool for the host to recover
 	time.Sleep(time.Duration(rand.Int31n(100)+31) * time.Millisecond)
-
-	pool.mu.Lock()
-	pool.filling = false
-	pool.mu.Unlock()
+	atomic.StoreInt32(&pool.filling, 0)
 }
 
 // create a new connection to the host and add it to the pool


### PR DESCRIPTION
In the PolicyAwareConnection pool we shouldn't hold the write lock
whilst dialing hosts as it will block all readers. In the event that
a host is down we will try to connect to it and wait until timeout
before stopping. This means that whilst the connection is dialing
all readers will be blocked acquiring the read lock to access the
pools.

Instead change the policy aware pools to use a copy on write map
which allows us to do the mutations to the map without having the
write lock.

Use CAS to prevent concurrent calls to fill both attempting to fill
under a write lock.

Improve concurrency when mutating the pool when multiple concurrent
calls are occurring.