### PR TITLE
suggest journey, Gemnasium's fork of the migrate library

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Ecosystem
 
 The following community maintained tools are known to integrate with gocql:
 
-* [migrate](https://github.com/mattes/migrate) is a migration handling tool written in Go with Cassandra support.
+* [journey](https://github.com/db-journey/journey) is a migration tool with Cassandra support.
 * [negronicql](https://github.com/mikebthun/negronicql) is gocql middleware for Negroni.
 * [cqlr](https://github.com/relops/cqlr) adds the ability to auto-bind a CQL iterator to a struct or to bind a struct to an INSERT statement.
 * [cqlc](http://relops.com/cqlc) generates gocql compliant code from your Cassandra schema so that you can write type safe CQL statements in Go with a natural query syntax.


### PR DESCRIPTION
It has more up-to-date support for Cassandra.

/cc @gravis @mattes

ref: https://github.com/mattes/migrate/issues/127
ref: https://github.com/gemnasium/migrate/blob/master/CHANGELOG.md