### PR TITLE
session: connection pool may be nil on close

### DIFF
--- a/session.go
+++ b/session.go
@@ -248,7 +248,9 @@ func (s *Session) Close() {
 	}
 	s.isClosed = true
 
-	s.pool.Close()
+	if s.pool != nil {
+		s.pool.Close()
+	}
 
 	if s.hostSource != nil {
 		close(s.hostSource.closeChan)


### PR DESCRIPTION
When the connConfig errors the connection pool will not be created,
check that it is not nil before closing it.