### PR TITLE
Routing key improvements

### DIFF
--- a/session.go
+++ b/session.go
@@ -542,7 +542,9 @@ func (q *Query) GetRoutingKey() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		binary.Write(buf, binary.BigEndian, int16(len(encoded)))
+		lenBuf := []byte{0x00, 0x00}
+		binary.BigEndian.PutUint16(lenBuf, uint16(len(encoded)))
+		buf.Write(lenBuf)
 		buf.Write(encoded)
 		buf.WriteByte(0x00)
 	}

--- a/session.go
+++ b/session.go
@@ -533,7 +533,7 @@ func (q *Query) GetRoutingKey() ([]byte, error) {
 	}
 
 	// composite routing key
-	buf := &bytes.Buffer{}
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
 	for i := range routingKeyInfo.indexes {
 		encoded, err := Marshal(
 			routingKeyInfo.types[i],

--- a/stress_test.go
+++ b/stress_test.go
@@ -38,3 +38,36 @@ func BenchmarkConnStress(b *testing.B) {
 	b.RunParallel(writer)
 
 }
+
+func BenchmarkConnRoutingKey(b *testing.B) {
+	const workers = 16
+
+	cluster := createCluster()
+	cluster.NumConns = 1
+	cluster.NumStreams = workers
+	cluster.ConnPoolType = NewTokenAwareConnPool
+	session := createSessionFromCluster(cluster, b)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS routing_key_stress (id int primary key)"); err != nil {
+		b.Fatal(err)
+	}
+
+	var seed uint64
+	writer := func(pb *testing.PB) {
+		seed := atomic.AddUint64(&seed, 1)
+		var i uint64 = 0
+		query := session.Query("insert into routing_key_stress (id) values (?)")
+
+		for pb.Next() {
+			if _, err := query.Bind(i * seed).GetRoutingKey(); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	}
+
+	b.SetParallelism(workers)
+	b.RunParallel(writer)
+}


### PR DESCRIPTION
This speeds up things quite a bit when doing lots of small insert queries against Cassandra, by reducing the load on the garbage collector. I'm not 100% sure about the correctness of "no need to include keyspace in routingKeyInfoCache key", but since the session keyspace seems to be immutable, including it in a map key when the map is per-session doesn't seem needed.

benchcmp (when running with benchtime 30s to let some time for the GC to kick in):
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkConnRoutingKey     654           421           -35.63%

benchmark                   old allocs     new allocs     delta
BenchmarkConnRoutingKey     5              4              -20.00%

benchmark                   old bytes     new bytes     delta
BenchmarkConnRoutingKey     112           48            -57.14%
```