### PR TITLE
Redefine snappy import

### DIFF
--- a/compressor.go
+++ b/compressor.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 )
 
 type Compressor interface {

--- a/compressor_test.go
+++ b/compressor_test.go
@@ -4,7 +4,7 @@ package gocql
 
 import (
 	"bytes"
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 	"testing"
 )
 


### PR DESCRIPTION
We seem to be getting the following error importing snappy:

```
package code.google.com/p/snappy-go/snappy: unable to detect version control system for code.google.com/ path
```

So this is an attempt to fix this (see #402 for context).