### PR TITLE
DSE reports >3 elements in the version string

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -32,7 +32,7 @@ type cassVersion struct {
 func (c *cassVersion) UnmarshalCQL(info TypeInfo, data []byte) error {
 	version := strings.TrimSuffix(string(data), "-SNAPSHOT")
 	v := strings.Split(version, ".")
-	if len(v) != 3 {
+	if len(v) < 3 {
 		return fmt.Errorf("invalid schema_version: %v", string(data))
 	}
 


### PR DESCRIPTION
When using this driver with the DataStax edition of Cassandra the connect bombs out after the most recent version validation change (was working as of 2 days ago).  This just allows for extra sections in the version string (which should work for DSE and OSS Cassandra).