### PR TITLE
SimpleRetryPolicy doc format fixed

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -28,17 +28,16 @@ type RetryPolicy interface {
 	Attempt(RetryableQuery) bool
 }
 
-/*
-SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.
-
-See below for examples of usage:
-
-	//Assign to the cluster
-	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 3}
-
-	//Assign to a query
- 	query.RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 1})
-*/
+// SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.
+//
+// See below for examples of usage:
+//
+//     //Assign to the cluster
+//     cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 3}
+//
+//     //Assign to a query
+//     query.RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 1})
+//
 type SimpleRetryPolicy struct {
 	NumRetries int //Number of times to retry a query
 }


### PR DESCRIPTION
This fixes the indentation of the example code, which was wrongly indented in the online Godoc.

With a local `godoc` server, here’s how it’s now:

![before](https://cloud.githubusercontent.com/assets/1334295/8254426/a790f1e0-1698-11e5-8bfb-000c7bfdb294.png)

And how it’s with this patch:

![after](https://cloud.githubusercontent.com/assets/1334295/8254427/a791046e-1698-11e5-9268-56bf371afa03.png)