### PR TITLE
Add option to ignore cassandras reported address

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -126,6 +126,15 @@ type ClusterConfig struct {
 	// via Discovery
 	HostFilter HostFilter
 
+	// If IgnorePeerAddr is true and the address in system.peers does not match
+	// the supplied host by either initial hosts or discovered via events then the
+	// host will be replaced with the supplied address.
+	//
+	// For example if an event comes in with host=10.0.0.1 but when looking up that
+	// address in system.local or system.peers returns 127.0.0.1, the peer will be
+	// set to 10.0.0.1 which is what will be used to connect to.
+	IgnorePeerAddr bool
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/cluster.go
+++ b/cluster.go
@@ -135,6 +135,13 @@ type ClusterConfig struct {
 	// set to 10.0.0.1 which is what will be used to connect to.
 	IgnorePeerAddr bool
 
+	// If DisableInitialHostLookup then the driver will not attempt to get host info
+	// from the system.peers table, this will mean that the driver will connect to
+	// hosts supplied and will not attempt to lookup the hosts information, this will
+	// mean that data_centre, rack and token information will not be available and as
+	// such host filtering and token aware query routing will not be available.
+	DisableInitialHostLookup bool
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/events.go
+++ b/events.go
@@ -167,6 +167,11 @@ func (s *Session) handleNewNode(host net.IP, port int, waitForBinary bool) {
 		hostInfo = &HostInfo{peer: host.String(), port: port, state: NodeUp}
 	}
 
+	addr := host.String()
+	if s.cfg.IgnorePeerAddr && hostInfo.Peer() != addr {
+		hostInfo.setPeer(addr)
+	}
+
 	if s.cfg.HostFilter != nil {
 		if !s.cfg.HostFilter.Accept(hostInfo) {
 			return
@@ -216,6 +221,10 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 	addr := ip.String()
 	host := s.ring.getHost(addr)
 	if host != nil {
+		if s.cfg.IgnorePeerAddr && host.Peer() != addr {
+			host.setPeer(addr)
+		}
+
 		if s.cfg.HostFilter != nil {
 			if !s.cfg.HostFilter.Accept(host) {
 				return


### PR DESCRIPTION
Add IgnorePeerAddr to cluster config which when enabled will use the
supplied host address instead of the one which the driver discovers from
cassandra.

updates #575 