### PR TITLE
Remove limitations of SslOptions by making it inherit from tls.Config.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ Justin Corpron <justin@retailnext.com>
 Miles Delahunty <miles.delahunty@gmail.com>
 Zach Badgett <zach.badgett@gmail.com>
 Maciek Sakrejda <maciek@heroku.com>
+Jeff Mitchell <jeffrey.mitchell@gmail.com>

--- a/conn.go
+++ b/conn.go
@@ -55,6 +55,8 @@ func (p PasswordAuthenticator) Success(data []byte) error {
 }
 
 type SslOptions struct {
+	tls.Config
+
 	// CertPath and KeyPath are optional depending on server
 	// config, but both fields must be omitted to avoid using a
 	// client certificate


### PR DESCRIPTION
The helper functions simply toggle internal state, now, and all the
flexibility of tls.Config is available.