### PR TITLE
When unmarshalling timestamps set null values to 0 time to be consist…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,3 +80,4 @@ Marcus King <marcusking01@gmail.com>
 Andrew de Andrade <andrew@deandrade.com.br>
 Robert Nix <robert@nicerobot.org>
 Nathan Youngman <git@nathany.com>
+Charles Law <charles.law@gmail.com>; <claw@conduce.com>

--- a/marshal.go
+++ b/marshal.go
@@ -1094,6 +1094,7 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	case *time.Time:
 		if len(data) == 0 {
+			*v = time.Time{}
 			return nil
 		}
 		x := decBigInt(data)


### PR DESCRIPTION
…ent with other types

Warning: I consider this a bug, but some people may be using this as a feature.

Below is a simplified version of some code I'm working with:


    //Print times files deleted
    iter := session.Query(`SELECT deleted FROM files.metadata WHERE owner = ?`, user).Iter()
    var deleted time.Time
    for iter.Scan(&deleted) {
        if !deleted.IsZero() {
            fmt.Println("File was deleted at", deleted)
        }
    }

The `deleted` variable is not re-zero'ed for null rows and so after seeing 1 non-null value, the deleted value remains non-zero.  Other types get reset.  Here it is for string: https://github.com/gocql/gocql/blob/master/marshal.go#L222 which gets set to an empty string.  Ints go through https://github.com/gocql/gocql/blob/master/marshal.go#L489, etc.