### PR TITLE
buffer the connection response channel

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -180,7 +180,7 @@ func Connect(addr string, cfg ConnConfig, errorHandler ConnErrorHandler) (*Conn,
 	}
 
 	for i := 0; i < cfg.NumStreams; i++ {
-		c.calls[i].resp = make(chan error)
+		c.calls[i].resp = make(chan error, 1)
 		c.uniq <- i
 	}
 


### PR DESCRIPTION
Buffer the channel which the IO goroutine sends the response
back to the stream handler so that the IO goroutine will not
block waiting for a slow stream handler.