### PR TITLE
Notify the HostSelectionPolicy of the partioner

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,7 +43,7 @@ James Maloney <jamessagan@gmail.com>
 Ashwin Purohit <purohit@gmail.com>
 Dan Kinder <dkinder.is.me@gmail.com>
 Oliver Beattie <oliver@obeattie.com>
-Justin Corpron <justin@retailnext.com>
+Justin Corpron <jncorpron@gmail.com>
 Miles Delahunty <miles.delahunty@gmail.com>
 Zach Badgett <zach.badgett@gmail.com>
 Maciek Sakrejda <maciek@heroku.com>

--- a/host_source.go
+++ b/host_source.go
@@ -391,5 +391,6 @@ func (r *ringDescriber) refreshRing() error {
 	}
 
 	r.session.metadata.setPartitioner(partitioner)
+	r.session.policy.SetPartitioner(partitioner)
 	return nil
 }


### PR DESCRIPTION
Adds a call to SetPartitioner on the session's HostSelectionPolicy. 
This is mostly needed so that the token aware policy initializes 
and updates its token ring representation.

Fixes #724 

- I've updated my email address in the AUTHORS file.