### PR TITLE
config: remove legacy DiscoveryConfig

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -22,27 +22,6 @@ func (p PoolConfig) buildPool(session *Session) *policyConnPool {
 	return newPolicyConnPool(session)
 }
 
-type DiscoveryConfig struct {
-	// If not empty will filter all discovered hosts to a single Data Centre (default: "")
-	DcFilter string
-	// If not empty will filter all discovered hosts to a single Rack (default: "")
-	RackFilter string
-	// ignored
-	Sleep time.Duration
-}
-
-func (d DiscoveryConfig) matchFilter(host *HostInfo) bool {
-	if d.DcFilter != "" && d.DcFilter != host.DataCenter() {
-		return false
-	}
-
-	if d.RackFilter != "" && d.RackFilter != host.Rack() {
-		return false
-	}
-
-	return true
-}
-
 // ClusterConfig is a struct to configure the default cluster implementation
 // of gocoql. It has a variety of attributes that can be used to modify the
 // behavior to fit the most common use cases. Applications that require a
@@ -69,8 +48,6 @@ type ClusterConfig struct {
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
-
-	Discovery DiscoveryConfig
 
 	// If not zero, gocql attempt to reconnect known DOWN nodes in every ReconnectSleep.
 	ReconnectInterval time.Duration

--- a/events.go
+++ b/events.go
@@ -192,12 +192,7 @@ func (s *Session) handleNewNode(host net.IP, port int, waitForBinary bool) {
 		hostInfo.setPeer(addr)
 	}
 
-	if s.cfg.HostFilter != nil {
-		if !s.cfg.HostFilter.Accept(hostInfo) {
-			return
-		}
-	} else if !s.cfg.Discovery.matchFilter(hostInfo) {
-		// TODO: remove this when the host selection policy is more sophisticated
+	if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(hostInfo) {
 		return
 	}
 
@@ -254,12 +249,7 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 			host.setPeer(addr)
 		}
 
-		if s.cfg.HostFilter != nil {
-			if !s.cfg.HostFilter.Accept(host) {
-				return
-			}
-		} else if !s.cfg.Discovery.matchFilter(host) {
-			// TODO: remove this when the host selection policy is more sophisticated
+		if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(host) {
 			return
 		}
 

--- a/session.go
+++ b/session.go
@@ -145,7 +145,6 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	}
 
 	var hosts []*HostInfo
-
 	if !cfg.disableControlConn {
 		s.control = createControlConn(s)
 		if err := s.control.connect(cfg.Hosts); err != nil {


### PR DESCRIPTION
DiscoveryConfig was replaced with the HostFilter, DiscoveryConfig was
not fully ported over when adding host events.