### PR TITLE
Expose page state

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -640,7 +640,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 			rows: x.rows,
 		}
 
-		if len(x.meta.pagingState) > 0 {
+		if len(x.meta.pagingState) > 0 && !qry.disableAutoPage {
 			iter.next = &nextIter{
 				qry: *qry,
 				pos: int((1 - qry.prefetch) * float64(len(iter.rows))),

--- a/session.go
+++ b/session.go
@@ -432,6 +432,8 @@ type Query struct {
 	totalLatency     int64
 	serialCons       SerialConsistency
 	defaultTimestamp bool
+
+	disableAutoPage bool
 }
 
 // String implements the stringer interface.
@@ -608,6 +610,15 @@ func (q *Query) Bind(v ...interface{}) *Query {
 // conditional update/insert.
 func (q *Query) SerialConsistency(cons SerialConsistency) *Query {
 	q.serialCons = cons
+	return q
+}
+
+// PageState sets the paging state for the query to resume paging from a specific
+// point in time. Setting this will disable to query paging for this query, and
+// must be used for all subsequent pages.
+func (q *Query) PageState(state []byte) *Query {
+	q.pageState = state
+	q.disableAutoPage = true
 	return q
 }
 
@@ -789,6 +800,12 @@ func (iter *Iter) checkErrAndNotFound() error {
 		return ErrNotFound
 	}
 	return nil
+}
+
+// PageState return the current paging state for a query which can be used for
+// subsequent quries to resume paging this point.
+func (iter *Iter) PageState() []byte {
+	return iter.meta.pagingState
 }
 
 type nextIter struct {


### PR DESCRIPTION
Exposes PageState on the Iter which can then be used to create a new Query which will page from a specific point, disabling automatic page fetching.

Fixes #400
