### PR TITLE
Add support for Cassandra 3 system_schema metadata

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -62,6 +62,60 @@ func dereference(i interface{}) interface{} {
 	return reflect.Indirect(reflect.ValueOf(i)).Interface()
 }
 
+func getCassandraType(name string) Type {
+	switch name {
+	case "ascii":
+		return TypeAscii
+	case "bigint":
+		return TypeBigInt
+	case "blob":
+		return TypeBlob
+	case "boolean":
+		return TypeBoolean
+	case "counter":
+		return TypeCounter
+	case "decimal":
+		return TypeDecimal
+	case "double":
+		return TypeDouble
+	case "float":
+		return TypeFloat
+	case "int":
+		return TypeInt
+	case "timestamp":
+		return TypeTimestamp
+	case "uuid":
+		return TypeUUID
+	case "varchar", "text":
+		return TypeVarchar
+	case "varint":
+		return TypeVarint
+	case "timeuuid":
+		return TypeTimeUUID
+	case "inet":
+		return TypeInet
+	case "MapType":
+		return TypeMap
+	case "ListType":
+		return TypeList
+	case "SetType":
+		return TypeSet
+	case "TupleType":
+		return TypeTuple
+	default:
+		if strings.HasPrefix(name, "set") {
+			return TypeSet
+		} else if strings.HasPrefix(name, "list") {
+			return TypeList
+		} else if strings.HasPrefix(name, "map") {
+			return TypeMap
+		} else if strings.HasPrefix(name, "tuple") {
+			return TypeTuple
+		}
+		return TypeCustom
+	}
+}
+
 func getApacheCassandraType(class string) Type {
 	switch strings.TrimPrefix(class, apacheCassandraTypePrefix) {
 	case "AsciiType":

--- a/session.go
+++ b/session.go
@@ -53,7 +53,8 @@ type Session struct {
 	schemaEvents *eventDeouncer
 
 	// ring metadata
-	hosts []HostInfo
+	hosts           []HostInfo
+	useSystemSchema bool
 
 	cfg ClusterConfig
 
@@ -165,6 +166,8 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		s.Close()
 		return nil, ErrNoConnectionsStarted
 	}
+
+	s.useSystemSchema = hosts[0].Version().Major >= 3
 
 	return s, nil
 }
@@ -427,7 +430,7 @@ func (s *Session) routingKeyInfo(stmt string) (*routingKeyInfo, error) {
 	table := info.request.columns[0].Table
 
 	var keyspaceMetadata *KeyspaceMetadata
-	keyspaceMetadata, inflight.err = s.KeyspaceMetadata(s.cfg.Keyspace)
+	keyspaceMetadata, inflight.err = s.KeyspaceMetadata(info.request.columns[0].Keyspace)
 	if inflight.err != nil {
 		// don't cache this error
 		s.routingKeyInfoCache.Remove(stmt)


### PR DESCRIPTION
This PR is a *very* quick fix to get cluster metadata and TokenAwareRouting working for Cassandra 3.0 clusters. It needs tests, and the code isn't very clean (a lot of names were removed/moved, and I opted to just co-opt the old names from Cassandra 2).

The cluster detection just tests for a single Cassandra 3 node, as the new `system_schema` keyspace depends on Cassandra version, as opposed to the protocol version.