### PR TITLE
add ParseConsistency() to frame.go

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,3 +55,4 @@ Adrian Casajus <adriancasajus@gmail.com>
 John Weldon <johnweldon4@gmail.com>
 Adrien Bustany <adrien@bustany.org>
 Andrey Smirnov <smirnov.andrey@gmail.com>
+Adam Weiner <adamsweiner@gmail.com>

--- a/frame.go
+++ b/frame.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -176,6 +177,31 @@ func (c Consistency) String() string {
 		return "LOCAL_ONE"
 	default:
 		return fmt.Sprintf("UNKNOWN_CONS_0x%x", uint16(c))
+	}
+}
+
+func ParseConsistency(s string) Consistency {
+	switch strings.ToUpper(s) {
+	case "ANY":
+		return Any
+	case "ONE":
+		return One
+	case "TWO":
+		return Two
+	case "THREE":
+		return Three
+	case "QUORUM":
+		return Quorum
+	case "ALL":
+		return All
+	case "LOCAL_QUORUM":
+		return LocalQuorum
+	case "EACH_QUORUM":
+		return EachQuorum
+	case "LOCAL_ONE":
+		return LocalOne
+	default:
+		panic("invalid consistency: " + s)
 	}
 }
 


### PR DESCRIPTION
Added a function to frame.go that takes a string representation of a Cassandra consistency level and returns the proper gocql constant. If an unrecognized string is provided, it defaults to ALL - when in doubt provide the highest consistency level.

One use case would be when reading the desired Cassandra consistency level from a configuration file.