### PR TITLE
Fix protocol v2 stream exhaustion.

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -538,12 +538,17 @@ func (r *roundRobinConnPolicy) Pick(qry *Query) *Conn {
 		return nil
 	}
 
+	var nextConn *Conn
+
 	for i := 0; i < len(r.conns); i++ {
 		conn := r.conns[(pos+i)%len(r.conns)]
 		if conn.AvailableStreams() > 0 {
 			return conn
+		} else if nextConn == nil {
+			nextConn = conn
 		}
 	}
 
-	return nil
+	// no streams available, fall back to plain round-robin
+	return nextConn
 }

--- a/policies_test.go
+++ b/policies_test.go
@@ -147,8 +147,8 @@ func TestHostPoolHostPolicy(t *testing.T) {
 func TestRoundRobinConnPolicy(t *testing.T) {
 	policy := RoundRobinConnPolicy()()
 
-	conn0 := &Conn{streams: streams.New(1)}
-	conn1 := &Conn{streams: streams.New(1)}
+	conn0 := &Conn{streams: streams.New(1, make(chan struct{}))}
+	conn1 := &Conn{streams: streams.New(1, make(chan struct{}))}
 	conn := []*Conn{
 		conn0,
 		conn1,


### PR DESCRIPTION
Protocol 2 only gets 128 streams per-connection, so it is easy to
exhaust all your streams if you have a lot of parallel
queries. Previously, gocql would wait for an available stream, but after
a refactoring of how stream allocation works, an error is returned
immediately if no stream is available. I made two change to address
this:

- change round robin connection policy to fall back to plain round robin
  logic if none of the connections have available streams (rather than
  returning nil and causing the client to get a mysterious "no
  connections available" error)
- change stream allocation to wait up to config.Timeout for an available
  stream. I tried to make it do timeout accounting
  properly (i.e. subtract stream wait time from available timeout for
  remainder of query)

Issue #658