### PR TITLE
Attempt to reconnect known DOWN nodes

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -566,7 +566,7 @@ func TestReconnection(t *testing.T) {
 	defer session.Close()
 
 	h := session.ring.allHosts()[0]
-	session.handleNodeDown(net.ParseIP(h.peer), h.port)
+	session.handleNodeDown(net.ParseIP(h.Peer()), h.Port())
 
 	if h.State() != NodeDown {
 		t.Fatal("Host should be NodeDown but not.")

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -4,7 +4,6 @@ package gocql
 
 import (
 	"bytes"
-	"golang.org/x/net/context"
 	"io"
 	"math"
 	"math/big"
@@ -16,6 +15,8 @@ import (
 	"testing"
 	"time"
 	"unicode"
+
+	"golang.org/x/net/context"
 
 	"gopkg.in/inf.v0"
 )
@@ -555,6 +556,26 @@ func TestCreateSessionTimeout(t *testing.T) {
 	if err == nil {
 		session.Close()
 		t.Fatal("expected ErrNoConnectionsStarted, but no error was returned.")
+	}
+}
+
+func TestReconnection(t *testing.T) {
+	cluster := createCluster()
+	cluster.ReconnectInterval = 1 * time.Second
+	session := createSessionFromCluster(cluster, t)
+	defer session.Close()
+
+	h := session.ring.allHosts()[0]
+	session.handleNodeDown(net.ParseIP(h.peer), h.port)
+
+	if h.State() != NodeDown {
+		t.Fatal("Host should be NodeDown but not.")
+	}
+
+	time.Sleep(cluster.ReconnectInterval + h.Version().nodeUpDelay() + 1*time.Second)
+
+	if h.State() != NodeUp {
+		t.Fatal("Host should be NodeUp but not. Failed to reconnect.")
 	}
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -72,6 +72,9 @@ type ClusterConfig struct {
 
 	Discovery DiscoveryConfig
 
+	// If not zero, gocql attempt to reconnect known DOWN nodes in every ReconnectSleep.
+	ReconnectInterval time.Duration
+
 	// The maximum amount of time to wait for schema agreement in a cluster after
 	// receiving a schema change frame. (deault: 60s)
 	MaxWaitSchemaAgreement time.Duration
@@ -126,6 +129,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		PageSize:               5000,
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
+		ReconnectInterval:      60 * time.Second,
 	}
 	return cfg
 }

--- a/conn.go
+++ b/conn.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"golang.org/x/net/context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -19,6 +18,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/gocql/gocql/internal/lru"
 

--- a/events.go
+++ b/events.go
@@ -244,6 +244,9 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 }
 
 func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
+	if gocqlDebug {
+		log.Printf("gocql: Session.handleNodeUp: %s:%d\n", ip.String(), port)
+	}
 	addr := ip.String()
 	host := s.ring.getHost(addr)
 	if host != nil {
@@ -275,6 +278,9 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 }
 
 func (s *Session) handleNodeDown(ip net.IP, port int) {
+	if gocqlDebug {
+		log.Printf("gocql: Session.handleNodeDown: %s:%d\n", ip.String(), port)
+	}
 	addr := ip.String()
 	host := s.ring.getHost(addr)
 	if host == nil {

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -51,6 +51,7 @@ func TestEventNodeDownControl(t *testing.T) {
 	}
 
 	cluster := createCluster()
+	cluster.ReconnectInterval = 0
 	cluster.Hosts = []string{status[targetNode].Addr}
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -51,7 +51,6 @@ func TestEventNodeDownControl(t *testing.T) {
 	}
 
 	cluster := createCluster()
-	cluster.ReconnectInterval = 0
 	cluster.Hosts = []string{status[targetNode].Addr}
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()


### PR DESCRIPTION
Hi, guys.

I've found that gocql doesn't try to reconnect to nodes which connection has been closed with TooManyTimeouts error.

For now, once a node goes DOWN, gocql can't get it back to UP status without UP server-push events.

But in some cases, gocql make nodes DOWN by itself. (e.g. after timeouts : https://github.com/gocql/gocql/blob/51009831ae7a79fd8f1b160d7359916a7a044afa/connectionpool.go#L399 )
In those case, UP events will not occur naturally so the node can't get back to UP forever.

So, I think polling for the DOWN nodes to make them UP would be a good way to keep connections.

Thanks.