### PR TITLE
Add reflection support for smallint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,3 +70,4 @@ Rob McColl <rob@robmccoll.com>; <rmccoll@ionicsecurity.com>
 Viktor Tönköl <viktor.toenkoel@motionlogic.de>
 Ian Lozinski <ian.lozinski@gmail.com>
 Michael Highstead <highstead@gmail.com>
+Sarah Brown <esbie.is@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -651,6 +651,7 @@ func TestSliceMap(t *testing.T) {
 			testfloat      float,
 			testdouble     double,
 			testint        int,
+			testsmallint   smallint,
 			testdecimal    decimal,
 			testlist       list<text>,
 			testset        set<int>,
@@ -676,6 +677,7 @@ func TestSliceMap(t *testing.T) {
 	m["testfloat"] = float32(4.564)
 	m["testdouble"] = float64(4.815162342)
 	m["testint"] = 2343
+	m["testsmallint"] = int16(2)
 	m["testdecimal"] = inf.NewDec(100, 0)
 	m["testlist"] = []string{"quux", "foo", "bar", "baz", "quux"}
 	m["testset"] = []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
@@ -683,8 +685,8 @@ func TestSliceMap(t *testing.T) {
 	m["testvarint"] = bigInt
 	m["testinet"] = "213.212.2.19"
 	sliceMap := []map[string]interface{}{m}
-	if err := session.Query(`INSERT INTO slice_map_table (testuuid, testtimestamp, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testdecimal, testlist, testset, testmap, testvarint, testinet) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		m["testuuid"], m["testtimestamp"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testdecimal"], m["testlist"], m["testset"], m["testmap"], m["testvarint"], m["testinet"]).Exec(); err != nil {
+	if err := session.Query(`INSERT INTO slice_map_table (testuuid, testtimestamp, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testsmallint, testdecimal, testlist, testset, testmap, testvarint, testinet) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		m["testuuid"], m["testtimestamp"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testsmallint"], m["testdecimal"], m["testlist"], m["testset"], m["testmap"], m["testvarint"], m["testinet"]).Exec(); err != nil {
 		t.Fatal("insert:", err)
 	}
 	if returned, retErr := session.Query(`SELECT * FROM slice_map_table`).Iter().SliceMap(); retErr != nil {
@@ -758,6 +760,9 @@ func matchSliceMap(t *testing.T, sliceMap []map[string]interface{}, testMap map[
 	}
 	if sliceMap[0]["testint"] != testMap["testint"] {
 		t.Fatal("returned testint did not match")
+	}
+	if sliceMap[0]["testsmallint"] != testMap["testsmallint"] {
+		t.Fatal("returned testsmallint did not match")
 	}
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -773,6 +773,7 @@ func TestSmallInt(t *testing.T) {
 		t.Fatal("create table:", err)
 	}
 	m := make(map[string]interface{})
+	m["testsmallint"] = int16(2)
 	sliceMap := []map[string]interface{}{m}
 	if err := session.Query(`INSERT INTO smallint_table (testsmallint) VALUES (?)`,
 		m["testsmallint"]).Exec(); err != nil {

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -768,7 +768,7 @@ func TestSmallInt(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
 	if err := createTable(session, `CREATE TABLE gocql_test.smallint_table (
-			testsmallint   smallint,
+			testsmallint  smallint PRIMARY KEY,
 		)`); err != nil {
 		t.Fatal("create table:", err)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -37,6 +37,8 @@ func goType(t TypeInfo) reflect.Type {
 		return reflect.TypeOf(*new(float64))
 	case TypeInt:
 		return reflect.TypeOf(*new(int))
+	case TypeSmallInt:
+		return reflect.TypeOf(*new(int16))
 	case TypeDecimal:
 		return reflect.TypeOf(*new(*inf.Dec))
 	case TypeUUID, TypeTimeUUID:


### PR DESCRIPTION
Problem:

When using `SliceMap` with a schema containing a `smallint`, gocql panics
```
events | 2016/07/13 23:58:25 http: panic serving 192.168.99.1:56947: reflect: New(nil)
events | goroutine 43 [running]:
events | net/http.(*conn).serve.func1(0xc8202b5880)
events | 	/usr/local/go/src/net/http/server.go:1389 +0xc1
events | panic(0x857e40, 0xc8202b6e80)
events | 	/usr/local/go/src/runtime/panic.go:443 +0x4e9
events | reflect.New(0x0, 0x0, 0x0, 0x0, 0x0)
events | 	/usr/local/go/src/reflect/value.go:2119 +0x85
events | github.com/buoyantio/helium/vendor/github.com/gocql/gocql.NativeType.New(0x7f9d00000003, 0x13, 0xc820145680, 0x29, 0x0, 0x0)
events | 	/go/src/github.com/buoyantio/helium/vendor/github.com/gocql/gocql/marshal.go:1788 +0xd6
events | github.com/buoyantio/helium/vendor/github.com/gocql/gocql.(*NativeType).New(0xc820182580, 0x0, 0x0)
events | 	<autogenerated>:206 +0xa2
events | github.com/buoyantio/helium/vendor/github.com/gocql/gocql.(*Iter).RowData(0xc820069320, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
events | 	/go/src/github.com/buoyantio/helium/vendor/github.com/gocql/gocql/helpers.go:214 +0x6eb
events | github.com/buoyantio/helium/vendor/github.com/gocql/gocql.(*Iter).SliceMap(0xc820069320, 0x0, 0x0, 0x0, 0x0, 0x0)
events | 	/go/src/github.com/buoyantio/helium/vendor/github.com/gocql/gocql/helpers.go:234 +0x9e
events | main.(*EventService).GetTrace(0xc820124bc0, 0x7f9d2c47d2a0, 0xc8202ba360, 0xc8202b6b90, 0xc8202b2c40, 0x0, 0x0)
events | 	/go/src/github.com/buoyantio/helium/service/events.go:43 +0x3a1
```

Solution:

Add `smallint` as a reflection type in `goType`