### PR TITLE
control: handle no hosts in connection pool

### DIFF
--- a/session.go
+++ b/session.go
@@ -259,6 +259,10 @@ func (s *Session) Close() {
 	if s.nodeEvents != nil {
 		s.nodeEvents.stop()
 	}
+
+	if s.schemaEvents != nil {
+		s.schemaEvents.stop()
+	}
 }
 
 func (s *Session) Closed() bool {


### PR DESCRIPTION
When the control connection attempts to reconnect and there are no hosts
in the connection pool, fallback to trying the initial endpoints
shuffled again.

Set the host to up after the control connection connects to it.

Simplify control connection reconnecting logic, it is threadsafe as the
only method calling the connect methods is the heartbeater and the
inital connection attempt.

fixes #609