### PR TITLE
batch: return an iter containing an error like queries

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1068,7 +1068,7 @@ func TestReprepareBatch(t *testing.T) {
 	stmt, conn := injectInvalidPreparedStatement(t, session, "test_reprepare_statement_batch")
 	batch := session.NewBatch(UnloggedBatch)
 	batch.Query(stmt, "bar")
-	if _, err := conn.executeBatch(batch); err != nil {
+	if err := conn.executeBatch(batch).Close(); err != nil {
 		t.Fatalf("Failed to execute query for reprepare statement: %v", err)
 	}
 


### PR DESCRIPTION
To be consistent with queries batches should return an error inside and
iter instead of directly. To access to the error callers should use
iter.Close().

Updates #589 