### PR TITLE
prepared INSERT JSON only works once

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2118,6 +2118,11 @@ func TestJSONSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = session.Query("INSERT INTO test_json JSON ?", `{"id": "user1234", "age": 43, "state": "CA"}`).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	var (
 		id    string
 		age   int
@@ -2137,6 +2142,20 @@ func TestJSONSupport(t *testing.T) {
 	}
 	if state != "TX" {
 		t.Errorf("got state %q expected %q", state, "TX")
+	}
+	err = session.Query("SELECT id, age, state FROM test_json WHERE id = ?", "user1234").Scan(&id, &age, &state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id != "user1234" {
+		t.Errorf("got id %q expected %q", id, "user1234")
+	}
+	if age != 43 {
+		t.Errorf("got age %d expected %d", age, 43)
+	}
+	if state != "CA" {
+		t.Errorf("got state %q expected %q", state, "CA")
 	}
 }
 


### PR DESCRIPTION
When inserting JSON via prepared statement only first insert is successful. The second insert fails silently without error. I modified the TestJSON function to make 2 inserts and verify both to test against this case. Tested to fail against cassandra 2.2.1. 

Seems to work in travis but tested locally in OSX and inside vagrant, both give:

go test -tags integration -v -proto 4 -run JSON
=== RUN   TestJSONSupport
2016/01/14 12:59:43 common_test.go:113: closing keyspace session
--- FAIL: TestJSONSupport (0.85s)
	cassandra_test.go:2148: not found
FAIL
exit status 1
FAIL	github.com/gocql/gocql	0.858s