### PR TITLE
marshal: dont reuse the bytes for inets

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1216,7 +1216,11 @@ func unmarshalInet(info TypeInfo, data []byte, value interface{}) error {
 	case Unmarshaler:
 		return v.UnmarshalCQL(info, data)
 	case *net.IP:
-		ip := net.IP(data)
+		if x := len(data); !(x == 4 || x == 16) {
+			return unmarshalErrorf("cannot unmarshal %s into %T: invalid sized IP: got %d bytes not 4 or 16", info, value, x)
+		}
+		buf := copyBytes(data)
+		ip := net.IP(buf)
 		if v4 := ip.To4(); v4 != nil {
 			*v = v4
 			return nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -933,3 +933,17 @@ func TestMarshalNil(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshalInetCopyBytes(t *testing.T) {
+	data := []byte{127, 0, 0, 1}
+	var ip net.IP
+	if err := unmarshalInet(NativeType{proto: 2, typ: TypeInet}, data, &ip); err != nil {
+		t.Fatal(err)
+	}
+
+	copy(data, []byte{0xFF, 0xFF, 0xFF, 0xFF})
+	ip2 := net.IP(data)
+	if !ip.Equal(net.IPv4(127, 0, 0, 1)) {
+		t.Fatalf("IP memory shared with data: ip=%v ip2=%v", ip, ip2)
+	}
+}


### PR DESCRIPTION
As the underlying framer buf is reused between requests the marshaller
must copy the bytes to prevent data corruption.

fixes #567