### PR TITLE
Set rpc_address for discovered hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Adrien Bustany <adrien@bustany.org>
 Andrey Smirnov <smirnov.andrey@gmail.com>
 Adam Weiner <adamsweiner@gmail.com>
 Daniel Cannon <daniel@danielcannon.co.uk>
+Johnny Bergström <johnny@joonix.se>

--- a/host_source.go
+++ b/host_source.go
@@ -98,7 +98,7 @@ func (r *ringDescriber) GetHosts() (hosts []HostInfo, partitioner string, err er
 
 	hosts = []HostInfo{localHost}
 
-	iter := r.session.control.query("SELECT peer, data_center, rack, host_id, tokens FROM system.peers")
+	iter := r.session.control.query("SELECT rpc_address, data_center, rack, host_id, tokens FROM system.peers")
 	if iter == nil {
 		return r.prevHosts, r.prevPartitioner, nil
 	}


### PR DESCRIPTION
According to [documentation](http://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html?scroll=reference_ds_qfg_n1r_1k__start_native_transport), the rpc_address is what should be used
for native transport. We should not use the peer address as the code currently suggest (listen address).