### PR TITLE
control.go: fix race condition on randr

### DIFF
--- a/control.go
+++ b/control.go
@@ -11,11 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"sync"
+
 	"golang.org/x/net/context"
 )
 
 var (
-	randr *rand.Rand
+	randr    *rand.Rand
+	mutRandr sync.Mutex
 )
 
 func init() {
@@ -135,7 +138,9 @@ func hostInfo(addr string, defaultPort int) (*HostInfo, error) {
 }
 
 func shuffleHosts(hosts []*HostInfo) []*HostInfo {
+	mutRandr.Lock()
 	perm := randr.Perm(len(hosts))
+	mutRandr.Unlock()
 	shuffled := make([]*HostInfo, len(hosts))
 
 	for i, host := range hosts {


### PR DESCRIPTION
```console
==================
WARNING: DATA RACE
Read at 0x00c42023c000 by goroutine 87:
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:231 +0x3f
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:81 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/go/src/math/rand/rand.go:95 +0x38
  math/rand.(*Rand).Int31n()
      /usr/local/go/src/math/rand/rand.go:127 +0xd2
  math/rand.(*Rand).Intn()
      /usr/local/go/src/math/rand/rand.go:144 +0x52
  math/rand.(*Rand).Perm()
      /usr/local/go/src/math/rand/rand.go:197 +0xa2
  github.com/.../github.com/gocql/gocql.(*controlConn).shuffleDial()
      /.../vendor/github.com/gocql/gocql/control.go:109 +0x6f


```