### PR TITLE
remove query level timeouts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -379,12 +379,7 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 		return nil, err
 	}
 
-	select {
-	case err = <-call.resp:
-	case <-time.After(c.timeout):
-		c.handleTimeout()
-		return nil, ErrTimeoutNoResponse
-	}
+	err = <-call.resp
 
 	if err != nil {
 		return nil, err

--- a/conn_test.go
+++ b/conn_test.go
@@ -472,6 +472,7 @@ func TestPolicyConnPoolSSL(t *testing.T) {
 }
 
 func TestQueryTimeout(t *testing.T) {
+	t.Skip("skipping until query timeouts are enabled")
 	srv := NewTestServer(t, protoVersion2)
 	defer srv.Stop()
 


### PR DESCRIPTION
Having a timeout on the query level introduces some very
subtle race condtions which need to be addressed before enabling.