### PR TITLE
change HostInfo.Peer to be an IP

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -27,7 +27,13 @@ func (p PoolConfig) buildPool(session *Session) *policyConnPool {
 // behavior to fit the most common use cases. Applications that require a
 // different setup must implement their own cluster.
 type ClusterConfig struct {
-	Hosts             []string          // addresses for the initial connections
+	// addresses for the initial connections. It is recomended to use the value set in
+	// the Cassandra config for broadcast_address or listen_address, an IP address not
+	// a domain name. This is because events from Cassandra will use the configured IP
+	// address, which is used to index connected hosts. If the domain name specified
+	// resolves to more than 1 IP address then the driver may connect multiple times to
+	// the same host, and will not mark the node being down or up from events.
+	Hosts             []string
 	CQLVersion        string            // CQL version (default: 3.0.0)
 	ProtoVersion      int               // version of the native protocol (default: 2)
 	Timeout           time.Duration     // connection timeout (default: 600ms)
@@ -100,6 +106,14 @@ type ClusterConfig struct {
 }
 
 // NewCluster generates a new config for the default cluster implementation.
+//
+// The supplied hosts are used to initially connect to the cluster then the rest of
+// the ring will be automatically discovered. It is recomended to use the value set in
+// the Cassandra config for broadcast_address or listen_address, an IP address not
+// a domain name. This is because events from Cassandra will use the configured IP
+// address, which is used to index connected hosts. If the domain name specified
+// resolves to more than 1 IP address then the driver may connect multiple times to
+// the same host, and will not mark the node being down or up from events.
 func NewCluster(hosts ...string) *ClusterConfig {
 	cfg := &ClusterConfig{
 		Hosts:                  hosts,

--- a/conn.go
+++ b/conn.go
@@ -152,8 +152,15 @@ type Conn struct {
 }
 
 // Connect establishes a connection to a Cassandra node.
-func Connect(host *HostInfo, addr string, cfg *ConnConfig,
-	errorHandler ConnErrorHandler, session *Session) (*Conn, error) {
+func Connect(host *HostInfo, cfg *ConnConfig, errorHandler ConnErrorHandler, session *Session) (*Conn, error) {
+	// TODO(zariel): remove these
+	if host == nil {
+		panic("host is nil")
+	} else if len(host.Peer()) == 0 {
+		panic("host missing peer ip address")
+	} else if host.Port() == 0 {
+		panic("host missing port")
+	}
 
 	var (
 		err  error
@@ -163,6 +170,9 @@ func Connect(host *HostInfo, addr string, cfg *ConnConfig,
 	dialer := &net.Dialer{
 		Timeout: cfg.Timeout,
 	}
+
+	// TODO(zariel): handle ipv6 zone
+	addr := (&net.TCPAddr{IP: host.Peer(), Port: host.Port()}).String()
 
 	if cfg.tlsConfig != nil {
 		// the TLS config is safe to be reused by connections but it must not

--- a/conn_test.go
+++ b/conn_test.go
@@ -473,8 +473,7 @@ func TestStream0(t *testing.T) {
 		}
 	})
 
-	host := &HostInfo{peer: srv.Address}
-	conn, err := Connect(host, srv.Address, &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
+	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,8 +508,7 @@ func TestConnClosedBlocked(t *testing.T) {
 		t.Log(err)
 	})
 
-	host := &HostInfo{peer: srv.Address}
-	conn, err := Connect(host, srv.Address, &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
+	conn, err := Connect(srv.host(), &ConnConfig{ProtoVersion: int(srv.protocol)}, errorHandler, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,6 +633,14 @@ type TestServer struct {
 	quit   chan struct{}
 	mu     sync.Mutex
 	closed bool
+}
+
+func (srv *TestServer) host() *HostInfo {
+	host, err := hostInfo(srv.Address, 9042)
+	if err != nil {
+		srv.t.Fatal(err)
+	}
+	return host
 }
 
 func (srv *TestServer) closeWatch() {

--- a/control_test.go
+++ b/control_test.go
@@ -1,0 +1,31 @@
+package gocql
+
+import (
+	"net"
+	"testing"
+)
+
+func TestHostInfo_Lookup(t *testing.T) {
+	hostLookupPreferV4 = true
+	defer func() { hostLookupPreferV4 = false }()
+
+	tests := [...]struct {
+		addr string
+		ip   net.IP
+	}{
+		{"127.0.0.1", net.IPv4(127, 0, 0, 1)},
+		{"localhost", net.IPv4(127, 0, 0, 1)}, // TODO: this may be host dependant
+	}
+
+	for i, test := range tests {
+		host, err := hostInfo(test.addr, 1)
+		if err != nil {
+			t.Errorf("%d: %v", i, err)
+			continue
+		}
+
+		if !host.peer.Equal(test.ip) {
+			t.Errorf("expected ip %v got %v for addr %q", test.ip, host.peer, test.addr)
+		}
+	}
+}

--- a/events.go
+++ b/events.go
@@ -171,25 +171,21 @@ func (s *Session) handleNodeEvent(frames []frame) {
 	}
 }
 
-func (s *Session) handleNewNode(host net.IP, port int, waitForBinary bool) {
-	// TODO(zariel): need to be able to filter discovered nodes
-
+func (s *Session) handleNewNode(ip net.IP, port int, waitForBinary bool) {
 	var hostInfo *HostInfo
 	if s.control != nil && !s.cfg.IgnorePeerAddr {
 		var err error
-		hostInfo, err = s.control.fetchHostInfo(host, port)
+		hostInfo, err = s.control.fetchHostInfo(ip, port)
 		if err != nil {
-			log.Printf("gocql: events: unable to fetch host info for %v: %v\n", host, err)
+			log.Printf("gocql: events: unable to fetch host info for (%s:%d): %v\n", ip, port, err)
 			return
 		}
-
 	} else {
-		hostInfo = &HostInfo{peer: host.String(), port: port, state: NodeUp}
+		hostInfo = &HostInfo{peer: ip, port: port}
 	}
 
-	addr := host.String()
-	if s.cfg.IgnorePeerAddr && hostInfo.Peer() != addr {
-		hostInfo.setPeer(addr)
+	if s.cfg.IgnorePeerAddr && hostInfo.Peer().Equal(ip) {
+		hostInfo.setPeer(ip)
 	}
 
 	if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(hostInfo) {
@@ -217,11 +213,9 @@ func (s *Session) handleNewNode(host net.IP, port int, waitForBinary bool) {
 
 func (s *Session) handleRemovedNode(ip net.IP, port int) {
 	// we remove all nodes but only add ones which pass the filter
-	addr := ip.String()
-
-	host := s.ring.getHost(addr)
+	host := s.ring.getHost(ip)
 	if host == nil {
-		host = &HostInfo{peer: addr}
+		host = &HostInfo{peer: ip, port: port}
 	}
 
 	if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(host) {
@@ -229,9 +223,9 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 	}
 
 	host.setState(NodeDown)
-	s.policy.RemoveHost(addr)
-	s.pool.removeHost(addr)
-	s.ring.removeHost(addr)
+	s.policy.RemoveHost(host)
+	s.pool.removeHost(ip)
+	s.ring.removeHost(ip)
 
 	if !s.cfg.IgnorePeerAddr {
 		s.hostSource.refreshRing()
@@ -242,11 +236,12 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 	if gocqlDebug {
 		log.Printf("gocql: Session.handleNodeUp: %s:%d\n", ip.String(), port)
 	}
-	addr := ip.String()
-	host := s.ring.getHost(addr)
+
+	host := s.ring.getHost(ip)
 	if host != nil {
-		if s.cfg.IgnorePeerAddr && host.Peer() != addr {
-			host.setPeer(addr)
+		if s.cfg.IgnorePeerAddr && host.Peer().Equal(ip) {
+			// TODO: how can this ever be true?
+			host.setPeer(ip)
 		}
 
 		if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(host) {
@@ -257,7 +252,6 @@ func (s *Session) handleNodeUp(ip net.IP, port int, waitForBinary bool) {
 			time.Sleep(t)
 		}
 
-		host.setPort(port)
 		s.pool.hostUp(host)
 		s.policy.HostUp(host)
 		host.setState(NodeUp)
@@ -271,10 +265,10 @@ func (s *Session) handleNodeDown(ip net.IP, port int) {
 	if gocqlDebug {
 		log.Printf("gocql: Session.handleNodeDown: %s:%d\n", ip.String(), port)
 	}
-	addr := ip.String()
-	host := s.ring.getHost(addr)
+
+	host := s.ring.getHost(ip)
 	if host == nil {
-		host = &HostInfo{peer: addr}
+		host = &HostInfo{peer: ip, port: port}
 	}
 
 	if s.cfg.HostFilter != nil && !s.cfg.HostFilter.Accept(host) {
@@ -282,6 +276,6 @@ func (s *Session) handleNodeDown(ip net.IP, port int) {
 	}
 
 	host.setState(NodeDown)
-	s.policy.HostDown(addr)
-	s.pool.hostDown(addr)
+	s.policy.HostDown(host)
+	s.pool.hostDown(ip)
 }

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -1,4 +1,4 @@
-// +build ccm
+// +build ccm, ignore
 
 package gocql
 

--- a/filters_test.go
+++ b/filters_test.go
@@ -1,16 +1,19 @@
 package gocql
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 func TestFilter_WhiteList(t *testing.T) {
-	f := WhiteListHostFilter("addr1", "addr2")
+	f := WhiteListHostFilter("127.0.0.1", "127.0.0.2")
 	tests := [...]struct {
-		addr   string
+		addr   net.IP
 		accept bool
 	}{
-		{"addr1", true},
-		{"addr2", true},
-		{"addr3", false},
+		{net.ParseIP("127.0.0.1"), true},
+		{net.ParseIP("127.0.0.2"), true},
+		{net.ParseIP("127.0.0.3"), false},
 	}
 
 	for i, test := range tests {
@@ -27,12 +30,12 @@ func TestFilter_WhiteList(t *testing.T) {
 func TestFilter_AllowAll(t *testing.T) {
 	f := AcceptAllFilter()
 	tests := [...]struct {
-		addr   string
+		addr   net.IP
 		accept bool
 	}{
-		{"addr1", true},
-		{"addr2", true},
-		{"addr3", true},
+		{net.ParseIP("127.0.0.1"), true},
+		{net.ParseIP("127.0.0.2"), true},
+		{net.ParseIP("127.0.0.3"), true},
 	}
 
 	for i, test := range tests {
@@ -49,12 +52,12 @@ func TestFilter_AllowAll(t *testing.T) {
 func TestFilter_DenyAll(t *testing.T) {
 	f := DenyAllFilter()
 	tests := [...]struct {
-		addr   string
+		addr   net.IP
 		accept bool
 	}{
-		{"addr1", false},
-		{"addr2", false},
-		{"addr3", false},
+		{net.ParseIP("127.0.0.1"), false},
+		{net.ParseIP("127.0.0.2"), false},
+		{net.ParseIP("127.0.0.3"), false},
 	}
 
 	for i, test := range tests {

--- a/policies.go
+++ b/policies.go
@@ -7,6 +7,7 @@ package gocql
 import (
 	"fmt"
 	"log"
+	"net"
 	"sync"
 	"sync/atomic"
 
@@ -90,7 +91,7 @@ func (c *cowHostList) update(host *HostInfo) {
 	c.mu.Unlock()
 }
 
-func (c *cowHostList) remove(addr string) bool {
+func (c *cowHostList) remove(ip net.IP) bool {
 	c.mu.Lock()
 	l := c.get()
 	size := len(l)
@@ -102,7 +103,7 @@ func (c *cowHostList) remove(addr string) bool {
 	found := false
 	newL := make([]*HostInfo, 0, size)
 	for i := 0; i < len(l); i++ {
-		if l[i].Peer() != addr {
+		if !l[i].Peer().Equal(ip) {
 			newL = append(newL, l[i])
 		} else {
 			found = true
@@ -161,9 +162,9 @@ func (s *SimpleRetryPolicy) Attempt(q RetryableQuery) bool {
 
 type HostStateNotifier interface {
 	AddHost(host *HostInfo)
-	RemoveHost(addr string)
+	RemoveHost(host *HostInfo)
 	HostUp(host *HostInfo)
-	HostDown(addr string)
+	HostDown(host *HostInfo)
 }
 
 // HostSelectionPolicy is an interface for selecting
@@ -235,16 +236,16 @@ func (r *roundRobinHostPolicy) AddHost(host *HostInfo) {
 	r.hosts.add(host)
 }
 
-func (r *roundRobinHostPolicy) RemoveHost(addr string) {
-	r.hosts.remove(addr)
+func (r *roundRobinHostPolicy) RemoveHost(host *HostInfo) {
+	r.hosts.remove(host.Peer())
 }
 
 func (r *roundRobinHostPolicy) HostUp(host *HostInfo) {
 	r.AddHost(host)
 }
 
-func (r *roundRobinHostPolicy) HostDown(addr string) {
-	r.RemoveHost(addr)
+func (r *roundRobinHostPolicy) HostDown(host *HostInfo) {
+	r.RemoveHost(host)
 }
 
 // TokenAwareHostPolicy is a token aware host selection policy, where hosts are
@@ -278,9 +279,9 @@ func (t *tokenAwareHostPolicy) AddHost(host *HostInfo) {
 	t.resetTokenRing()
 }
 
-func (t *tokenAwareHostPolicy) RemoveHost(addr string) {
-	t.hosts.remove(addr)
-	t.fallback.RemoveHost(addr)
+func (t *tokenAwareHostPolicy) RemoveHost(host *HostInfo) {
+	t.hosts.remove(host.Peer())
+	t.fallback.RemoveHost(host)
 
 	t.resetTokenRing()
 }
@@ -289,8 +290,8 @@ func (t *tokenAwareHostPolicy) HostUp(host *HostInfo) {
 	t.AddHost(host)
 }
 
-func (t *tokenAwareHostPolicy) HostDown(addr string) {
-	t.RemoveHost(addr)
+func (t *tokenAwareHostPolicy) HostDown(host *HostInfo) {
+	t.RemoveHost(host)
 }
 
 func (t *tokenAwareHostPolicy) resetTokenRing() {
@@ -393,8 +394,9 @@ func (r *hostPoolHostPolicy) SetHosts(hosts []*HostInfo) {
 	hostMap := make(map[string]*HostInfo, len(hosts))
 
 	for i, host := range hosts {
-		peers[i] = host.Peer()
-		hostMap[host.Peer()] = host
+		ip := host.Peer().String()
+		peers[i] = ip
+		hostMap[ip] = host
 	}
 
 	r.mu.Lock()
@@ -404,15 +406,17 @@ func (r *hostPoolHostPolicy) SetHosts(hosts []*HostInfo) {
 }
 
 func (r *hostPoolHostPolicy) AddHost(host *HostInfo) {
+	ip := host.Peer().String()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// If the host addr is present and isn't nil return
-	if h, ok := r.hostMap[host.Peer()]; ok && h != nil{
+	if h, ok := r.hostMap[ip]; ok && h != nil {
 		return
 	}
 	// otherwise, add the host to the map
-	r.hostMap[host.Peer()] = host
+	r.hostMap[ip] = host
 	// and construct a new peer list to give to the HostPool
 	hosts := make([]string, 0, len(r.hostMap))
 	for addr := range r.hostMap {
@@ -420,21 +424,22 @@ func (r *hostPoolHostPolicy) AddHost(host *HostInfo) {
 	}
 
 	r.hp.SetHosts(hosts)
-
 }
 
-func (r *hostPoolHostPolicy) RemoveHost(addr string) {
+func (r *hostPoolHostPolicy) RemoveHost(host *HostInfo) {
+	ip := host.Peer().String()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, ok := r.hostMap[addr]; !ok {
+	if _, ok := r.hostMap[ip]; !ok {
 		return
 	}
 
-	delete(r.hostMap, addr)
+	delete(r.hostMap, ip)
 	hosts := make([]string, 0, len(r.hostMap))
-	for addr := range r.hostMap {
-		hosts = append(hosts, addr)
+	for _, host := range r.hostMap {
+		hosts = append(hosts, host.Peer().String())
 	}
 
 	r.hp.SetHosts(hosts)
@@ -444,8 +449,8 @@ func (r *hostPoolHostPolicy) HostUp(host *HostInfo) {
 	r.AddHost(host)
 }
 
-func (r *hostPoolHostPolicy) HostDown(addr string) {
-	r.RemoveHost(addr)
+func (r *hostPoolHostPolicy) HostDown(host *HostInfo) {
+	r.RemoveHost(host)
 }
 
 func (r *hostPoolHostPolicy) SetPartitioner(partitioner string) {
@@ -488,10 +493,12 @@ func (host selectedHostPoolHost) Info() *HostInfo {
 }
 
 func (host selectedHostPoolHost) Mark(err error) {
+	ip := host.info.Peer().String()
+
 	host.policy.mu.RLock()
 	defer host.policy.mu.RUnlock()
 
-	if _, ok := host.policy.hostMap[host.info.Peer()]; !ok {
+	if _, ok := host.policy.hostMap[ip]; !ok {
 		// host was removed between pick and mark
 		return
 	}

--- a/query_executor.go
+++ b/query_executor.go
@@ -28,7 +28,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 			continue
 		}
 
-		pool, ok := q.pool.getPool(host.Peer())
+		pool, ok := q.pool.getPool(host)
 		if !ok {
 			continue
 		}

--- a/ring_test.go
+++ b/ring_test.go
@@ -1,11 +1,14 @@
 package gocql
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 func TestRing_AddHostIfMissing_Missing(t *testing.T) {
 	ring := &ring{}
 
-	host := &HostInfo{peer: "test1"}
+	host := &HostInfo{peer: net.IPv4(1, 1, 1, 1)}
 	h1, ok := ring.addHostIfMissing(host)
 	if ok {
 		t.Fatal("host was reported as already existing")
@@ -19,10 +22,10 @@ func TestRing_AddHostIfMissing_Missing(t *testing.T) {
 func TestRing_AddHostIfMissing_Existing(t *testing.T) {
 	ring := &ring{}
 
-	host := &HostInfo{peer: "test1"}
+	host := &HostInfo{peer: net.IPv4(1, 1, 1, 1)}
 	ring.addHostIfMissing(host)
 
-	h2 := &HostInfo{peer: "test1"}
+	h2 := &HostInfo{peer: net.IPv4(1, 1, 1, 1)}
 
 	h1, ok := ring.addHostIfMissing(h2)
 	if !ok {

--- a/token.go
+++ b/token.go
@@ -184,7 +184,7 @@ func (t *tokenRing) String() string {
 		buf.WriteString("]")
 		buf.WriteString(t.tokens[i].String())
 		buf.WriteString(":")
-		buf.WriteString(t.hosts[i].Peer())
+		buf.WriteString(t.hosts[i].Peer().String())
 	}
 	buf.WriteString("\n}")
 	return string(buf.Bytes())


### PR DESCRIPTION
When Cassandra returns a hosts info the peer address is defined as an
inet both at protocol for events and the schema for the peer
information.

Previously this was stored as a string, and is used to
connect to hosts and also to index hosts by. This is different to what
happens for a user supplied address, the potentially DNS name is kept 
as the peer address. This means that there can be duplicate
host pools, duplicate host info in the ring.

Fix this by making everything rely on a hosts address being an IP
address instead of either a DNS name or an IP.