### PR TITLE
Add ExecuteBatchCAS and MapExecuteBatchCAS functions for using batches with LWT. Fixes #453

### DIFF
--- a/session.go
+++ b/session.go
@@ -372,22 +372,21 @@ func (s *Session) routingKeyInfo(stmt string) (*routingKeyInfo, error) {
 	return routingKeyInfo, nil
 }
 
-// ExecuteBatch executes a batch operation and returns nil if successful
-// otherwise an error is returned describing the failure.
-func (s *Session) ExecuteBatch(batch *Batch) error {
+func (s *Session) executeBatch(batch *Batch) (*Iter, error) {
 	// fail fast
 	if s.Closed() {
-		return ErrSessionClosed
+		return nil, ErrSessionClosed
 	}
 
 	// Prevent the execution of the batch if greater than the limit
 	// Currently batches have a limit of 65536 queries.
 	// https://datastax-oss.atlassian.net/browse/JAVA-229
 	if batch.Size() > BatchSizeMaximum {
-		return ErrTooManyStmts
+		return nil, ErrTooManyStmts
 	}
 
 	var err error
+	var iter *Iter
 	batch.attempts = 0
 	batch.totalLatency = 0
 	for {
@@ -399,12 +398,12 @@ func (s *Session) ExecuteBatch(batch *Batch) error {
 			break
 		}
 		t := time.Now()
-		err = conn.executeBatch(batch)
+		iter, err = conn.executeBatch(batch)
 		batch.totalLatency += time.Now().Sub(t).Nanoseconds()
 		batch.attempts++
 		//Exit loop if operation executed correctly
 		if err == nil {
-			return nil
+			return iter, err
 		}
 
 		if batch.rt == nil || !batch.rt.Attempt(batch) {
@@ -412,7 +411,57 @@ func (s *Session) ExecuteBatch(batch *Batch) error {
 		}
 	}
 
+	return nil, err
+}
+
+// ExecuteBatch executes a batch operation and returns nil if successful
+// otherwise an error is returned describing the failure.
+func (s *Session) ExecuteBatch(batch *Batch) error {
+	_, err := s.executeBatch(batch)
 	return err
+}
+
+// ExecuteBatchCAS executes a batch operation and returns nil if successful and
+// an iterator (to scan aditional rows if more than one conditional statement)
+// was sent, otherwise an error is returned describing the failure.
+// Further scans on the interator must also remember to include
+// the applied boolean as the first argument to *Iter.Scan
+func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bool, iter *Iter, err error) {
+	if iter, err := s.executeBatch(batch); err == nil {
+		if err := iter.checkErrAndNotFound(); err != nil {
+			return false, nil, err
+		}
+		if len(iter.Columns()) > 1 {
+			dest = append([]interface{}{&applied}, dest...)
+			iter.Scan(dest...)
+		} else {
+			iter.Scan(&applied)
+		}
+		return applied, iter, nil
+	} else {
+		return false, nil, err
+	}
+}
+
+// MapExecuteBatchCAS executes a batch operation much like ExecuteBatchCAS,
+// however it accepts a map rather than a list of arguments for the initial
+// scan.
+func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) (applied bool, iter *Iter, err error) {
+	if iter, err := s.executeBatch(batch); err == nil {
+		if err := iter.checkErrAndNotFound(); err != nil {
+			return false, nil, err
+		}
+		iter.MapScan(dest)
+		applied = dest["[applied]"].(bool)
+		delete(dest, "[applied]")
+
+		// we usually close here, but instead of closing, just returin an error
+		// if MapScan failed. Although Close just returns err, using Close
+		// here might be confusing as we are not actually closing the iter
+		return applied, iter, iter.err
+	} else {
+		return false, nil, err
+	}
 }
 
 // Query represents a CQL statement that can be executed.


### PR DESCRIPTION
I quickly put this together thinking I would need something like ExecuteBatchCAS, and while in the middle of writing the tests, I realized it wouldn't work for the use case I had imagined. 

In any case, this PR adds two functions, `ExecuteBatchCAS` and `MapExecuteBatchCAS`. They function like `ScanCAS`, except they also return an `*Iter` allowing you to read more rows if needed. The `[applied]` column is taken care of in the first function call, but further calls to `.Scan` need to take care of the `applied` column. 

Potentially what we could also do is add a `.ScanCAS` helper function on `*Iter`. What do you guys think?