### PR TITLE
Refresh ring only if DiscoverHosts is true in control connection

### DIFF
--- a/control.go
+++ b/control.go
@@ -103,7 +103,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 		oldConn.Close()
 	}
 
-	if refreshring {
+	if refreshring && c.session.cfg.DiscoverHosts {
 		c.session.hostSource.refreshRing()
 	}
 }


### PR DESCRIPTION
This prevents a panic on calling a `nil` `ringDescriber` when you call `refreshRing`.