### PR TITLE
conn: dont use stream 0 for outgoing requests

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2016,13 +2016,13 @@ func TestStream0(t *testing.T) {
 		return f.finishWrite()
 	})
 
-	const expErr = "gocql: error on stream 0: Invalid or unsupported protocol version: 127"
+	const expErr = "gocql: error on stream 0:"
 	// need to write out an invalid frame, which we need a connection to do
 	frame, err := conn.exec(writer, nil)
 	if err == nil {
 		t.Fatal("expected to get an error on stream 0")
-	} else if err.Error() != expErr {
-		t.Fatalf("expected to get error %q got %q", expErr, err.Error())
+	} else if !strings.HasPrefix(err.Error(), expErr) {
+		t.Fatalf("expected to get error prefix %q got %q", expErr, err.Error())
 	} else if frame != nil {
 		t.Fatalf("expected to get nil frame got %+v", frame)
 	}

--- a/conn.go
+++ b/conn.go
@@ -367,14 +367,14 @@ func (c *Conn) recv() error {
 
 	if head.stream > len(c.calls) {
 		return fmt.Errorf("gocql: frame header stream is beyond call exepected bounds: %d", head.stream)
-	} else if head.stream < 0 {
+	} else if head.stream == -1 {
 		// TODO: handle cassandra event frames, we shouldnt get any currently
 		_, err := io.CopyN(ioutil.Discard, c, int64(head.length))
 		if err != nil {
 			return err
 		}
 		return nil
-	} else if head.stream == 0 {
+	} else if head.stream <= 0 {
 		// reserved stream that we dont use, probably due to a protocol error
 		// or a bug in Cassandra, this should be an error, parse it and return.
 		framer := newFramer(c, c, c.compressor, c.version)
@@ -389,9 +389,9 @@ func (c *Conn) recv() error {
 
 		switch v := frame.(type) {
 		case error:
-			return fmt.Errorf("gocql: error on stream 0: %v", v)
+			return fmt.Errorf("gocql: error on stream %d: %v", head.stream, v)
 		default:
-			return fmt.Errorf("gocql: received frame on stream 0: %v", frame)
+			return fmt.Errorf("gocql: received frame on stream %d: %v", head.stream, frame)
 		}
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -157,7 +157,7 @@ func Connect(addr string, cfg ConnConfig, errorHandler ConnErrorHandler) (*Conn,
 		headerSize = 9
 	}
 
-	if cfg.NumStreams <= 0 || cfg.NumStreams > maxStreams {
+	if cfg.NumStreams <= 0 || cfg.NumStreams >= maxStreams {
 		cfg.NumStreams = maxStreams
 	} else {
 		cfg.NumStreams++

--- a/conn_test.go
+++ b/conn_test.go
@@ -284,7 +284,7 @@ func TestStreams_Protocol1(t *testing.T) {
 	defer db.Close()
 
 	var wg sync.WaitGroup
-	for i := 0; i < db.cfg.NumStreams; i++ {
+	for i := 1; i < db.cfg.NumStreams; i++ {
 		// here were just validating that if we send NumStream request we get
 		// a response for every stream and the lengths for the queries are set
 		// correctly.
@@ -315,7 +315,7 @@ func TestStreams_Protocol2(t *testing.T) {
 	}
 	defer db.Close()
 
-	for i := 0; i < db.cfg.NumStreams; i++ {
+	for i := 1; i < db.cfg.NumStreams; i++ {
 		// the test server processes each conn synchronously
 		// here were just validating that if we send NumStream request we get
 		// a response for every stream and the lengths for the queries are set
@@ -342,7 +342,7 @@ func TestStreams_Protocol3(t *testing.T) {
 	}
 	defer db.Close()
 
-	for i := 0; i < db.cfg.NumStreams; i++ {
+	for i := 1; i < db.cfg.NumStreams; i++ {
 		// the test server processes each conn synchronously
 		// here were just validating that if we send NumStream request we get
 		// a response for every stream and the lengths for the queries are set


### PR DESCRIPTION
If Cassandra has an error and does not honor the protocol and returns
a response on a different stream than the request then the stream will
be 0, this can happen if there is a corrputed frame or an invalid
protocol version.

Detect the responses on stream 0 and cause it to be sent to all
outstanding requests so that they don't block indefinatly, as they may
have caused the original error.