### PR TITLE
query: add NoSkipMetadata option

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -720,7 +720,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 			// TODO: handle query binding names
 		}
 
-		params.skipMeta = !qry.isCAS
+		params.skipMeta = !qry.disableSkipMetadata
 
 		frame = &writeExecuteFrame{
 			preparedID: info.id,


### PR DESCRIPTION
NoSkipMetadata will disable reusing the preapred result metadata when
parsing the query. To work around a bug in Cassandra.

Updates #612 