### PR TITLE
control: align atomic variable to 64bit boundary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Adam Weiner <adamsweiner@gmail.com>
 Daniel Cannon <daniel@danielcannon.co.uk>
 Johnny Bergström <johnny@joonix.se>
 Adriano Orioli <orioli.adriano@gmail.com>
+Claudiu Raveica <claudiu.raveica@gmail.com>

--- a/control.go
+++ b/control.go
@@ -8,10 +8,11 @@ import (
 )
 
 type controlConn struct {
+	connecting uint64
+
 	session *Session
 
 	conn       atomic.Value
-	connecting uint64
 
 	retry RetryPolicy
 

--- a/control.go
+++ b/control.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// Ensure that the atomic variable is aligned to a 64bit boundary 
+// so that atomic operations can be applied on 32bit architectures.
 type controlConn struct {
 	connecting uint64
 


### PR DESCRIPTION
Ensure that the atomic variable is aligned to a 64bit boundary so that atomic operations can be applied on 32bit architectures.

Fixes #542 