### PR TITLE
mark the selected host with the real batch response

### DIFF
--- a/session.go
+++ b/session.go
@@ -470,21 +470,21 @@ func (s *Session) executeBatch(batch *Batch) (*Iter, error) {
 		iter, err = conn.executeBatch(batch)
 		batch.totalLatency += time.Now().Sub(t).Nanoseconds()
 		batch.attempts++
-		//Exit loop if operation executed correctly
-		if err == nil {
-			host.Mark(err)
-			return iter, err
-		}
 
-		// Mark host as OK
-		host.Mark(nil)
+		// Update host
+		host.Mark(err)
+
+		// Exit loop if operation executed correctly
+		if err == nil {
+			break
+		}
 
 		if batch.rt == nil || !batch.rt.Attempt(batch) {
 			break
 		}
 	}
 
-	return nil, err
+	return iter, err
 }
 
 // ExecuteBatch executes a batch operation and returns nil if successful


### PR DESCRIPTION
There is the same issue with batch operation. Didn't see it in the previous PR. Would be good to create a follow up ticket to merge some logic into one function because executeQuery/executeBatch looks almost the same.