### PR TITLE
Correctly handle null value for varint type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gocql-fuzz
 fuzz-corpus
 fuzz-work
 gocql.test
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,4 @@ Ference Fu <fym201@msn.com>
 LOVOO <opensource@lovoo.com>
 nikandfor <nikandfor@gmail.com>
 Anthony Woods <awoods@raintank.io>
+Alexander Inozemtsev <alexander.inozemtsev@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1363,6 +1363,28 @@ func TestVarint(t *testing.T) {
 		t.Errorf("Expected -1, was %d", result)
 	}
 
+	if err := session.Query(`INSERT INTO varint_test (id, test) VALUES (?, ?)`, "id", nil).Exec(); err != nil {
+		t.Fatalf("insert varint: %v", err)
+	}
+
+	if err := session.Query("SELECT test FROM varint_test").Scan(&result); err != nil {
+		t.Fatalf("select from varint_test failed: %v", err)
+	}
+
+	if result != 0 {
+		t.Errorf("Expected 0, was %d", result)
+	}
+
+	var nullableResult *int
+
+	if err := session.Query("SELECT test FROM varint_test").Scan(&nullableResult); err != nil {
+		t.Fatalf("select from varint_test failed: %v", err)
+	}
+
+	if nullableResult != nil {
+		t.Errorf("Expected nil, was %d", nullableResult)
+	}
+
 	if err := session.Query(`INSERT INTO varint_test (id, test) VALUES (?, ?)`, "id", int64(math.MaxInt32)+1).Exec(); err != nil {
 		t.Fatalf("insert varint: %v", err)
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -432,7 +432,7 @@ func unmarshalVarint(info TypeInfo, data []byte, value interface{}) error {
 	}
 
 	int64Val := bytesToInt64(data)
-	if len(data) < 8 && data[0]&0x80 > 0 {
+	if len(data) > 0 && len(data) < 8 && data[0]&0x80 > 0 {
 		int64Val -= (1 << uint(len(data)*8))
 	}
 	return unmarshalIntlike(info, int64Val, data, value)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -341,6 +341,11 @@ var marshalTests = []struct {
 		bigintize("123456789123456789123456789"), // From the datastax/python-driver test suite
 	},
 	{
+		NativeType{proto: 2, typ: TypeVarint},
+		[]byte(nil),
+		nil,
+	},
+	{
 		NativeType{proto: 2, typ: TypeInet},
 		[]byte("\x7F\x00\x00\x01"),
 		net.ParseIP("127.0.0.1").To4(),


### PR DESCRIPTION
Got panic while fetching null value for varint type:
```
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range
github.com/gocql/gocql.unmarshalVarint(0x13b4630, 0xc820075860, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/vecmezoni/go/src/github.com/gocql/gocql/marshal.go:435 +0x40c
github.com/gocql/gocql.Unmarshal(0x13b4630, 0xc820075860, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/vecmezoni/go/src/github.com/gocql/gocql/marshal.go:127 +0x7ae
```