### PR TITLE
marshal: handle alias type of int correctly.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -297,12 +297,7 @@ func marshalInt(info TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
-	rv := reflect.ValueOf(value)
-	if rv.IsNil() {
-		return nil, nil
-	}
-
-	switch rv.Type().Kind() {
+	switch rv := reflect.ValueOf(value); rv.Type().Kind() {
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
 		v := rv.Int()
 		if v > math.MaxInt32 || v < math.MinInt32 {
@@ -315,7 +310,12 @@ func marshalInt(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("marshal int: value %d out of range", v)
 		}
 		return encInt(int32(v)), nil
+	default:
+		if rv.IsNil() {
+			return nil, nil
+		}
 	}
+
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/inf.v0"
 )
 
+type AliasInt int
+
 var marshalTests = []struct {
 	Info  TypeInfo
 	Data  []byte
@@ -72,6 +74,11 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeInt},
 		[]byte("\x01\x02\x03\x04"),
 		int(16909060),
+	},
+	{
+		NativeType{proto: 2, typ: TypeInt},
+		[]byte("\x01\x02\x03\x04"),
+		AliasInt(16909060),
 	},
 	{
 		NativeType{proto: 2, typ: TypeInt},


### PR DESCRIPTION
gocql panics when I marshal a custom type that aliases for int like this ` type EnumFoo int`.

```
2015/11/09 19:50:03 http: panic serving 127.0.0.1:38775: reflect: call of reflect.Value.IsNil on int Value
goroutine 35 [running]:
net/http.(*conn).serve.func1(0xc8200fc580, 0x7f90518dc898, 0xc820124128)
        /usr/local/go/src/net/http/server.go:1287 +0xb5
reflect.Value.IsNil(0x7e7420, 0xc82011c430, 0x42, 0xc82011c430)
        /usr/local/go/src/reflect/value.go:971 +0xe3
github.com/gocql/gocql.marshalInt(0x7f90518eab18, 0xc821574960, 0x7e7420, 0xc82011c430, 0x0, 0x0, 0x0, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/marshal.go:301 +0x5f9
github.com/gocql/gocql.Marshal(0x7f90518eab18, 0xc821574960, 0x7e7420, 0xc82011c430, 0x0, 0x0, 0x0, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/marshal.go:70 +0x9b0
github.com/gocql/gocql.Marshal(0x7f90518eab18, 0xc821574960, 0x7c5200, 0xc820082978, 0x0, 0x0, 0x0, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/marshal.go:56 +0x30f
github.com/gocql/gocql.(*Conn).executeBatch(0xc8200cc000, 0xc820129090, 0xbba880, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/conn.go:827 +0xe9f
github.com/gocql/gocql.(*Session).executeBatch(0xc820182000, 0xc820129090, 0xc82011b7a0, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/session.go:437 +0x1ad
github.com/gocql/gocql.(*Session).ExecuteBatch(0xc820182000, 0xc820129090, 0x0, 0x0)
        (...)/go/src/github.com/gocql/gocql/session.go:460 +0x37
(...)
```

I found that #521 call of IsNil on EnumFoo and panic because they are not able to catch bye `value.(int)`.

Could you please review this PR?