### PR TITLE
Improve cassandra version parsing

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -31,10 +31,8 @@ type cassVersion struct {
 
 func (c *cassVersion) UnmarshalCQL(info TypeInfo, data []byte) error {
 	version := strings.TrimSuffix(string(data), "-SNAPSHOT")
+	version = strings.TrimPrefix(version, "v")
 	v := strings.Split(version, ".")
-	if len(v) < 3 {
-		return fmt.Errorf("invalid schema_version: %v", string(data))
-	}
 
 	var err error
 	c.Major, err = strconv.Atoi(v[0])
@@ -47,9 +45,11 @@ func (c *cassVersion) UnmarshalCQL(info TypeInfo, data []byte) error {
 		return fmt.Errorf("invalid minor version %v: %v", v[1], err)
 	}
 
-	c.Patch, err = strconv.Atoi(v[2])
-	if err != nil {
-		return fmt.Errorf("invalid patch version %v: %v", v[2], err)
+	if len(v) > 2 {
+		c.Patch, err = strconv.Atoi(v[2])
+		if err != nil {
+			return fmt.Errorf("invalid patch version %v: %v", v[2], err)
+		}
 	}
 
 	return nil

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -1,0 +1,23 @@
+package gocql
+
+import "testing"
+
+func TestUnmarshalCassVersion(t *testing.T) {
+	tests := [...]struct {
+		data    string
+		version cassVersion
+	}{
+		{"3.2", cassVersion{3, 2, 0}},
+		{"2.10.1-SNAPSHOT", cassVersion{2, 10, 1}},
+		{"1.2.3", cassVersion{1, 2, 3}},
+	}
+
+	for i, test := range tests {
+		v := &cassVersion{}
+		if err := v.UnmarshalCQL(nil, []byte(test.data)); err != nil {
+			t.Errorf("%d: %v", i, err)
+		} else if *v != test.version {
+			t.Errorf("%d: expected %#+v got %#+v", i, test.version, *v)
+		}
+	}
+}


### PR DESCRIPTION
Handle more casses of cassandra versions, be more lenient if we dont get
them all.

fixes #579