### PR TITLE
readme: svg badge for “retina” displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ gocql
 =====
 
 [![Join the chat at https://gitter.im/gocql/gocql](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gocql/gocql?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/gocql/gocql.png?branch=master)](https://travis-ci.org/gocql/gocql)
-[![GoDoc](http://godoc.org/github.com/gocql/gocql?status.png)](http://godoc.org/github.com/gocql/gocql)
+[![Build Status](https://travis-ci.org/gocql/gocql.svg?branch=master)](https://travis-ci.org/gocql/gocql)
+[![GoDoc](https://godoc.org/github.com/gocql/gocql?status.svg)](https://godoc.org/github.com/gocql/gocql)
 
 Package gocql implements a fast and robust Cassandra client for the
 Go programming language.
 
-Project Website: http://gocql.github.io/<br>
-API documentation: http://godoc.org/github.com/gocql/gocql<br>
+Project Website: https://gocql.github.io/<br>
+API documentation: https://godoc.org/github.com/gocql/gocql<br>
 Discussions: https://groups.google.com/forum/#!forum/gocql
 
 Production Stability


### PR DESCRIPTION
and HTTPS links where possible

NOTE: the project url at the top of the page on GitHub could also be using HTTPS.

> Package gocql implements a fast and robust Cassandra client for the Go programming language. http://gocql.github.io/