### PR TITLE
adding AddressTranslator interface and impl for use in ec2

### DIFF
--- a/address_translators.go
+++ b/address_translators.go
@@ -1,0 +1,26 @@
+package gocql
+
+import "net"
+
+// AddressTranslator provides a way to translate node addresses (and ports) that are
+// discovered or received as a node event. This can be useful in an ec2 environment,
+// for instance, to translate public IPs to private IPs.
+type AddressTranslator interface {
+	// Translate will translate the provided address and/or port to another
+	// address and/or port. If no translation is possible, Translate will return the
+	// address and port provided to it.
+	Translate(addr net.IP, port int) (net.IP, int)
+}
+
+type AddressTranslatorFunc func(addr net.IP, port int) (net.IP, int)
+
+func (fn AddressTranslatorFunc) Translate(addr net.IP, port int) (net.IP, int) {
+	return fn(addr, port)
+}
+
+// IdentityTranslator will do nothing but return what it was provided. It is essentially a no-op.
+func IdentityTranslator() AddressTranslator {
+	return AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
+		return addr, port
+	})
+}

--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -1,0 +1,34 @@
+package gocql
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIdentityAddressTranslator_NilAddrAndZeroPort(t *testing.T) {
+	var tr AddressTranslator = IdentityTranslator()
+	hostIP := net.ParseIP("")
+	if hostIP != nil {
+		t.Errorf("expected host ip to be (nil) but was (%+v) instead", hostIP)
+	}
+
+	addr, port := tr.Translate(hostIP, 0)
+	if addr != nil {
+		t.Errorf("expected translated host to be (nil) but was (%+v) instead", addr)
+	}
+	assertEqual(t, "translated port", 0, port)
+}
+
+func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
+	var tr AddressTranslator = IdentityTranslator()
+	hostIP := net.ParseIP("10.1.2.3")
+	if hostIP == nil {
+		t.Error("expected host ip not to be (nil)")
+	}
+
+	addr, port := tr.Translate(hostIP, 9042)
+	if !hostIP.Equal(addr) {
+		t.Errorf("expected translated addr to be (%+v) but was (%+v) instead", hostIP, addr)
+	}
+	assertEqual(t, "translated port", 9042, port)
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,0 +1,53 @@
+package gocql
+
+import (
+	"testing"
+	"time"
+	"net"
+)
+
+func TestNewCluster_Defaults(t *testing.T) {
+	cfg := NewCluster()
+	assertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
+	assertEqual(t, "cluster config timeout", 600*time.Millisecond, cfg.Timeout)
+	assertEqual(t, "cluster config port", 9042, cfg.Port)
+	assertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
+	assertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
+	assertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
+	assertEqual(t, "cluster config max routing key info", 1000, cfg.MaxRoutingKeyInfo)
+	assertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
+	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
+	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
+	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
+}
+
+func TestNewCluster_WithHosts(t *testing.T) {
+	cfg := NewCluster("addr1", "addr2")
+	assertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
+	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
+	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+}
+
+func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
+	cfg := NewCluster()
+	assertNil(t, "cluster config address translator", cfg.AddressTranslator)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234)
+	assertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
+	assertEqual(t, "translated host and port", 1234, newPort)
+}
+
+func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
+	cfg := NewCluster()
+	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
+	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0)
+	assertTrue(t, "translated address is still empty", len(newAddr) == 0)
+	assertEqual(t, "translated port", 0, newPort)
+}
+
+func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
+	cfg := NewCluster()
+	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
+	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
+	assertEqual(t, "translated port", 5432, newPort)
+}

--- a/conn.go
+++ b/conn.go
@@ -172,7 +172,9 @@ func Connect(host *HostInfo, cfg *ConnConfig, errorHandler ConnErrorHandler, ses
 	}
 
 	// TODO(zariel): handle ipv6 zone
-	addr := (&net.TCPAddr{IP: host.Peer(), Port: host.Port()}).String()
+	translatedPeer, translatedPort := session.cfg.translateAddressPort(host.Peer(), host.Port())
+	addr := (&net.TCPAddr{IP: translatedPeer, Port: translatedPort}).String()
+	//addr := (&net.TCPAddr{IP: host.Peer(), Port: host.Port()}).String()
 
 	if cfg.tlsConfig != nil {
 		// the TLS config is safe to be reused by connections but it must not

--- a/conn_test.go
+++ b/conn_test.go
@@ -474,7 +474,7 @@ func TestStream0(t *testing.T) {
 		}
 	})
 
-	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
+	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, createTestSession())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,7 +509,7 @@ func TestConnClosedBlocked(t *testing.T) {
 		t.Log(err)
 	})
 
-	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
+	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, createTestSession())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/control.go
+++ b/control.go
@@ -318,8 +318,8 @@ func (c *controlConn) reconnect(refreshring bool) {
 		}
 	}
 
-	// TODO: should have our own roundrobbin for hosts so that we can try each
-	// in succession and guantee that we get a different host each time.
+	// TODO: should have our own round-robin for hosts so that we can try each
+	// in succession and guarantee that we get a different host each time.
 	if newConn == nil {
 		host := c.session.ring.rrHost()
 		if host == nil {

--- a/events.go
+++ b/events.go
@@ -205,7 +205,6 @@ func (s *Session) handleNewNode(ip net.IP, port int, waitForBinary bool) {
 	s.pool.addHost(hostInfo)
 	s.policy.AddHost(hostInfo)
 	hostInfo.setState(NodeUp)
-
 	if s.control != nil && !s.cfg.IgnorePeerAddr {
 		s.hostSource.refreshRing()
 	}

--- a/integration.sh
+++ b/integration.sh
@@ -64,7 +64,7 @@ function run_tests() {
 
 	local args="-gocql.timeout=60s -runssl -proto=$proto -rf=3 -clusterSize=$clusterSize -autowait=2000ms -compressor=snappy -gocql.cversion=$version -cluster=$(ccm liveset) ./..."
 
-	go test -v -tags unit
+    go test -v -tags unit
 
 	if [ "$auth" = true ]
 	then

--- a/session_connect_test.go
+++ b/session_connect_test.go
@@ -1,0 +1,131 @@
+package gocql
+
+import (
+	"golang.org/x/net/context"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type OneConnTestServer struct {
+	Err  error
+	Addr net.IP
+	Port int
+
+	listener   net.Listener
+	acceptChan chan struct{}
+	mu         sync.Mutex
+	closed     bool
+}
+
+func NewOneConnTestServer() (*OneConnTestServer, error) {
+	lstn, err := net.Listen("tcp4", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+	addr, port := parseAddressPort(lstn.Addr().String())
+	return &OneConnTestServer{
+		listener:   lstn,
+		acceptChan: make(chan struct{}),
+		Addr:       addr,
+		Port:       port,
+	}, nil
+}
+
+func (c *OneConnTestServer) Accepted() chan struct{} {
+	return c.acceptChan
+}
+
+func (c *OneConnTestServer) Close() {
+	c.lockedClose()
+}
+
+func (c *OneConnTestServer) Serve() {
+	conn, err := c.listener.Accept()
+	c.Err = err
+	if conn != nil {
+		conn.Close()
+	}
+	c.lockedClose()
+}
+
+func (c *OneConnTestServer) lockedClose() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		close(c.acceptChan)
+		c.listener.Close()
+		c.closed = true
+	}
+}
+
+func parseAddressPort(hostPort string) (net.IP, int) {
+	host, portStr, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return net.ParseIP(""), 0
+	}
+	port, _ := strconv.Atoi(portStr)
+	return net.ParseIP(host), port
+}
+
+func testConnErrorHandler(t *testing.T) ConnErrorHandler {
+	return connErrorHandlerFn(func(conn *Conn, err error, closed bool) {
+		t.Errorf("in connection handler: %v", err)
+	})
+}
+
+func assertConnectionEventually(t *testing.T, wait time.Duration, srvr *OneConnTestServer) {
+	ctx, cancel := context.WithTimeout(context.Background(), wait)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		if ctx.Err() != nil {
+			t.Errorf("waiting for connection: %v", ctx.Err())
+		}
+	case <-srvr.Accepted():
+		if srvr.Err != nil {
+			t.Errorf("accepting connection: %v", srvr.Err)
+		}
+	}
+}
+
+func TestSession_connect_WithNoTranslator(t *testing.T) {
+	srvr, err := NewOneConnTestServer()
+	assertNil(t, "error when creating tcp server", err)
+	defer srvr.Close()
+
+	session := createTestSession()
+	defer session.Close()
+
+	go srvr.Serve()
+
+	Connect(&HostInfo{
+		peer: srvr.Addr,
+		port: srvr.Port,
+	}, session.connCfg, testConnErrorHandler(t), session)
+
+	assertConnectionEventually(t, 500*time.Millisecond, srvr)
+}
+
+func TestSession_connect_WithTranslator(t *testing.T) {
+	srvr, err := NewOneConnTestServer()
+	assertNil(t, "error when creating tcp server", err)
+	defer srvr.Close()
+
+	session := createTestSession()
+	defer session.Close()
+	session.cfg.AddressTranslator = staticAddressTranslator(srvr.Addr, srvr.Port)
+
+	go srvr.Serve()
+
+	// the provided address will be translated
+	Connect(&HostInfo{
+		peer: net.ParseIP("10.10.10.10"),
+		port: 5432,
+	}, session.connCfg, testConnErrorHandler(t), session)
+
+	assertConnectionEventually(t, 500*time.Millisecond, srvr)
+}

--- a/session_test.go
+++ b/session_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestSessionAPI(t *testing.T) {
-
 	cfg := &ClusterConfig{}
 
 	s := &Session{

--- a/udt_test.go
+++ b/udt_test.go
@@ -147,7 +147,7 @@ func TestUDT_Reflect(t *testing.T) {
 	}
 
 	if *retrievedHorse != *insertedHorse {
-		t.Fatalf("exepcted to get %+v got %+v", insertedHorse, retrievedHorse)
+		t.Fatalf("expected to get %+v got %+v", insertedHorse, retrievedHorse)
 	}
 }
 


### PR DESCRIPTION
This change introduces the AddressTranslator interface, which is
intended for use during discovery and node-event processing to translate
peer addresses of nodes. The primary use -- which is driving the
change -- is to translate public IPs to private IPs (when possible)
in ec2. The ec2 translator will be implemented elsewhere and is not
provided here.

This solution is common among other CQL driver implementations. The
specific implementation here also follows the convention set by
HostFilter.

We try our best to have test coverage for the bits that changed.

Signed-off-by: Justin "Gus" Knowlden gus@gusg.us
