### PR TITLE
Fix token aware metadata fetching deadlock.

### DIFF
--- a/control.go
+++ b/control.go
@@ -292,7 +292,7 @@ func (c *controlConn) withConn(fn func(*Conn) *Iter) *Iter {
 
 // query will return nil if the connection is closed or nil
 func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter) {
-	q := c.session.Query(statement, values...).Consistency(One)
+	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{})
 
 	for {
 		iter = c.withConn(func(conn *Conn) *Iter {


### PR DESCRIPTION
The token aware host policy needs to fetch schema metadata so it can
hash row keys properly. Before the internal "control" conn was added,
metadata.go would set Query().RoutingKey([]byte{}) before it performed
the metadata queries so the metadata queries themselves didn't re-enter
the token aware host selection code (and deadlock). The control conn
still works most of the time, though, because the control conn performs
queries directly on a conn object, bypassing the token aware selection
stuff. That is, unless there is more than one page of metadata, since
iter.next.fetch() executes the query via the session, which re-enters
the token aware host selection code.

Fix by setting RoutingKey to []byte{} on the control conn's
queries. This is the same tactic the old code was using to avoid this
problem.