### PR TITLE
add the Warnings function on Iter

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -275,6 +275,7 @@ type frameHeader struct {
 	op            frameOp
 	length        int
 	customPayload map[string][]byte
+	warnings      []string
 }
 
 func (f frameHeader) String() string {
@@ -468,11 +469,7 @@ func (f *framer) parseFrame() (frame frame, err error) {
 	}
 
 	if f.header.flags&flagWarning == flagWarning {
-		warnings := f.readStringList()
-		// what to do with warnings?
-		for _, v := range warnings {
-			Logger.Println(v)
-		}
+		f.header.warnings = f.readStringList()
 	}
 
 	if f.header.flags&flagCustomPayload == flagCustomPayload {

--- a/session.go
+++ b/session.go
@@ -1234,6 +1234,13 @@ func (iter *Iter) GetCustomPayload() map[string][]byte {
 	return iter.framer.header.customPayload
 }
 
+// Warnings returns any warnings generated if given in the response from Cassandra.
+//
+// This is only available starting with CQL Protocol v4.
+func (iter *Iter) Warnings() []string {
+	return iter.framer.header.warnings
+}
+
 // Close closes the iterator and returns any errors that happened during
 // the query or the iteration.
 func (iter *Iter) Close() error {


### PR DESCRIPTION
Took a shot at implementing #813.

I store the warnings inside the header, mostly because the custom payload is there already so it made sense.