### PR TITLE
Improve support for complicated cassandra schemas.

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -330,6 +330,14 @@ func TestCompileMetadata(t *testing.T) {
 		ColumnMetadata{
 			Keyspace:       "V2Keyspace",
 			Table:          "Table1",
+			Name:           "KEY1",
+			Kind:           PARTITION_KEY,
+			ComponentIndex: 0,
+			Validator:      "org.apache.cassandra.db.marshal.UTF8Type",
+		},
+		ColumnMetadata{
+			Keyspace:       "V2Keyspace",
+			Table:          "Table1",
 			Name:           "Key1",
 			Kind:           PARTITION_KEY,
 			ComponentIndex: 0,
@@ -383,6 +391,11 @@ func TestCompileMetadata(t *testing.T) {
 					},
 					ClusteringColumns: []*ColumnMetadata{},
 					Columns: map[string]*ColumnMetadata{
+						"KEY1": &ColumnMetadata{
+							Name: "KEY1",
+							Type: NativeType{typ: TypeVarchar},
+							Kind: PARTITION_KEY,
+						},
 						"Key1": &ColumnMetadata{
 							Name: "Key1",
 							Type: NativeType{typ: TypeVarchar},


### PR DESCRIPTION
In some schemas there may be "partition_key" type columns returned in the V2 protocol metadata which have the same component index; in our case we have a couple column families with aliased columns "KEY" and "key" for historical reasons. When the token-aware connection pool is used with these column families, a nil-pointer panic occurs since the partition key length (column count) was being incorrectly calculated; This change is based on the DataStax driver's behavior for columns with the same component index, which prefers the last column in order defined for that component index; the consequence of this behavior is that other column names defined for the same component index will not be identified as part of a routing key.

Also, "compact_value" has been added as a column kind/type.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gocql/gocql/442)
<!-- Reviewable:end -->
