### PR TITLE
Use correct CQL version even if `DisableInitialHostLookup` is true

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Sarah Brown <esbie.is@gmail.com>
 Caleb Doxsey <caleb@datadoghq.com>
 Frederic Hemery <frederic.hemery@datadoghq.com>
 Pekka Enberg <penberg@scylladb.com>
+Mark M <m.mim95@gmail.com>

--- a/host_source.go
+++ b/host_source.go
@@ -272,6 +272,22 @@ func checkSystemLocal(control *controlConn) (bool, error) {
 	return true, nil
 }
 
+// Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
+func checkSystemSchema(control *controlConn) (bool, error) {
+	iter := control.query("SELECT * FROM system_schema.keyspaces")
+	if err := iter.err; err != nil {
+		if errf, ok := err.(*errorFrame); ok {
+			if errf.code == errReadFailure {
+				return false, nil
+			}
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (r *ringDescriber) GetHosts() (hosts []*HostInfo, partitioner string, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/session.go
+++ b/session.go
@@ -195,7 +195,14 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		return nil, ErrNoConnectionsStarted
 	}
 
-	s.useSystemSchema = hosts[0].Version().Major >= 3
+	// If initial host lookup is disabled, then we should use the ClusterConfig CQL version
+	if cfg.DisableInitialHostLookup {
+		var v cassVersion
+		v.Set(cfg.CQLVersion)
+		s.useSystemSchema = v.Major >= 3
+	} else {
+		s.useSystemSchema = hosts[0].Version().Major >= 3
+	}
 
 	return s, nil
 }

--- a/session.go
+++ b/session.go
@@ -195,11 +195,13 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		return nil, ErrNoConnectionsStarted
 	}
 
-	// If initial host lookup is disabled, then we should use the ClusterConfig CQL version
-	if cfg.DisableInitialHostLookup {
-		var v cassVersion
-		v.Set(cfg.CQLVersion)
-		s.useSystemSchema = v.Major >= 3
+	// If we disable the initial host lookup, we need to still check if the
+	// cluster is using the newer system schema or not... however, if control
+	// connection is disable, we really have no choice, so we just make our
+	// best guess...
+	if !cfg.disableControlConn && cfg.DisableInitialHostLookup {
+		newer, _ := checkSystemSchema(s.control)
+		s.useSystemSchema = newer
 	} else {
 		s.useSystemSchema = hosts[0].Version().Major >= 3
 	}


### PR DESCRIPTION
When `DisableInitialHostLookup` is true, `addrToHost` is called instead of doing a lookup in `system.local` and `system.peers`. This means that the host's version is the zero value (version 0) for all hosts.

Thus, calls to `KeyspaceMetadata` fail for cassandra versions >= 3.x because gocql attempts to make queries on `system.schema_keyspaces`, which no longer exists.

This PR simply stipulates that if `DisableInitialHostLookup` is true, we should use CQL version specified by the ClusterConfig that was used to create the session. Otherwise, we use the version of the first host, as before.