### PR TITLE
Add Session.DisableSkipMetadata to avoid panic by CASSANDRA-10786

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -110,6 +110,14 @@ type ClusterConfig struct {
 		DisableSchemaEvents bool
 	}
 
+	// DisableSkipMetadata will override the internal result metadata cache so that the driver does not
+	// send skip_metadata for queries, this means that the result will always contain
+	// the metadata to parse the rows and will not reuse the metadata from the prepared
+	// staement.
+	//
+	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
+	DisableSkipMetadata bool
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/conn.go
+++ b/conn.go
@@ -794,7 +794,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 			// TODO: handle query binding names
 		}
 
-		params.skipMeta = !qry.disableSkipMetadata
+		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata)
 
 		frame = &writeExecuteFrame{
 			preparedID: info.id,


### PR DESCRIPTION
Hi.

After we `ALTER TABLE ADD COLUMEN...` on a live cluster, almost all C* clients using gocql failed with panic.
As a result of some investigation, we found that the panic has been caused by [CASSANDRA-10786](https://issues.apache.org/jira/browse/CASSANDRA-10786).

The metadata for EXECUTE ROWS results have been changed after a `ALTER TABLE` but only one client can handle the change of the metadata. Other clients failed to unmarshal (especially for parse of collection type) and panic.

So, In this ticket, I'd like to add a way to disable SkipMetadata within the session to avoid this issue.