### PR TITLE
Concurrent connect to hosts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,4 @@ Adriano Orioli <orioli.adriano@gmail.com>
 Claudiu Raveica <claudiu.raveica@gmail.com>
 Artem Chernyshev <artem.0xD2@gmail.com>
 Ference Fu <fym201@msn.com>
+LOVOO <opensource@lovoo.com>


### PR DESCRIPTION
Currently, if a new cluster should be created all pools and connections are created in sequence which can take a few seconds in a big cluster. This PR implements concurrent pool creation which speedup cluster initialization.