### PR TITLE
Add support for "LexicalUUIDType".

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -83,7 +83,7 @@ func getApacheCassandraType(class string) Type {
 		return TypeInt
 	case "DateType", "TimestampType":
 		return TypeTimestamp
-	case "UUIDType":
+	case "UUIDType", "LexicalUUIDType":
 		return TypeUUID
 	case "UTF8Type":
 		return TypeVarchar


### PR DESCRIPTION
Support it by treating it the same as UUIDType.

AFAIK originally there was LexicalUUIDType and TimeUUIDType. Lexical did
simple byte-wise comparison, where Time sorted using the UUID's time
value. UUIDType was added as a convenience type (CASSANDRA-2233) which
compares using the time value for time UUIDs, else byte-wise.
LexicalUUIDType was deprecated but not removed. We still have some
schema around explicitly using the LexicalUUIDType comparator.