### PR TITLE
Fix a panic that could happen when using the TokenAwareHostPolicy

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -370,7 +370,7 @@ func (t *tokenAwareHostPolicy) Pick(qry *Query) NextHost {
 		fallbackHost := fallbackIter()
 
 		// filter the token aware selected hosts from the fallback hosts
-		if fallbackHost.Info() == host {
+		if fallbackHost != nil && fallbackHost.Info() == host {
 			fallbackHost = fallbackIter()
 		}
 


### PR DESCRIPTION
This was due to that the fallbackHost could be nil but was still accessed to check if the host was the same as the filtered. The behaviour is now similar to the round robin version.

Should fix #544.