### PR TITLE
Fix Unlock of unlocked RWMutex when removing a host from a host policy

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -450,7 +450,7 @@ func (r *hostPoolHostPolicy) AddHost(host *HostInfo) {
 }
 
 func (r *hostPoolHostPolicy) RemoveHost(addr string) {
-	r.mu.Unlock()
+	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if _, ok := r.hostMap[addr]; !ok {


### PR DESCRIPTION
I'm guessing this is a typo - we're calling `Unlock`, then defering another `Unlock`, which results in the following panic:

```panic: sync: Unlock of unlocked RWMutex```
