### PR TITLE
marshalUDT: allow not using all the UDT fields

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1590,7 +1590,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		for _, e := range udt.Elements {
 			val, ok := v[e.Name]
 			if !ok {
-				return nil, marshalErrorf("missing UDT field in map: %s", e.Name)
+				continue
 			}
 
 			data, err := Marshal(e.Type, val)


### PR DESCRIPTION
When inserting a UDT via a map, allow the map to be a subset of the UDT.

Fixes #841