### PR TITLE
Fix 100ms sleep when creating session.

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -88,9 +88,6 @@ func TestInvalidPeerEntry(t *testing.T) {
 		"169.254.235.45",
 	)
 
-	// clean up naughty peer
-	defer session.Query("DELETE from system.peers where peer == ?", "169.254.235.45").Exec()
-
 	if err := query.Exec(); err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +97,10 @@ func TestInvalidPeerEntry(t *testing.T) {
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
 	session = createSessionFromCluster(cluster, t)
-	defer session.Close()
+	defer func() {
+		session.Query("DELETE from system.peers where peer = ?", "169.254.235.45").Exec()
+		session.Close()
+	}()
 
 	// check we can perform a query
 	iter := session.Query("select peer from system.peers").Iter()


### PR DESCRIPTION
hostConnPool.fill() was synchronously filling the pool and calling
fillingStopped(), which sleeps for ~100ms.

- don't synchronously fill the entire conn pool (connect once
  synchronously, then fill the rest in a separate goroutine)
- only sleep in hostConnPool.fillingStopped if fill() encountered an
  error
- fix cleanup of bad system.peer in TestInvalidPeerEntry