### PR TITLE
Support adding cluster contact points with specified port

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -4,6 +4,7 @@ package gocql
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math"
 	"math/big"
@@ -51,7 +52,14 @@ func TestAuthentication(t *testing.T) {
 //TestRingDiscovery makes sure that you can autodiscover other cluster members when you seed a cluster config with just one node
 func TestRingDiscovery(t *testing.T) {
 	cluster := createCluster()
-	cluster.Hosts = clusterHosts[:1]
+	hosts := make([]Host, len(clusterHosts[:1]))
+	for i, h := range clusterHosts[:1] {
+		hosts[i] = Host{
+			Host: h,
+			Port: 9042,
+		}
+	}
+	cluster.Hosts = hosts
 
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
@@ -562,7 +570,12 @@ func TestCreateSessionTimeout(t *testing.T) {
 	}()
 
 	cluster := createCluster()
-	cluster.Hosts = []string{"127.0.0.1:1"}
+	cluster.Hosts = []Host{
+		{
+			Host: "127.0.0.1",
+			Port: 1,
+		},
+	}
 	session, err := cluster.CreateSession()
 	if err == nil {
 		session.Close()
@@ -1203,7 +1216,12 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 	cluster := createCluster()
 	cluster.MaxPreparedStmts = maxPrepared
 	cluster.Events.DisableSchemaEvents = true
-	cluster.Hosts = []string{host}
+	cluster.Hosts = []Host{
+		{
+			Host: host,
+			Port: 9042,
+		},
+	}
 
 	cluster.HostFilter = WhiteListHostFilter(host)
 
@@ -1259,29 +1277,29 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 
 	// Walk through all the configured hosts and test cache retention and eviction
 	for _, host := range session.cfg.Hosts {
-		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
+		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(fmt.Sprintf("%s:%d", host.Host, host.Port), session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
 		if ok {
-			t.Errorf("expected first select to be purged but was in cache for host=%q", host)
+			t.Errorf("expected first select to be purged but was in cache for host=%+v", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(fmt.Sprintf("%s:%d", host.Host, host.Port), session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
 		if !ok {
-			t.Errorf("exepected second select to be in cache for host=%q", host)
+			t.Errorf("exepected second select to be in cache for host=%+v", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(fmt.Sprintf("%s:%d", host.Host, host.Port), session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
 		if !ok {
-			t.Errorf("expected insert to be in cache for host=%q", host)
+			t.Errorf("expected insert to be in cache for host=%+v", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(fmt.Sprintf("%s:%d", host.Host, host.Port), session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
 		if !ok {
-			t.Errorf("expected update to be in cached for host=%q", host)
+			t.Errorf("expected update to be in cached for host=%+v", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(fmt.Sprintf("%s:%d", host.Host, host.Port), session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
 		if !ok {
-			t.Errorf("expected delete to be cached for host=%q", host)
+			t.Errorf("expected delete to be cached for host=%+v", host)
 		}
 	}
 }
@@ -2346,13 +2364,16 @@ func TestDiscoverViaProxy(t *testing.T) {
 	}(&wg)
 
 	defer wg.Wait()
-
 	proxyAddr := proxy.Addr().String()
 
 	cluster := createCluster()
 	cluster.NumConns = 1
 	// initial host is the proxy address
-	cluster.Hosts = []string{proxyAddr}
+	cluster.Hosts = []Host{
+		{
+			Host: proxyAddr,
+		},
+	}
 
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()

--- a/cluster.go
+++ b/cluster.go
@@ -7,6 +7,7 @@ package gocql
 import (
 	"errors"
 	"net"
+	"strconv"
 	"time"
 )
 
@@ -23,6 +24,12 @@ func (p PoolConfig) buildPool(session *Session) *policyConnPool {
 	return newPolicyConnPool(session)
 }
 
+// Host is a struct to define a host with port for a node in the cluster.
+type Host struct {
+	Host string
+	Port int
+}
+
 // ClusterConfig is a struct to configure the default cluster implementation
 // of gocql. It has a variety of attributes that can be used to modify the
 // behavior to fit the most common use cases. Applications that require a
@@ -34,7 +41,7 @@ type ClusterConfig struct {
 	// address, which is used to index connected hosts. If the domain name specified
 	// resolves to more than 1 IP address then the driver may connect multiple times to
 	// the same host, and will not mark the node being down or up from events.
-	Hosts      []string
+	Hosts      []Host
 	CQLVersion string // CQL version (default: 3.0.0)
 
 	// ProtoVersion sets the version of the native protocol to use, this will
@@ -44,22 +51,22 @@ type ClusterConfig struct {
 	// If it is 0 or unset (the default) then the driver will attempt to discover the
 	// highest supported protocol for the cluster. In clusters with nodes of different
 	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
-	ProtoVersion      int
-	Timeout           time.Duration     // connection timeout (default: 600ms)
-	Port              int               // port (default: 9042)
-	Keyspace          string            // initial keyspace (optional)
-	NumConns          int               // number of connections per host (default: 2)
-	Consistency       Consistency       // default consistency level (default: Quorum)
-	Compressor        Compressor        // compression algorithm (default: nil)
-	Authenticator     Authenticator     // authenticator (default: nil)
-	RetryPolicy       RetryPolicy       // Default retry policy to use for queries (default: 0)
-	SocketKeepalive   time.Duration     // The keepalive period to use, enabled if > 0 (default: 0)
-	MaxPreparedStmts  int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
-	MaxRoutingKeyInfo int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
-	PageSize          int               // Default page size to use for created sessions (default: 5000)
-	SerialConsistency SerialConsistency // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
-	SslOpts           *SslOptions
-	DefaultTimestamp  bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
+	ProtoVersion        int
+	Timeout             time.Duration     // connection timeout (default: 600ms)
+	NativeTransportPort int               // native transport port (default: 9042)
+	Keyspace            string            // initial keyspace (optional)
+	NumConns            int               // number of connections per host (default: 2)
+	Consistency         Consistency       // default consistency level (default: Quorum)
+	Compressor          Compressor        // compression algorithm (default: nil)
+	Authenticator       Authenticator     // authenticator (default: nil)
+	RetryPolicy         RetryPolicy       // Default retry policy to use for queries (default: 0)
+	SocketKeepalive     time.Duration     // The keepalive period to use, enabled if > 0 (default: 0)
+	MaxPreparedStmts    int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
+	MaxRoutingKeyInfo   int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
+	PageSize            int               // Default page size to use for created sessions (default: 5000)
+	SerialConsistency   SerialConsistency // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
+	SslOpts             *SslOptions
+	DefaultTimestamp    bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
@@ -128,11 +135,43 @@ type ClusterConfig struct {
 // resolves to more than 1 IP address then the driver may connect multiple times to
 // the same host, and will not mark the node being down or up from events.
 func NewCluster(hosts ...string) *ClusterConfig {
+	h := make([]Host, len(hosts))
+	for i, host := range hosts {
+		h[i] = Host{
+			Host: host,
+			Port: 9042,
+		}
+	}
+	return defaultCluster(h)
+}
+
+// NewClusterWithPort generates a new config for the default cluster implementation with host:port Hosts.
+// The same caveats apply as with NewCluster.
+func NewClusterWithPort(hosts ...string) (*ClusterConfig, error) {
+	h := make([]Host, len(hosts))
+	for i, host := range hosts {
+		host, port, err := net.SplitHostPort(host)
+		if err != nil {
+			return nil, err
+		}
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, err
+		}
+		h[i] = Host{
+			Host: host,
+			Port: p,
+		}
+	}
+	return defaultCluster(h), nil
+}
+
+func defaultCluster(hosts []Host) *ClusterConfig {
 	cfg := &ClusterConfig{
 		Hosts:                  hosts,
 		CQLVersion:             "3.0.0",
 		Timeout:                600 * time.Millisecond,
-		Port:                   9042,
+		NativeTransportPort:    9042,
 		NumConns:               2,
 		Consistency:            Quorum,
 		MaxPreparedStmts:       defaultMaxPreparedStmts,

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,16 +1,16 @@
 package gocql
 
 import (
+	"net"
 	"testing"
 	"time"
-	"net"
 )
 
 func TestNewCluster_Defaults(t *testing.T) {
 	cfg := NewCluster()
 	assertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
 	assertEqual(t, "cluster config timeout", 600*time.Millisecond, cfg.Timeout)
-	assertEqual(t, "cluster config port", 9042, cfg.Port)
+	assertEqual(t, "cluster config native transport port", 9042, cfg.NativeTransportPort)
 	assertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
 	assertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
 	assertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
@@ -24,8 +24,20 @@ func TestNewCluster_Defaults(t *testing.T) {
 func TestNewCluster_WithHosts(t *testing.T) {
 	cfg := NewCluster("addr1", "addr2")
 	assertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
-	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
-	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0].Host)
+	assertEqual(t, "cluster config port 0", 9042, cfg.Hosts[0].Port)
+	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1].Host)
+	assertEqual(t, "cluster config port 0", 9042, cfg.Hosts[1].Port)
+}
+
+func TestNewCluster_WithHostsAndPorts(t *testing.T) {
+	cfg, err := NewClusterWithPort("addr1:1", "addr2:2")
+	assertNil(t, "new cluster should not error", err)
+	assertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
+	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0].Host)
+	assertEqual(t, "cluster config port 0", 1, cfg.Hosts[0].Port)
+	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1].Host)
+	assertEqual(t, "cluster config port 0", 2, cfg.Hosts[1].Port)
 }
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {

--- a/common_test.go
+++ b/common_test.go
@@ -4,15 +4,15 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"net"
 )
 
 var (
-	flagCluster      = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
+	flagCluster      = flag.String("cluster", "127.0.0.1:9042", "a comma-separated list of host:port tuples")
 	flagProto        = flag.Int("proto", 2, "protcol version")
 	flagCQL          = flag.String("cql", "3.0.0", "CQL version")
 	flagRF           = flag.Int("rf", 1, "replication factor for test keyspace")
@@ -154,9 +154,9 @@ func createTestSession() *Session {
 	config.IgnorePeerAddr = true
 	config.PoolConfig.HostSelectionPolicy = RoundRobinHostPolicy()
 	session := &Session{
-		cfg:    *config,
+		cfg: *config,
 		connCfg: &ConnConfig{
-			Timeout: 10*time.Millisecond,
+			Timeout:   10 * time.Millisecond,
 			Keepalive: 0,
 		},
 		policy: config.PoolConfig.HostSelectionPolicy,

--- a/common_test.go
+++ b/common_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	flagCluster      = flag.String("cluster", "127.0.0.1:9042", "a comma-separated list of host:port tuples")
+	flagCluster      = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
 	flagProto        = flag.Int("proto", 2, "protcol version")
 	flagCQL          = flag.String("cql", "3.0.0", "CQL version")
 	flagRF           = flag.Int("rf", 1, "replication factor for test keyspace")

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -60,14 +60,13 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 type policyConnPool struct {
 	session *Session
 
-	port     int
 	numConns int
 	keyspace string
 
 	mu            sync.RWMutex
 	hostConnPools map[string]*hostConnPool
 
-	endpoints []string
+	endpoints []Host
 }
 
 func connConfig(session *Session) (*ConnConfig, error) {
@@ -101,13 +100,12 @@ func newPolicyConnPool(session *Session) *policyConnPool {
 	// create the pool
 	pool := &policyConnPool{
 		session:       session,
-		port:          session.cfg.Port,
 		numConns:      session.cfg.NumConns,
 		keyspace:      session.cfg.Keyspace,
 		hostConnPools: map[string]*hostConnPool{},
 	}
 
-	pool.endpoints = make([]string, len(session.cfg.Hosts))
+	pool.endpoints = make([]Host, len(session.cfg.Hosts))
 	copy(pool.endpoints, session.cfg.Hosts)
 
 	return pool
@@ -142,7 +140,7 @@ func (p *policyConnPool) SetHosts(hosts []*HostInfo) {
 			pools <- newHostConnPool(
 				p.session,
 				host,
-				p.port,
+				host.Port(),
 				p.numConns,
 				p.keyspace,
 			)

--- a/filters.go
+++ b/filters.go
@@ -40,7 +40,13 @@ func DataCentreHostFilter(dataCentre string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(hosts, 9042)
+	h := make([]Host, len(hosts))
+	for i, host := range hosts {
+		h[i] = Host{
+			Host: host,
+		}
+	}
+	hostInfos, err := addrsToHosts(h)
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/host_source.go
+++ b/host_source.go
@@ -328,9 +328,7 @@ func (r *ringDescriber) GetHosts() (hosts []*HostInfo, partitioner string, err e
 			return nil, "", err
 		}
 	}
-
-	localHost.port = r.session.cfg.Port
-
+	localHost.port = r.session.cfg.NativeTransportPort
 	hosts = []*HostInfo{localHost}
 
 	rows := r.session.control.query("SELECT rpc_address, data_center, rack, host_id, tokens, release_version FROM system.peers").Scanner()
@@ -339,7 +337,7 @@ func (r *ringDescriber) GetHosts() (hosts []*HostInfo, partitioner string, err e
 	}
 
 	for rows.Next() {
-		host := &HostInfo{port: r.session.cfg.Port}
+		host := &HostInfo{port: r.session.cfg.NativeTransportPort}
 		err := rows.Scan(&host.peer, &host.dataCenter, &host.rack, &host.hostId, &host.tokens, &host.version)
 		if err != nil {
 			Logger.Println(err)

--- a/session.go
+++ b/session.go
@@ -75,18 +75,16 @@ var queryPool = &sync.Pool{
 	},
 }
 
-func addrsToHosts(addrs []string, defaultPort int) ([]*HostInfo, error) {
-	hosts := make([]*HostInfo, len(addrs))
-	for i, hostport := range addrs {
-		host, err := hostInfo(hostport, defaultPort)
+func addrsToHosts(hosts []Host) ([]*HostInfo, error) {
+	hostinfo := make([]*HostInfo, len(hosts))
+	for i, host := range hosts {
+		h, err := hostInfo(host.Host, host.Port)
 		if err != nil {
 			return nil, err
 		}
-
-		hosts[i] = host
+		hostinfo[i] = h
 	}
-
-	return hosts, nil
+	return hostinfo, nil
 }
 
 // NewSession wraps an existing Node.
@@ -142,7 +140,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 }
 
 func (s *Session) init() error {
-	hosts, err := addrsToHosts(s.cfg.Hosts, s.cfg.Port)
+	hosts, err := addrsToHosts(s.cfg.Hosts)
 	if err != nil {
 		return err
 	}
@@ -167,7 +165,6 @@ func (s *Session) init() error {
 			s.cfg.ProtoVersion = proto
 			connCfg.ProtoVersion = proto
 		}
-
 		if err := s.control.connect(hosts); err != nil {
 			return err
 		}


### PR DESCRIPTION
In our cluster set up (hosted on [Compose](https://www.compose.com)), the public facing contact points for the cluster do not have consistent ports, due to how they are hosted. We implemented support for specifying the port for each host during cluster configuration.

Let me know if this is something you guys would consider useful or if you guys need any changes before getting this upstream.