### PR TITLE
query: Improve efficiency of 'USE' statement detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Matt Heath <matt@mattheath.com>
 Jamie Cuthill <jamie.cuthill@gmail.com>
 Adrian Casajus <adriancasajus@gmail.com>
 John Weldon <johnweldon4@gmail.com>
+Adrien Bustany <adrien@bustany.org>

--- a/session.go
+++ b/session.go
@@ -609,10 +609,18 @@ func (q *Query) Exec() error {
 	return iter.err
 }
 
+func isUseStatement(stmt string) bool {
+	if len(stmt) < 3 {
+		return false
+	}
+
+	return strings.ToLower(stmt[0:3]) == "use"
+}
+
 // Iter executes the query and returns an iterator capable of iterating
 // over all results.
 func (q *Query) Iter() *Iter {
-	if strings.Index(strings.ToLower(q.stmt), "use") == 0 {
+	if isUseStatement(q.stmt) {
 		return &Iter{err: ErrUseStmt}
 	}
 	return q.session.executeQuery(q)


### PR DESCRIPTION
Benchmark results for a 80 character statement that does not start with
'use':

Before: 1927 ns/op   192 B/op   2 allocs/op
After:  142 ns/op      6 B/op   2 allocs/op