### PR TITLE
Added closeChan to clean up ring describer when session is closed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Dan Kinder <dkinder.is.me@gmail.com>
 Oliver Beattie <oliver@obeattie.com>
 Justin Corpron <justin@retailnext.com>
 Miles Delahunty <miles.delahunty@gmail.com>
+Zach Badgett <zach.badgett@gmail.com>

--- a/host_source.go
+++ b/host_source.go
@@ -97,23 +97,21 @@ func (h *ringDescriber) run(sleep time.Duration) {
 	}
 
 	for {
-		// if we have 0 hosts this will return the previous list of hosts to
-		// attempt to reconnect to the cluster otherwise we would never find
-		// downed hosts again, could possibly have an optimisation to only
-		// try to add new hosts if GetHosts didnt error and the hosts didnt change.
-		hosts, partitioner, err := h.GetHosts()
-		if err != nil {
-			log.Println("RingDescriber: unable to get ring topology:", err)
-		} else {
-			h.session.Pool.SetHosts(hosts)
-			if v, ok := h.session.Pool.(SetPartitioner); ok {
-				v.SetPartitioner(partitioner)
-			}
-		}
-
-		time.Sleep(sleep)
-
 		select {
+		case <-time.After(sleep):
+			// if we have 0 hosts this will return the previous list of hosts to
+			// attempt to reconnect to the cluster otherwise we would never find
+			// downed hosts again, could possibly have an optimisation to only
+			// try to add new hosts if GetHosts didnt error and the hosts didnt change.
+			hosts, partitioner, err := h.GetHosts()
+			if err != nil {
+				log.Println("RingDescriber: unable to get ring topology:", err)
+			} else {
+				h.session.Pool.SetHosts(hosts)
+				if v, ok := h.session.Pool.(SetPartitioner); ok {
+					v.SetPartitioner(partitioner)
+				}
+			}
 		case <-h.closeChan:
 			return
 		}

--- a/host_source.go
+++ b/host_source.go
@@ -97,10 +97,6 @@ func (h *ringDescriber) run(sleep time.Duration) {
 	}
 
 	for {
-		select {
-		case <-h.closeChan:
-			return
-		}
 		// if we have 0 hosts this will return the previous list of hosts to
 		// attempt to reconnect to the cluster otherwise we would never find
 		// downed hosts again, could possibly have an optimisation to only
@@ -116,5 +112,10 @@ func (h *ringDescriber) run(sleep time.Duration) {
 		}
 
 		time.Sleep(sleep)
+
+		select {
+		case <-h.closeChan:
+			return
+		}
 	}
 }

--- a/host_source.go
+++ b/host_source.go
@@ -21,6 +21,7 @@ type ringDescriber struct {
 	prevHosts       []HostInfo
 	prevPartitioner string
 	session         *Session
+	closeChan       chan bool
 }
 
 func (r *ringDescriber) GetHosts() (
@@ -96,6 +97,10 @@ func (h *ringDescriber) run(sleep time.Duration) {
 	}
 
 	for {
+		select {
+		case <-h.closeChan:
+			return
+		}
 		// if we have 0 hosts this will return the previous list of hosts to
 		// attempt to reconnect to the cluster otherwise we would never find
 		// downed hosts again, could possibly have an optimisation to only


### PR DESCRIPTION
Currently, when setting 'DiscoverHosts' to 'true', you open up a goroutine that periodically checks for host updates; this goroutine is never cleaned up (goroutine leak) when the session is closed and it will display 'RingDescriber: unable to get ring topology: use of closed network connection' continuously until the program exits.

My pull request adds a channel to 'ringDescriber'; adds a select statement to the 'run' method to check when the channel is closed; 'hostSource' variable is added to 'Session' (I'm not sure if keeping 'Session' agnostic to 'ringDescriber' is important or not); on session close we check to see if 'session.hostSource' is nil, if not, close the 'closeChan' that will clean up the goroutine.