### PR TITLE
Avoid ErrTooManyTimeouts if TimeoutLimit is 0

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -113,7 +113,7 @@ func (fn connErrorHandlerFn) HandleError(conn *Conn, err error, closed bool) {
 	fn(conn, err, closed)
 }
 
-// How many timeouts we will allow to occur before the connection is closed
+// If not zero, how many timeouts we will allow to occur before the connection is closed
 // and restarted. This is to prevent a single query timeout from killing a connection
 // which may be serving more queries just fine.
 // Default is 10, should not be changed concurrently with queries.
@@ -522,7 +522,7 @@ func (c *Conn) releaseStream(stream int) {
 }
 
 func (c *Conn) handleTimeout() {
-	if atomic.AddInt64(&c.timeouts, 1) > TimeoutLimit {
+	if TimeoutLimit > 0 && atomic.AddInt64(&c.timeouts, 1) > TimeoutLimit {
 		c.closeWithError(ErrTooManyTimeouts)
 	}
 }


### PR DESCRIPTION
Hi, again!

In my environment, many ErrTooManyTimeouts occurs and many in-flight requests are closed with the error abruptly.

I'm not sure if counting timeouts would be a good way to detect failure for the coordinator nodes.
Timeouts can be occurred by not only coordinator nodes but also specific heavy query( like scanning ) or heavy-loading of data-nodes.

Also, I'm thinking of HostSelectionPolicy might be a good place to handle these kind things.

So, In this branch, I'd like to add an option to avoid this way to ErrTooManyTimeouts by setting TimeoutLimit zero.

I'd appreciate it if you could review this PR.
Thanks.