### PR TITLE
Connection pool deadlock / invalid discovery rpc address

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -35,7 +35,7 @@ type ringDescriber struct {
 }
 
 func checkSystemLocal(control *controlConn) (bool, error) {
-	iter := control.query("SELECT rpc_address FROM system.local")
+	iter := control.query("SELECT broadcast_address FROM system.local")
 	if err := iter.err; err != nil {
 		if errf, ok := err.(*errorFrame); ok {
 			if errf.code == errSyntax {
@@ -58,7 +58,7 @@ func (r *ringDescriber) GetHosts() (hosts []HostInfo, partitioner string, err er
 	const (
 		legacyLocalQuery = "SELECT data_center, rack, host_id, tokens, partitioner FROM system.local"
 		// only supported in 2.2.0, 2.1.6, 2.0.16
-		localQuery = "SELECT rpc_address, data_center, rack, host_id, tokens, partitioner FROM system.local"
+		localQuery = "SELECT broadcast_address, data_center, rack, host_id, tokens, partitioner FROM system.local"
 	)
 
 	var localHost HostInfo

--- a/policies.go
+++ b/policies.go
@@ -94,11 +94,11 @@ func (r *roundRobinHostPolicy) SetPartitioner(partitioner string) {
 func (r *roundRobinHostPolicy) Pick(qry *Query) NextHost {
 	// i is used to limit the number of attempts to find a host
 	// to the number of hosts known to this policy
-	var i uint32 = 0
+	var i uint32
 	return func() SelectedHost {
 		r.mu.RLock()
+		defer r.mu.RUnlock()
 		if len(r.hosts) == 0 {
-			r.mu.RUnlock()
 			return nil
 		}
 
@@ -110,7 +110,6 @@ func (r *roundRobinHostPolicy) Pick(qry *Query) NextHost {
 			host = &r.hosts[(pos)%uint32(len(r.hosts))]
 			i++
 		}
-		r.mu.RUnlock()
 		return selectedRoundRobinHost{host}
 	}
 }


### PR DESCRIPTION
- Using broadcast address instead of rpc adress (which might not be unicast IP for client connections)
- Small refactoring of mutex locking

From [Cassandra docs](http://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html?scroll=reference_ds_qfg_n1r_1k__broadcast_rpc_address):
```
RPC (remote procedure call) settings

Settings for configuring and tuning client connections.

broadcast_rpc_address 
    (Default: unset)note RPC address to broadcast to drivers and other Cassandra nodes. This cannot be set to 0.0.0.0. If blank, it is set to the value of the rpc_address or rpc_interface. If rpc_address or rpc_interfaceis set to 0.0.0.0, this property must be set. 
```

Fixes #509