### PR TITLE
close call.timeout to prevent deadlock.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,3 +64,4 @@ Artem Chernyshev <artem.0xD2@gmail.com>
 Ference Fu <fym201@msn.com>
 LOVOO <opensource@lovoo.com>
 nikandfor <nikandfor@gmail.com>
+Anthony Woods <awoods@raintank.io>

--- a/conn.go
+++ b/conn.go
@@ -570,6 +570,7 @@ func (c *Conn) exec(req frameWriter, tracer Tracer) (*framer, error) {
 
 	select {
 	case err := <-call.resp:
+		close(call.timeout)
 		if err != nil {
 			if !c.Closed() {
 				// if the connection is closed then we cant release the stream,


### PR DESCRIPTION
if a successful response is recieve at the same time as the 10th
timeout, a deadlock can occur if succesfull response is read
from the response channel before closeWithError send an error
of response channel. By closing the call.timeout after reading
from the response channel we can avoid this deadlock.

 fixes #664