### PR TITLE
prevent duplicate stream usage

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -105,9 +105,7 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
 	tb.Logf("Created keyspace %s", keyspace)
 }
 
-func createSession(tb testing.TB) *Session {
-	cluster := createCluster()
-
+func createSessionFromCluster(cluster *ClusterConfig, tb testing.TB) *Session {
 	// Drop and re-create the keyspace once. Different tests should use their own
 	// individual tables, but can assume that the table does not exist before.
 	initOnce.Do(func() {
@@ -121,6 +119,11 @@ func createSession(tb testing.TB) *Session {
 	}
 
 	return session
+}
+
+func createSession(tb testing.TB) *Session {
+	cluster := createCluster()
+	return createSessionFromCluster(cluster, tb)
 }
 
 // TestAuthentication verifies that gocql will work with a host configured to only accept authenticated connections

--- a/stress_test.go
+++ b/stress_test.go
@@ -1,0 +1,40 @@
+// +build all integration
+
+package gocql
+
+import (
+	"sync/atomic"
+
+	"testing"
+)
+
+func BenchmarkConnStress(b *testing.B) {
+	const workers = 16
+
+	cluster := createCluster()
+	cluster.NumConns = 1
+	cluster.NumStreams = workers
+	session := createSessionFromCluster(cluster, b)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS conn_stress (id int primary key)"); err != nil {
+		b.Fatal(err)
+	}
+
+	var seed uint64
+	writer := func(pb *testing.PB) {
+		seed := atomic.AddUint64(&seed, 1)
+		var i uint64 = 0
+		for pb.Next() {
+			if err := session.Query("insert into conn_stress (id) values (?)", i*seed).Exec(); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	}
+
+	b.SetParallelism(workers)
+	b.RunParallel(writer)
+
+}


### PR DESCRIPTION
Remove the atomic waiting variable, it can lead to a case
where a stream is released twice which will cause data races
and unforseen panics.

The case this can happen is that in exec the frame is written
and the response is received before call.waiting is set
from 0 to 1. This is most likely down to the runtime scheduling
the recv() io goroutine before the atomic store happens. The recv()
goroutine sees that call.waiting is 0 and assumes that is has timed
out, releasing the stream. Then the exec() goroutine is scheduled
which sets call.waiting to 1 and then blocks in the select waiting
for the response, which never comes so the timeout option is selected
which then releases the stream again.

Solve this by removing the call.waiting synchronisation which was
not protecting anything as the channels were providing specific
synchronisation points.

Add a stress test benchmark which can reproduce panics that this
patch fixes.

Updates #439, #435, #437, #430