### PR TITLE
conn: dont mutate the conn config

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -160,18 +160,19 @@ func Connect(addr string, cfg *ConnConfig, errorHandler ConnErrorHandler, sessio
 		headerSize = 9
 	}
 
-	if cfg.NumStreams <= 0 || cfg.NumStreams >= maxStreams {
-		cfg.NumStreams = maxStreams
+	streams := cfg.NumStreams
+	if streams <= 0 || streams >= maxStreams {
+		streams = maxStreams
 	} else {
-		cfg.NumStreams++
+		streams++
 	}
 
 	c := &Conn{
 		conn:         conn,
 		r:            bufio.NewReader(conn),
 		cfg:          cfg,
-		uniq:         make(chan int, cfg.NumStreams),
-		calls:        make([]callReq, cfg.NumStreams),
+		uniq:         make(chan int, streams),
+		calls:        make([]callReq, streams),
 		timeout:      cfg.Timeout,
 		version:      uint8(cfg.ProtoVersion),
 		addr:         conn.RemoteAddr().String(),
@@ -189,7 +190,7 @@ func Connect(addr string, cfg *ConnConfig, errorHandler ConnErrorHandler, sessio
 
 	// reserve stream 0 incase cassandra returns an error on it without us sending
 	// a request.
-	for i := 1; i < cfg.NumStreams; i++ {
+	for i := 1; i < streams; i++ {
 		c.calls[i].resp = make(chan error)
 		c.uniq <- i
 	}


### PR DESCRIPTION
The conn config is shared by the connection pool.

Updates #519