### PR TITLE
marshal: handle nil collection correctly in udts

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -106,6 +106,15 @@ func getApacheCassandraType(class string) Type {
 	}
 }
 
+func typeCanBeNull(typ TypeInfo) bool {
+	switch typ.(type) {
+	case CollectionType, UDTTypeInfo, TupleTypeInfo:
+		return false
+	}
+
+	return true
+}
+
 func (r *RowData) rowMap(m map[string]interface{}) {
 	for i, column := range r.Columns {
 		val := dereference(r.Values[i])

--- a/marshal.go
+++ b/marshal.go
@@ -1285,9 +1285,12 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 				return nil, err
 			}
 
-			n := len(data)
-			buf = appendInt(buf, int32(n))
-			buf = append(buf, data...)
+			if data == nil && typeCanBeNull(e.Type) {
+				buf = appendInt(buf, -1)
+			} else {
+				buf = appendInt(buf, int32(len(data)))
+				buf = append(buf, data...)
+			}
 		}
 
 		return buf, nil
@@ -1304,9 +1307,12 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 				return nil, err
 			}
 
-			n := len(data)
-			buf = appendInt(buf, int32(n))
-			buf = append(buf, data...)
+			if data == nil && typeCanBeNull(e.Type) {
+				buf = appendInt(buf, -1)
+			} else {
+				buf = appendInt(buf, int32(len(data)))
+				buf = append(buf, data...)
+			}
 		}
 
 		return buf, nil
@@ -1342,8 +1348,12 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 
 		if !f.IsValid() {
-			buf = appendInt(buf, -1)
-			continue
+			if _, ok := e.Type.(CollectionType); ok {
+				f = reflect.Zero(goType(e.Type))
+			} else {
+				buf = appendInt(buf, -1)
+				continue
+			}
 		} else if f.Kind() == reflect.Ptr {
 			if f.IsNil() {
 				buf = appendInt(buf, -1)
@@ -1358,9 +1368,12 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, err
 		}
 
-		n := len(data)
-		buf = appendInt(buf, int32(n))
-		buf = append(buf, data...)
+		if data == nil && typeCanBeNull(e.Type) {
+			buf = appendInt(buf, -1)
+		} else {
+			buf = appendInt(buf, int32(len(data)))
+			buf = append(buf, data...)
+		}
 	}
 
 	return buf, nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -257,8 +257,8 @@ var marshalTests = []struct {
 			NativeType: NativeType{proto: 2, typ: TypeSet},
 			Elem:       NativeType{proto: 2, typ: TypeInt},
 		},
-		[]byte(nil),
-		[]int(nil),
+		[]byte{0, 0}, // encoding of a list should always include the size of the collection
+		[]int{},
 	},
 	{
 		CollectionType{
@@ -275,8 +275,8 @@ var marshalTests = []struct {
 			Key:        NativeType{proto: 2, typ: TypeVarchar},
 			Elem:       NativeType{proto: 2, typ: TypeInt},
 		},
-		[]byte(nil),
-		map[string]int(nil),
+		[]byte{0, 0},
+		map[string]int{},
 	},
 	{
 		CollectionType{


### PR DESCRIPTION
When a UDT has a missing value or a nil value for a collection
we should correctly encode it as a collection with 0 elements not
as a null value.

Fixes #518