### PR TITLE
Update deprecated package

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Maciek Sakrejda <maciek@heroku.com>
 Jeff Mitchell <jeffrey.mitchell@gmail.com>
 Baptiste Fontaine <b@ptistefontaine.fr>
 Matt Heath <matt@mattheath.com>
+Adrian Casajus <adriancasajus@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -18,7 +18,7 @@ import (
 	"time"
 	"unicode"
 
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 )
 
 var (

--- a/helpers.go
+++ b/helpers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 )
 
 type RowData struct {

--- a/marshal.go
+++ b/marshal.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 )
 
 var (

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 )
 
 var marshalTests = []struct {

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"speter.net/go/exp/math/dec/inf"
+	"gopkg.in/inf.v0"
 	"testing"
 	"time"
 )


### PR DESCRIPTION
At http://speter.net/ it says that the speter.net/go/exp/math/dec/inf has been replaced by gopkg.in/inf.v0