### PR TITLE
[WIP] use a Logger interface for logging

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -6,6 +6,8 @@ package gocql
 
 import (
 	"errors"
+	"log"
+	"os"
 	"time"
 )
 
@@ -101,8 +103,17 @@ type ClusterConfig struct {
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
 	DisableSkipMetadata bool
 
+	// Log can be set to use a custom logging package.
+	Log Logger
+
 	// internal config for testing
 	disableControlConn bool
+}
+
+// Logging methods used by gocql
+type Logger interface {
+	Printf(string, ...interface{})
+	Println(...interface{})
 }
 
 // NewCluster generates a new config for the default cluster implementation.
@@ -115,6 +126,8 @@ type ClusterConfig struct {
 // resolves to more than 1 IP address then the driver may connect multiple times to
 // the same host, and will not mark the node being down or up from events.
 func NewCluster(hosts ...string) *ClusterConfig {
+	stdLog := log.New(os.Stderr, "", log.LstdFlags)
+
 	cfg := &ClusterConfig{
 		Hosts:                  hosts,
 		CQLVersion:             "3.0.0",
@@ -129,6 +142,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
+		Log:                    stdLog,
 	}
 	return cfg
 }

--- a/conn.go
+++ b/conn.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -491,7 +490,7 @@ func (c *Conn) recv() error {
 	call, ok := c.calls[head.stream]
 	c.mu.RUnlock()
 	if call == nil || call.framer == nil || !ok {
-		log.Printf("gocql: received response for stream which has no handler: header=%v\n", head)
+		c.session.cfg.Log.Printf("gocql: received response for stream which has no handler: header=%v\n", head)
 		return c.discardFrame(head)
 	}
 
@@ -871,7 +870,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 		iter := &Iter{framer: framer}
 		if err := c.awaitSchemaAgreement(); err != nil {
 			// TODO: should have this behind a flag
-			log.Println(err)
+			c.session.cfg.Log.Println(err)
 		}
 		// dont return an error from this, might be a good idea to give a warning
 		// though. The impact of this returning an error would be that the cluster
@@ -1082,7 +1081,7 @@ func (c *Conn) awaitSchemaAgreement() (err error) {
 		var schemaVersion string
 		for iter.Scan(&schemaVersion) {
 			if schemaVersion == "" {
-				log.Println("skipping peer entry with empty schema_version")
+				c.session.cfg.Log.Println("skipping peer entry with empty schema_version")
 				continue
 			}
 

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net"
 	"sync"
@@ -422,11 +421,11 @@ func (pool *hostConnPool) logConnectErr(err error) {
 		// connection refused
 		// these are typical during a node outage so avoid log spam.
 		if gocqlDebug {
-			log.Printf("unable to dial %q: %v\n", pool.host.Peer(), err)
+			pool.session.cfg.Log.Printf("unable to dial %q: %v\n", pool.host.Peer(), err)
 		}
 	} else if err != nil {
 		// unexpected error
-		log.Printf("error: failed to connect to %s due to error: %v", pool.addr, err)
+		pool.session.cfg.Log.Printf("error: failed to connect to %s due to error: %v", pool.addr, err)
 	}
 }
 

--- a/control.go
+++ b/control.go
@@ -4,7 +4,6 @@ import (
 	crand "crypto/rand"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"strconv"
@@ -164,8 +163,7 @@ func (c *controlConn) shuffleDial(endpoints []string) (conn *Conn, err error) {
 		if err == nil {
 			return conn, err
 		}
-
-		log.Printf("gocql: unable to dial control conn %v: %v\n", addr, err)
+		c.session.cfg.Log.Printf("gocql: unable to dial control conn %v: %v\n", addr, err)
 	}
 
 	if err != nil {
@@ -298,7 +296,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 
 	if err := c.setupConn(newConn); err != nil {
 		newConn.Close()
-		log.Printf("gocql: control unable to register events: %v\n", err)
+		c.session.cfg.Log.Printf("gocql: control unable to register events: %v\n", err)
 		return
 	}
 
@@ -367,7 +365,7 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 		})
 
 		if gocqlDebug && iter.err != nil {
-			log.Printf("control: error executing %q: %v\n", statement, iter.err)
+			c.session.cfg.Log.Printf("control: error executing %q: %v\n", statement, iter.err)
 		}
 
 		q.attempts++

--- a/events.go
+++ b/events.go
@@ -74,6 +74,7 @@ func (e *eventDebouncer) debounce(frame frame) {
 	if len(e.events) < eventBufferSize {
 		e.events = append(e.events, frame)
 	} else {
+		// TODO: use Logger
 		log.Printf("%s: buffer full, dropping event frame: %s", e.name, frame)
 	}
 
@@ -86,13 +87,12 @@ func (s *Session) handleEvent(framer *framer) {
 
 	frame, err := framer.parseFrame()
 	if err != nil {
-		// TODO: logger
-		log.Printf("gocql: unable to parse event frame: %v\n", err)
+		s.cfg.Log.Printf("gocql: unable to parse event frame: %v\n", err)
 		return
 	}
 
 	if gocqlDebug {
-		log.Printf("gocql: handling frame: %v\n", frame)
+		s.cfg.Log.Printf("gocql: handling frame: %v\n", frame)
 	}
 
 	// TODO: handle medatadata events
@@ -102,7 +102,7 @@ func (s *Session) handleEvent(framer *framer) {
 	case *topologyChangeEventFrame, *statusChangeEventFrame:
 		s.nodeEvents.debounce(frame)
 	default:
-		log.Printf("gocql: invalid event frame (%T): %v\n", f, f)
+		s.cfg.Log.Printf("gocql: invalid event frame (%T): %v\n", f, f)
 	}
 }
 
@@ -152,7 +152,7 @@ func (s *Session) handleNodeEvent(frames []frame) {
 
 	for _, f := range events {
 		if gocqlDebug {
-			log.Printf("gocql: dispatching event: %+v\n", f)
+			s.cfg.Log.Printf("gocql: dispatching event: %+v\n", f)
 		}
 
 		switch f.change {
@@ -177,7 +177,7 @@ func (s *Session) handleNewNode(ip net.IP, port int, waitForBinary bool) {
 		var err error
 		hostInfo, err = s.control.fetchHostInfo(ip, port)
 		if err != nil {
-			log.Printf("gocql: events: unable to fetch host info for (%s:%d): %v\n", ip, port, err)
+			s.cfg.Log.Printf("gocql: events: unable to fetch host info for (%s:%d): %v\n", ip, port, err)
 			return
 		}
 	} else {
@@ -234,7 +234,7 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 
 func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 	if gocqlDebug {
-		log.Printf("gocql: Session.handleNodeUp: %s:%d\n", ip.String(), port)
+		s.cfg.Log.Printf("gocql: Session.handleNodeUp: %s:%d\n", ip.String(), port)
 	}
 
 	host := s.ring.getHost(ip)
@@ -263,7 +263,7 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 
 func (s *Session) handleNodeDown(ip net.IP, port int) {
 	if gocqlDebug {
-		log.Printf("gocql: Session.handleNodeDown: %s:%d\n", ip.String(), port)
+		s.cfg.Log.Printf("gocql: Session.handleNodeDown: %s:%d\n", ip.String(), port)
 	}
 
 	host := s.ring.getHost(ip)

--- a/frame.go
+++ b/frame.go
@@ -472,6 +472,7 @@ func (f *framer) parseFrame() (frame frame, err error) {
 		warnings := f.readStringList()
 		// what to do with warnings?
 		for _, v := range warnings {
+			// TODO: use Logger
 			log.Println(v)
 		}
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -2,7 +2,6 @@ package gocql
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -343,7 +342,7 @@ func (r *ringDescriber) GetHosts() (hosts []*HostInfo, partitioner string, err e
 		host := &HostInfo{port: r.session.cfg.Port}
 		err := rows.Scan(&host.peer, &host.dataCenter, &host.rack, &host.hostId, &host.tokens, &host.version)
 		if err != nil {
-			log.Println(err)
+			r.session.cfg.Log.Println(err)
 			continue
 		}
 

--- a/metadata.go
+++ b/metadata.go
@@ -850,6 +850,7 @@ func (t *typeParser) parse() typeParserResult {
 				var name string
 				decoded, err := hex.DecodeString(*param.name)
 				if err != nil {
+					// TODO: use Logger
 					log.Printf(
 						"Error parsing type '%s', contains collection name '%s' with an invalid format: %v",
 						t.input,

--- a/policies.go
+++ b/policies.go
@@ -307,6 +307,7 @@ func (t *tokenAwareHostPolicy) resetTokenRing() {
 	hosts := t.hosts.get()
 	tokenRing, err := newTokenRing(t.partitioner, hosts)
 	if err != nil {
+		// TODO: use Logger
 		log.Printf("Unable to update the token ring due to error: %s", err)
 		return
 	}

--- a/session.go
+++ b/session.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -220,7 +219,7 @@ func (s *Session) reconnectDownedHosts(intv time.Duration) {
 				for _, h := range hosts {
 					buf.WriteString("[" + h.Peer().String() + ":" + h.State().String() + "]")
 				}
-				log.Println(buf.String())
+				s.cfg.Log.Println(buf.String())
 			}
 
 			for _, h := range hosts {


### PR DESCRIPTION
Adds Log to ClusterConfig to use for all logging, allowing a custom logger like [Logrus](https://github.com/Sirupsen/logrus) to be used. fixes #766

This is partially implemented, as there are several uses of the standard logger that may be more difficult to get the Logger into (marked with TODOs). 
- [ ] resetTokenRing() in polices.go 
- [ ] parse() in metadata.go
- [ ] parseFrame() in frame.go
- [ ] debounce(frame frame) in events.go

I'm interested in feedback on how each of those situations should be resolved:
- Inject the logger somehow
- Bubble errors up, so the logging can be moved elsewhere
- Remove the logging
#### Finishing the implementation

If someone wants to take on the rest of the implementation, [hub](https://github.com/github/hub) makes it easy to pull this code into a new local branch:

``` console
git checkout -b logger
hub am -3 https://github.com/gocql/gocql/pull/803
```
#### How should this be manually tested?

Something like this:

``` go
log := logrus.New()
log.Formatter = &logrus.JSONFormatter{}
...
cfg.Log = log
```

Output like this:

```
{"level":"info","msg":"gocql: unable to dial control conn localhost:9042: dial tcp [::1]:9042: getsockopt: connection refused\n","time":"2016-10-18T17:27:53-06:00"}
```
