### PR TITLE
Correctly handle missing UDT fields in Marshal

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -1579,25 +1579,22 @@ func (f *framer) writeByte(b byte) {
 	f.wbuf = append(f.wbuf, b)
 }
 
-// these are protocol level binary types
-func (f *framer) writeInt(n int32) {
-	f.wbuf = append(f.wbuf,
-		byte(n>>24),
+func appendShort(p []byte, n uint16) []byte {
+	return append(p,
+		byte(n>>8),
+		byte(n),
+	)
+}
+
+func appendInt(p []byte, n int32) []byte {
+	return append(p, byte(n>>24),
 		byte(n>>16),
 		byte(n>>8),
-		byte(n),
-	)
+		byte(n))
 }
 
-func (f *framer) writeShort(n uint16) {
-	f.wbuf = append(f.wbuf,
-		byte(n>>8),
-		byte(n),
-	)
-}
-
-func (f *framer) writeLong(n int64) {
-	f.wbuf = append(f.wbuf,
+func appendLong(p []byte, n int64) []byte {
+	return append(p,
 		byte(n>>56),
 		byte(n>>48),
 		byte(n>>40),
@@ -1607,6 +1604,19 @@ func (f *framer) writeLong(n int64) {
 		byte(n>>8),
 		byte(n),
 	)
+}
+
+// these are protocol level binary types
+func (f *framer) writeInt(n int32) {
+	f.wbuf = appendInt(f.wbuf, n)
+}
+
+func (f *framer) writeShort(n uint16) {
+	f.wbuf = appendShort(f.wbuf, n)
+}
+
+func (f *framer) writeLong(n int64) {
+	f.wbuf = appendLong(f.wbuf, n)
 }
 
 func (f *framer) writeString(s string) {

--- a/marshal.go
+++ b/marshal.go
@@ -1290,11 +1290,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 			}
 
 			n := len(data)
-			buf = append(buf, byte(n>>24),
-				byte(n>>16),
-				byte(n>>8),
-				byte(n))
-
+			buf = appendInt(buf, int32(n))
 			buf = append(buf, data...)
 		}
 
@@ -1313,11 +1309,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 			}
 
 			n := len(data)
-			buf = append(buf, byte(n>>24),
-				byte(n>>16),
-				byte(n>>8),
-				byte(n))
-
+			buf = appendInt(buf, int32(n))
 			buf = append(buf, data...)
 		}
 
@@ -1354,14 +1346,13 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 
 		if !f.IsValid() {
-			return nil, marshalErrorf("cannot marshal %T into %s", value, info)
+			n := -1
+			buf = appendInt(buf, int32(n))
+			continue
 		} else if f.Kind() == reflect.Ptr {
 			if f.IsNil() {
 				n := -1
-				buf = append(buf, byte(n>>24),
-					byte(n>>16),
-					byte(n>>8),
-					byte(n))
+				buf = appendInt(buf, int32(n))
 				continue
 			} else {
 				f = f.Elem()
@@ -1374,11 +1365,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 
 		n := len(data)
-		buf = append(buf, byte(n>>24),
-			byte(n>>16),
-			byte(n>>8),
-			byte(n))
-
+		buf = appendInt(buf, int32(n))
 		buf = append(buf, data...)
 	}
 


### PR DESCRIPTION
When we receive a struct which does not have all the fields for
that UDT then we should encode them as missing values, null on
the wire.

Fixes #515