### PR TITLE
Stop retrying to connect on permanent failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,3 +69,4 @@ Alexander Inozemtsev <alexander.inozemtsev@gmail.com>
 Rob McColl <rob@robmccoll.com>; <rmccoll@ionicsecurity.com>
 Viktor Tönköl <viktor.toenkoel@motionlogic.de>
 Ian Lozinski <ian.lozinski@gmail.com>
+Michael Highstead <highstead@gmail.com>

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -481,6 +481,13 @@ func (pool *hostConnPool) connect() (err error) {
 		if err == nil {
 			break
 		}
+		if opErr, isOpErr := err.(*net.OpError); isOpErr {
+			// if the error is not a temporary error (ex: network unreachable) don't
+			//  retry
+			if !opErr.Temporary() {
+				break
+			}
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Minor change to the connection pool code that uses the *net.OpError type
to pull of retrying to connect to a host if the error is a permanent
erorr.

Reduces startup time on creating a new sesession when we try to
establish a connection using gocql that does not have visibility to the
host.

Performance improvement easily reproduced when using default cassandra
docker container with gocql.

Relates to issue #696 