### PR TITLE
correctly handle tuples in MapScan

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -336,8 +336,8 @@ func TestCAS(t *testing.T) {
 	}
 
 	if _, err := session.Query(`DELETE FROM cas_table WHERE title = ? and revid = ? IF last_modified = ?`,
-		title, revid, tenSecondsLater).ScanCAS(); err.Error() != "count mismatch" {
-		t.Fatalf("delete: was expecting count mismatch error but got %s", err)
+		title, revid, tenSecondsLater).ScanCAS(); !strings.HasPrefix(err.Error(), "gocql: not enough columns to scan into") {
+		t.Fatal("delete: was expecting count mismatch error but got: %q", err.Error())
 	}
 
 	if applied, err := session.Query(`DELETE FROM cas_table WHERE title = ? and revid = ? IF last_modified = ?`,

--- a/marshal.go
+++ b/marshal.go
@@ -1616,6 +1616,10 @@ type TupleTypeInfo struct {
 	Elems []TypeInfo
 }
 
+func (t TupleTypeInfo) New() interface{} {
+	return reflect.New(goType(t)).Interface()
+}
+
 type UDTField struct {
 	Name string
 	Type TypeInfo
@@ -1626,6 +1630,10 @@ type UDTTypeInfo struct {
 	KeySpace string
 	Name     string
 	Elements []UDTField
+}
+
+func (u UDTTypeInfo) New() interface{} {
+	return reflect.New(goType(u)).Interface()
 }
 
 func (u UDTTypeInfo) String() string {

--- a/session.go
+++ b/session.go
@@ -834,7 +834,7 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 	// currently only support scanning into an expand tuple, such that its the same
 	// as scanning in more values from a single column
 	if len(dest) != iter.meta.actualColCount {
-		iter.err = errors.New("count mismatch")
+		iter.err = fmt.Errorf("gocql: not enough columns to scan into: have %d want %d", len(dest), iter.meta.actualColCount)
 		return false
 	}
 

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -49,3 +49,31 @@ func TestTupleSimple(t *testing.T) {
 		t.Errorf("expected to get coord.y=-100 got: %v", coord.y)
 	}
 }
+
+func TestTupleMapScan(t *testing.T) {
+	if *flagProto < protoVersion3 {
+		t.Skip("tuple types are only available of proto>=3")
+	}
+
+	session := createSession(t)
+	defer session.Close()
+
+	err := createTable(session, `CREATE TABLE gocql_test.tuple_map_scan(
+		id int,
+		val frozen<tuple<int, int>>,
+
+		primary key(id))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Query(`INSERT INTO tuple_map_scan (id, val) VALUES (1, (1, 2));`).Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	m := make(map[string]interface{})
+	err = session.Query(`SELECT * FROM tuple_map_scan`).MapScan(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Tuples are handled specially in Scan and as such each element in the
tuple must be treated as a single column. MapScan now generates one
element in the map for each element in the tuple, these can be accessed
by name using the new TupleColumnName function.

fixes #561