### PR TITLE
Reinstate query timeouts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -348,6 +348,7 @@ func (c *Conn) recv() error {
 	select {
 	case call.resp <- err:
 	case <-call.timeout:
+		c.releaseStream(head.stream)
 	case <-c.quit:
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -611,12 +611,11 @@ func (c *Conn) closeWithError(err error) {
 		req := &c.calls[id]
 		// we need to send the error to all waiting queries, put the state
 		// of this conn into not active so that it can not execute any queries.
+		atomic.StoreInt32(&req.waiting, 0)
 		select {
 		case req.resp <- err:
 		default:
 		}
-
-		close(req.resp)
 	}
 
 	c.conn.Close()

--- a/conn.go
+++ b/conn.go
@@ -376,6 +376,7 @@ func (c *Conn) handleTimeout() {
 
 func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	// TODO: move tracer onto conn
+	start := time.Now()
 	stream := <-c.uniq
 
 	call := &c.calls[stream]
@@ -407,6 +408,7 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 		}
 	case <-time.After(c.timeout):
 		c.handleTimeout()
+		log.Printf("querytime=%v\n", time.Now().Sub(start))
 		return nil, ErrTimeoutNoResponse
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -381,7 +381,12 @@ func (c *Conn) handleTimeout() {
 
 func (c *Conn) exec(req frameWriter, tracer Tracer) (frame, error) {
 	// TODO: move tracer onto conn
-	stream := <-c.uniq
+	var stream int
+	select {
+	case stream = <-c.uniq:
+	case <-c.quit:
+		return nil, ErrConnectionClosed
+	}
 
 	call := &c.calls[stream]
 	// resp is basically a waiting semaphore protecting the framer


### PR DESCRIPTION
Correctly synchronise the response timeout handling between waiting for the response and sending the response back. Improve handling of streams so they are returned in the correct place, ensure that streams are returned always. Improve handling when a connection is closed so queries don't get blocked in exec.

Add a test which timesout on a stream then execute another query before the first query returns which triggers the previous error when reusing streams.

Fixes #426 #417 