### PR TITLE
Dont allocate all the columninfo upfront

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -730,10 +730,10 @@ func (f *framer) parseResultMetadata() resultMetadata {
 		table = f.readString()
 	}
 
-	cols := make([]ColumnInfo, colCount)
+	var cols []ColumnInfo
 
 	for i := 0; i < colCount; i++ {
-		col := &cols[i]
+		var col ColumnInfo
 
 		if !globalSpec {
 			col.Keyspace = f.readString()
@@ -751,6 +751,8 @@ func (f *framer) parseResultMetadata() resultMetadata {
 			// -1 because we already included the tuple column
 			meta.actualColCount += len(v.Elems) - 1
 		}
+
+		cols = append(cols, col)
 	}
 
 	meta.columns = cols

--- a/frame_test.go
+++ b/frame_test.go
@@ -23,6 +23,8 @@ func TestFuzzBugs(t *testing.T) {
 		[]byte("\x8200\b\x00\x00\x00\b0\x00\x00\x00\x040000"),
 		[]byte("\x8200\x00\x00\x00\x00\x100\x00\x00\x12\x00\x00\x0000000" +
 			"00000"),
+		[]byte("\x83000\b\x00\x00\x00\x14\x00\x00\x00\x020000000" +
+			"000000000"),
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
If the column count for a row result is huge it will trigger either
a makeslice: len out of range or the program will do lots of gc
which make the application unresponsive, even if there are not really
that many columns.