### PR TITLE
big uint64 unmarshalling fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,3 +63,4 @@ Claudiu Raveica <claudiu.raveica@gmail.com>
 Artem Chernyshev <artem.0xD2@gmail.com>
 Ference Fu <fym201@msn.com>
 LOVOO <opensource@lovoo.com>
+nikandfor <nikandfor@gmail.com>

--- a/marshal.go
+++ b/marshal.go
@@ -401,6 +401,13 @@ func bytesToInt64(data []byte) (ret int64) {
 	return ret
 }
 
+func bytesToUint64(data []byte) (ret uint64) {
+	for i := range data {
+		ret |= uint64(data[i]) << (8 * uint(len(data)-i-1))
+	}
+	return ret
+}
+
 func unmarshalBigInt(info TypeInfo, data []byte, value interface{}) error {
 	return unmarshalIntlike(info, decBigInt(data), data, value)
 }
@@ -410,9 +417,14 @@ func unmarshalInt(info TypeInfo, data []byte, value interface{}) error {
 }
 
 func unmarshalVarint(info TypeInfo, data []byte, value interface{}) error {
-	switch value.(type) {
+	switch v := value.(type) {
 	case *big.Int:
 		return unmarshalIntlike(info, 0, data, value)
+	case *uint64:
+		if len(data) == 9 && data[0] == 0 {
+			*v = bytesToUint64(data[1:])
+			return nil
+		}
 	}
 
 	if len(data) > 8 {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -723,7 +723,7 @@ func TestMarshalVarint(t *testing.T) {
 			t.Errorf("marshaled varint mismatch: expected %v, got %v (test #%d)", test.Marshaled, data, i)
 		}
 
-		binder := new(uint64)
+		var binder uint64
 		err = Unmarshal(NativeType{proto: 2, typ: TypeVarint}, test.Marshaled, &binder)
 		if err != nil {
 			t.Errorf("error unmarshaling varint: %v (test #%d)", err, i)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -713,7 +713,7 @@ func TestMarshalVarint(t *testing.T) {
 		},
 	}
 
-	for i, test := range varintTests {
+	for i, test := range varintUint64Tests {
 		data, err := Marshal(NativeType{proto: 2, typ: TypeVarint}, test.Value)
 		if err != nil {
 			t.Errorf("error marshaling varint: %v (test #%d)", err, i)
@@ -726,7 +726,7 @@ func TestMarshalVarint(t *testing.T) {
 		var binder uint64
 		err = Unmarshal(NativeType{proto: 2, typ: TypeVarint}, test.Marshaled, &binder)
 		if err != nil {
-			t.Errorf("error unmarshaling varint: %v (test #%d)", err, i)
+			t.Errorf("error unmarshaling varint to uint64: %v (test #%d)", err, i)
 		}
 
 		if test.Unmarshaled != binder {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -708,7 +708,7 @@ func TestMarshalVarint(t *testing.T) {
 		},
 		{
 			Value:       uint64(math.MaxUint64),
-			Marshaled:   []byte("\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
+			Marshaled:   []byte("\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"),
 			Unmarshaled: uint64(math.MaxUint64),
 		},
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -707,9 +707,9 @@ func TestMarshalVarint(t *testing.T) {
 			Unmarshaled: 9223372036854775808,
 		},
 		{
-			Value:       math.MaxUint64,
+			Value:       uint64(math.MaxUint64),
 			Marshaled:   []byte("\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
-			Unmarshaled: math.MaxUint64,
+			Unmarshaled: uint64(math.MaxUint64),
 		},
 	}
 
@@ -724,7 +724,7 @@ func TestMarshalVarint(t *testing.T) {
 		}
 
 		binder := new(uint64)
-		err = Unmarshal(NativeType{proto: 2, typ: TypeVarint}, test.Marshaled, binder)
+		err = Unmarshal(NativeType{proto: 2, typ: TypeVarint}, test.Marshaled, &binder)
 		if err != nil {
 			t.Errorf("error unmarshaling varint: %v (test #%d)", err, i)
 		}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -675,6 +675,64 @@ func TestMarshalVarint(t *testing.T) {
 			t.Errorf("unmarshaled varint mismatch: expected %v, got %v (test #%d)", test.Unmarshaled, binder, i)
 		}
 	}
+
+	varintUint64Tests := []struct {
+		Value       interface{}
+		Marshaled   []byte
+		Unmarshaled uint64
+	}{
+		{
+			Value:       int8(0),
+			Marshaled:   []byte("\x00"),
+			Unmarshaled: 0,
+		},
+		{
+			Value:       uint8(255),
+			Marshaled:   []byte("\x00\xFF"),
+			Unmarshaled: 255,
+		},
+		{
+			Value:       big.NewInt(math.MaxInt32),
+			Marshaled:   []byte("\x7F\xFF\xFF\xFF"),
+			Unmarshaled: uint64(math.MaxInt32),
+		},
+		{
+			Value:       big.NewInt(int64(math.MaxInt32) + 1),
+			Marshaled:   []byte("\x00\x80\x00\x00\x00"),
+			Unmarshaled: uint64(int64(math.MaxInt32) + 1),
+		},
+		{
+			Value:       uint64(math.MaxInt64) + 1,
+			Marshaled:   []byte("\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
+			Unmarshaled: 9223372036854775808,
+		},
+		{
+			Value:       math.MaxUint64,
+			Marshaled:   []byte("\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
+			Unmarshaled: math.MaxUint64,
+		},
+	}
+
+	for i, test := range varintTests {
+		data, err := Marshal(NativeType{proto: 2, typ: TypeVarint}, test.Value)
+		if err != nil {
+			t.Errorf("error marshaling varint: %v (test #%d)", err, i)
+		}
+
+		if !bytes.Equal(test.Marshaled, data) {
+			t.Errorf("marshaled varint mismatch: expected %v, got %v (test #%d)", test.Marshaled, data, i)
+		}
+
+		binder := new(uint64)
+		err = Unmarshal(NativeType{proto: 2, typ: TypeVarint}, test.Marshaled, binder)
+		if err != nil {
+			t.Errorf("error unmarshaling varint: %v (test #%d)", err, i)
+		}
+
+		if test.Unmarshaled != binder {
+			t.Errorf("unmarshaled varint mismatch: expected %v, got %v (test #%d)", test.Unmarshaled, binder, i)
+		}
+	}
 }
 
 func equalStringSlice(leftList, rightList []string) bool {


### PR DESCRIPTION
Decode `varint` to `uint64` variable in case when it greater then `MaxInt64` and less then `MaxUint64`