### PR TITLE
Add ScyllaDB to "Ecosphere"

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following community maintained tools are known to integrate with gocql:
 * [gocassa](https://github.com/hailocab/gocassa) provides query building, adds data binding, and provides easy-to-use "recipe" tables for common query use-cases.
 * [gocqltable](https://github.com/kristoiv/gocqltable) is a wrapper around gocql that aims to simplify common operations whilst working the library.
 * [gockle](https://github.com/willfaught/gockle) provides simple, mockable interfaces that wrap gocql types
+* [scylladb](https://github.com/scylladb/scylla) is a fast Apache Cassandra-compatible NoSQL database
 
 Other Projects
 --------------


### PR DESCRIPTION
ScyllaDB is a fast Apache Cassandra compatible NoSQL database that is
used with gocql in production for high performance deployments:

  http://developer.eniro.com/blog/post/scylladb-a-monster-or-a-rock/

Add ScyllaDB to the "Ecosphere" section of gocql's README so that people
know gocql also integrates very well with ScyllaDB.