### PR TITLE
Set Cluster Default PageSize to 5000

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -72,7 +72,7 @@ type ClusterConfig struct {
 	DiscoverHosts     bool              // If set, gocql will attempt to automatically discover other members of the Cassandra cluster (default: false)
 	MaxPreparedStmts  int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
 	MaxRoutingKeyInfo int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
-	PageSize          int               // Default page size to use for created sessions (default: 0)
+	PageSize          int               // Default page size to use for created sessions (default: 5000)
 	SerialConsistency SerialConsistency // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
 	Discovery         DiscoveryConfig
 	SslOpts           *SslOptions
@@ -93,6 +93,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DiscoverHosts:     false,
 		MaxPreparedStmts:  defaultMaxPreparedStmts,
 		MaxRoutingKeyInfo: 1000,
+		PageSize:          5000,
 		DefaultTimestamp:  true,
 	}
 	return cfg


### PR DESCRIPTION
If we do not set default `PageSize` to a reasonable number, the query may cause whole cassandra cluster OOM. The [default page size of cassandra java driver is 5000](http://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/QueryOptions.html#DEFAULT_FETCH_SIZE). 

More information can be found in this issue: https://issues.apache.org/jira/browse/CASSANDRA-9607

