### PR TITLE
Fix bitshift order in udt length calculation

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1252,9 +1252,9 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 			}
 
 			n := len(data)
-			buf = append(buf, byte(n<<24),
-				byte(n<<16),
-				byte(n<<8),
+			buf = append(buf, byte(n>>24),
+				byte(n>>16),
+				byte(n>>8),
 				byte(n))
 
 			buf = append(buf, data...)
@@ -1275,9 +1275,9 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 			}
 
 			n := len(data)
-			buf = append(buf, byte(n<<24),
-				byte(n<<16),
-				byte(n<<8),
+			buf = append(buf, byte(n>>24),
+				byte(n>>16),
+				byte(n>>8),
 				byte(n))
 
 			buf = append(buf, data...)
@@ -1327,9 +1327,9 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 
 		n := len(data)
-		buf = append(buf, byte(n<<24),
-			byte(n<<16),
-			byte(n<<8),
+		buf = append(buf, byte(n>>24),
+			byte(n>>16),
+			byte(n>>8),
 			byte(n))
 
 		buf = append(buf, data...)


### PR DESCRIPTION
Currently, when marshaling UDTs, the marshaling of the `length` of the UDT's data uses the wrong bit shift order - which prevents UDTs from being larger than 256 bytes. Cassandra returns back with `Invalid remaining data after end of UDT value`.

This PR fixes the shift order, and also provides a test that trigger the big.