### PR TITLE
Use RWMutex in prepared statement cache

### DIFF
--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -9,7 +9,7 @@ const defaultMaxPreparedStmts = 1000
 
 // preparedLRU is the prepared statement cache
 type preparedLRU struct {
-	mu  sync.Mutex
+	mu  sync.RWMutex
 	lru *lru.Cache
 }
 
@@ -47,10 +47,10 @@ func (p *preparedLRU) remove(key string) bool {
 }
 
 func (p *preparedLRU) execIfMissing(key string, fn func(lru *lru.Cache) *inflightPrepare) (*inflightPrepare, bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
+	p.mu.RLock()
 	val, ok := p.lru.Get(key)
+	p.mu.RUnlock()
+
 	if ok {
 		return val.(*inflightPrepare), true
 	}

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -57,6 +57,9 @@ func (p *preparedLRU) execIfMissing(key string, fn func(lru *lru.Cache) *infligh
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if val, ok := p.lru.Get(key); ok {
+		return val.(*inflightPrepare), true
+	}
 	return fn(p.lru), false
 }
 

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -55,6 +55,8 @@ func (p *preparedLRU) execIfMissing(key string, fn func(lru *lru.Cache) *infligh
 		return val.(*inflightPrepare), true
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return fn(p.lru), false
 }
 

--- a/prepared_cache_test.go
+++ b/prepared_cache_test.go
@@ -1,0 +1,22 @@
+package gocql
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql/internal/lru"
+)
+
+func BenchmarkLRU(b *testing.B) {
+	pl := preparedLRU{
+		lru: lru.New(10),
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			pl.execIfMissing("foo", func(c *lru.Cache) *inflightPrepare {
+				c.Add("foo", (*inflightPrepare)(nil))
+				return nil
+			})
+		}
+	})
+}


### PR DESCRIPTION
This change introduces the usage of an RWMutex in order to use `RLock` in the execIfMissing.


Benchmark results using the the old way:
```
BenchmarkLRU                    10000000               185 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-2                  10000000               178 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-4                   5000000               212 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-8                   5000000               248 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-16                 10000000               222 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-24                  5000000               240 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-32                  5000000               283 ns/op               0 B/op          0 allocs/op
BenchmarkLRU-40                  5000000               251 ns/op               0 B/op          0 allocs/op
```

Benchmark results using the new way:
```
BenchmarkLRU                    30000000                45.5 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-2                  30000000                68.8 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-4                  20000000                64.9 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-8                  20000000                64.1 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-16                 20000000                66.6 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-24                 20000000                67.1 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-32                 20000000                67.7 ns/op             0 B/op          0 allocs/op
BenchmarkLRU-40                 20000000                67.7 ns/op             0 B/op          0 allocs/op
```