### PR TITLE
Fix bug preventing hostnames from being added to hostpool correctly

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -396,7 +396,12 @@ func (pool *hostConnPool) fill() {
 
 			// this is calle with the connetion pool mutex held, this call will
 			// then recursivly try to lock it again. FIXME
-			go pool.session.handleNodeDown(net.ParseIP(pool.host.Peer()), pool.port)
+			go func(host string) {
+				hostAddr, err := lookupHostAddress(host)
+				if err == nil {
+					pool.session.handleNodeDown(hostAddr, pool.port)
+				}
+			}(pool.host.Peer())
 			return
 		}
 

--- a/session.go
+++ b/session.go
@@ -180,7 +180,10 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 				existingHost.update(host)
 			}
 
-			s.handleNodeUp(net.ParseIP(host.Peer()), host.Port(), false)
+			hostAddr, err := lookupHostAddress(host.Peer())
+			if err == nil {
+				s.handleNodeUp(hostAddr, host.Port(), false)
+			}
 		}
 	}
 
@@ -234,7 +237,10 @@ func (s *Session) reconnectDownedHosts(intv time.Duration) {
 				if h.IsUp() {
 					continue
 				}
-				s.handleNodeUp(net.ParseIP(h.Peer()), h.Port(), true)
+				hostAddr, err := lookupHostAddress(h.Peer())
+				if err == nil {
+					s.handleNodeUp(hostAddr, h.Port(), true)
+				}
 			}
 		case <-s.quit:
 			return


### PR DESCRIPTION
Currently if multiple hostnames are passed to `Connect` only the last hostname is actually used by the host selection policy. This is because the hostname is passed by `net.ParseIP` which given anything other than an IP address returns a nil `net.IP` which results in adding the host `{Peer: "<nil>"}`. Any other hosts added to the pool will have the same peer value meaning that any previous hosts are overridden.

To fix this issue all calls to `net.ParseIP` are replaced by a call to the new function `lookupHostAddress` which will attempt to lookup the IP from the hostname if `net.ParseIP` fails.