### PR TITLE
Fix timestamp type marshaling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,3 +49,4 @@ Zach Badgett <zach.badgett@gmail.com>
 Maciek Sakrejda <maciek@heroku.com>
 Jeff Mitchell <jeffrey.mitchell@gmail.com>
 Baptiste Fontaine <b@ptistefontaine.fr>
+Matt Heath <matt@mattheath.com>

--- a/marshal.go
+++ b/marshal.go
@@ -802,7 +802,7 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:
-		x := v.UnixNano() / int64(1000000)
+		x := int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
 		return encBigInt(x), nil
 	}
 	rv := reflect.ValueOf(value)

--- a/marshal.go
+++ b/marshal.go
@@ -802,6 +802,9 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:
+		if v.IsZero() {
+			return []byte{}, nil
+		}
 		x := int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
 		return encBigInt(x), nil
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -794,3 +794,63 @@ func TestMarshalPointer(t *testing.T) {
 		t.Errorf("Pointer marshaling failed. Expected %+v, got %+v", []byte{42}, data)
 	}
 }
+
+func TestMarshalTimestamp(t *testing.T) {
+	var marshalTimestampTests = []struct {
+		Info  TypeInfo
+		Data  []byte
+		Value interface{}
+	}{
+		{
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
+			time.Date(2013, time.August, 13, 9, 52, 3, 0, time.UTC),
+		},
+		{
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
+			int64(1376387523000),
+		},
+		{
+			// 9223372036854 is the maximum time representable in ms since the epoch
+			// with int64 if using UnixNano to convert
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\x00\x00\x08\x63\x7b\xd0\x5a\xf6"),
+			time.Date(2262, time.April, 11, 23, 47, 16, 854775807, time.UTC),
+		},
+		{
+			// One nanosecond after causes overflow when using UnixNano
+			// Instead it should resolve to the same time in ms
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\x00\x00\x08\x63\x7b\xd0\x5a\xf6"),
+			time.Date(2262, time.April, 11, 23, 47, 16, 854775808, time.UTC),
+		},
+		{
+			// -9223372036855 is the minimum time representable in ms since the epoch
+			// with int64 if using UnixNano to convert
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
+			time.Date(1677, time.September, 21, 00, 12, 43, 145224192, time.UTC),
+		},
+		{
+			// One nanosecond earlier causes overflow when using UnixNano
+			// it should resolve to the same time in ms
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
+			time.Date(1677, time.September, 21, 00, 12, 43, 145224191, time.UTC),
+		},
+	}
+
+	for i, test := range marshalTimestampTests {
+		t.Log(i, test)
+		data, err := Marshal(test.Info, test.Value)
+		if err != nil {
+			t.Errorf("marshalTest[%d]: %v", i, err)
+			continue
+		}
+		if !bytes.Equal(data, test.Data) {
+			t.Errorf("marshalTest[%d]: expected %x (%v), got %x (%v) for time %s", i,
+				test.Data, decBigInt(test.Data), data, decBigInt(data), test.Value)
+		}
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -839,6 +839,12 @@ func TestMarshalTimestamp(t *testing.T) {
 			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
 			time.Date(1677, time.September, 21, 00, 12, 43, 145224191, time.UTC),
 		},
+		{
+			// Store the zero time as a blank slice
+			NativeType{proto: 2, typ: TypeTimestamp},
+			[]byte{},
+			time.Time{},
+		},
 	}
 
 	for i, test := range marshalTimestampTests {


### PR DESCRIPTION
The `Timestamp` CQL type is represented by a 64bit integer number of ms since the epoch, stored as 8 bytes. Currently marshaling of the `time.Time` type into this uses the `UnixNano()` func, which can only represent times between approximately the years 1677 and 2262 before overflowing.

This means that the zero time (`0001-01-01 00:00:00 +0000 UTC`) can _not_ be represented within this range, as mentioned in the [time pkg documentation](http://golang.org/pkg/time/#Time.UnixNano): _"the result of calling UnixNano on the zero Time is undefined"_. And as a side effect, marshaling a zero time into the cassandra results in a time of approx `1754-08-30 22:43:41.129 +0000 UTC` rather than zero. This is then correctly unmarshalled back out of cassandra, so the data stored does not equal the expected read data. An example can be seen here: http://play.golang.org/p/mY0KhtD1DF

This PR changes this behaviour to take the seconds from the epoch, and separately combine the `ms` component from `Nanoseconds`, preventing overflowing. There are test cases which demonstrate the overflow with the addition or subtraction of a single nanosecond.

In addition I think it makes sense to store the actual zero time, as a blank `[]byte` rather than its numerical value of `-62135596800000` (or bytes "\xff\xff\xc7\x7c\xed\xd3\x28\x00") , so this has been added as a special case in the marshaling step. Note that the `unmarshalTimestamp` method already supports unmarshaling data with a len of 0.