### PR TITLE
Implemented WithTimestamp function in gocql.Query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -715,6 +715,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 	// frame checks that it is not 0
 	params.serialConsistency = qry.serialCons
 	params.defaultTimestamp = qry.defaultTimestamp
+	params.defaultTimestampValue = qry.defaultTimestampValue
 
 	if len(qry.pageState) > 0 {
 		params.pagingState = qry.pageState

--- a/frame.go
+++ b/frame.go
@@ -1229,7 +1229,8 @@ type queryParams struct {
 	pagingState       []byte
 	serialConsistency SerialConsistency
 	// v3+
-	defaultTimestamp bool
+	defaultTimestamp      bool
+	defaultTimestampValue int64
 }
 
 func (q queryParams) String() string {
@@ -1301,7 +1302,12 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 
 	if f.proto > protoVersion2 && opts.defaultTimestamp {
 		// timestamp in microseconds
-		ts := time.Now().UnixNano() / 1000
+		var ts int64
+		if opts.defaultTimestampValue != 0 {
+			ts = opts.defaultTimestampValue
+		} else {
+			ts = time.Now().UnixNano() / 1000
+		}
 		f.writeLong(ts)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -569,23 +569,24 @@ func (s *Session) connect(addr string, errorHandler ConnErrorHandler, host *Host
 
 // Query represents a CQL statement that can be executed.
 type Query struct {
-	stmt                string
-	values              []interface{}
-	cons                Consistency
-	pageSize            int
-	routingKey          []byte
-	routingKeyBuffer    []byte
-	pageState           []byte
-	prefetch            float64
-	trace               Tracer
-	session             *Session
-	rt                  RetryPolicy
-	binding             func(q *QueryInfo) ([]interface{}, error)
-	attempts            int
-	totalLatency        int64
-	serialCons          SerialConsistency
-	defaultTimestamp    bool
-	disableSkipMetadata bool
+	stmt                  string
+	values                []interface{}
+	cons                  Consistency
+	pageSize              int
+	routingKey            []byte
+	routingKeyBuffer      []byte
+	pageState             []byte
+	prefetch              float64
+	trace                 Tracer
+	session               *Session
+	rt                    RetryPolicy
+	binding               func(q *QueryInfo) ([]interface{}, error)
+	attempts              int
+	totalLatency          int64
+	serialCons            SerialConsistency
+	defaultTimestamp      bool
+	defaultTimestampValue int64
+	disableSkipMetadata   bool
 
 	disableAutoPage bool
 }
@@ -646,6 +647,18 @@ func (q *Query) PageSize(n int) *Query {
 // Only available on protocol >= 3
 func (q *Query) DefaultTimestamp(enable bool) *Query {
 	q.defaultTimestamp = enable
+	return q
+}
+
+// WithTimestamp will enable the with default timestamp flag on the query
+// like DefaultTimestamp does. But also allows to define value for timestamp.
+// It works the same way as USING TIMESTAMP in the query itself, but
+// should not break prepared query optimization
+//
+// Only available on protocol >= 3
+func (q *Query) WithTimestamp(timestamp int64) *Query {
+	q.DefaultTimestamp(true)
+	q.defaultTimestampValue = timestamp
 	return q
 }
 


### PR DESCRIPTION
This function is an addition to `DefaultTimestamp` function.
Using this function enables defaultTimestamp flag, but instead of
generating new timestamp, it is possible to set it's value explicitly.

It's equal to `USING TIMESTAMP x` in the statement, but does not break
prepared query optimization.