### PR TITLE
Pool query objects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,3 +68,4 @@ Anthony Woods <awoods@raintank.io>
 Alexander Inozemtsev <alexander.inozemtsev@gmail.com>
 Rob McColl <rob@robmccoll.com>; <rmccoll@ionicsecurity.com>
 Viktor Tönköl <viktor.toenkoel@motionlogic.de>
+Ian Lozinski <ian.lozinski@gmail.com>

--- a/session.go
+++ b/session.go
@@ -968,6 +968,7 @@ func (q *Query) Release() {
 		return
 	}
 	pool := q.session.queryPool
+	q.reset()
 	pool.Put(q)
 }
 

--- a/session.go
+++ b/session.go
@@ -968,7 +968,7 @@ func (q *Query) MapScanCAS(dest map[string]interface{}) (applied bool, err error
 // 		qry.Release()
 func (q *Query) Release() {
 	q.reset()
-	pool.Put(q)
+	queryPool.Put(q)
 }
 
 // reset zeroes out all fields of a query so that it can be safely pooled.

--- a/session_test.go
+++ b/session_test.go
@@ -4,7 +4,6 @@ package gocql
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 )
 

--- a/session_test.go
+++ b/session_test.go
@@ -13,10 +13,9 @@ func TestSessionAPI(t *testing.T) {
 	cfg := &ClusterConfig{}
 
 	s := &Session{
-		cfg:       *cfg,
-		cons:      Quorum,
-		policy:    RoundRobinHostPolicy(),
-		queryPool: &sync.Pool{New: func() interface{} { return new(Query) }},
+		cfg:    *cfg,
+		cons:   Quorum,
+		policy: RoundRobinHostPolicy(),
 	}
 
 	s.pool = cfg.PoolConfig.buildPool(s)
@@ -165,9 +164,8 @@ func TestBatchBasicAPI(t *testing.T) {
 	cfg := &ClusterConfig{RetryPolicy: &SimpleRetryPolicy{NumRetries: 2}}
 
 	s := &Session{
-		cfg:       *cfg,
-		cons:      Quorum,
-		queryPool: &sync.Pool{New: func() interface{} { return new(Query) }},
+		cfg:  *cfg,
+		cons: Quorum,
 	}
 	defer s.Close()
 

--- a/session_test.go
+++ b/session_test.go
@@ -12,9 +12,10 @@ func TestSessionAPI(t *testing.T) {
 	cfg := &ClusterConfig{}
 
 	s := &Session{
-		cfg:    *cfg,
-		cons:   Quorum,
-		policy: RoundRobinHostPolicy(),
+		cfg:       *cfg,
+		cons:      Quorum,
+		policy:    RoundRobinHostPolicy(),
+		queryPool: &sync.Pool{New: func() interface{} { return new(Query) }},
 	}
 
 	s.pool = cfg.PoolConfig.buildPool(s)
@@ -163,8 +164,9 @@ func TestBatchBasicAPI(t *testing.T) {
 	cfg := &ClusterConfig{RetryPolicy: &SimpleRetryPolicy{NumRetries: 2}}
 
 	s := &Session{
-		cfg:  *cfg,
-		cons: Quorum,
+		cfg:       *cfg,
+		cons:      Quorum,
+		queryPool: &sync.Pool{New: func() interface{} { return new(Query) }},
 	}
 	defer s.Close()
 

--- a/session_test.go
+++ b/session_test.go
@@ -4,6 +4,7 @@ package gocql
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 )
 


### PR DESCRIPTION
Queries account for a lot of unnecessary allocations. This PR exposes a `Release` method on the `Query` type so that callers of `Session.Query()` can reduce the number of allocations.