### PR TITLE
Change KeypsaceMetadata() to return an error if the keyspace does not exist 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,3 +84,4 @@ Charles Law <charles.law@gmail.com>; <claw@conduce.com>
 Nathan Davies <nathanjamesdavies@gmail.com>
 Bo Blanton <bo.blanton@gmail.com>
 Vincent Rischmann <me@vrischmann.me>
+Jesse Claven <jesse.claven@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1598,7 +1598,7 @@ func TestEmptyTimestamp(t *testing.T) {
 	}
 }
 
-// Integration test of just querying for data from the system.schema_keyspace table
+// Integration test of just querying for data from the system.schema_keyspace table where the keyspace DOES exist.
 func TestGetKeyspaceMetadata(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1629,6 +1629,18 @@ func TestGetKeyspaceMetadata(t *testing.T) {
 	}
 	if rfInt != *flagRF {
 		t.Errorf("Expected replication factor to be %d but was %d", *flagRF, rfInt)
+	}
+}
+
+// Integration test of just querying for data from the system.schema_keyspace table where the keyspace DOES NOT exist.
+func TestGetKeyspaceMetadataFails(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	keyspaceMetadata, err := getKeyspaceMetadata(session, "gocql_keyspace_does_not_exist")
+
+	if err != ErrKeyspaceDoesNotExist || err == nil {
+		t.Failf("Expected error of type ErrKeySpaceDoesNotExist. Instead, error was %v", err)
 	}
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1640,7 +1640,7 @@ func TestGetKeyspaceMetadataFails(t *testing.T) {
 	keyspaceMetadata, err := getKeyspaceMetadata(session, "gocql_keyspace_does_not_exist")
 
 	if err != ErrKeyspaceDoesNotExist || err == nil {
-		t.Failf("Expected error of type ErrKeySpaceDoesNotExist. Instead, error was %v", err)
+		t.Fatalf("Expected error of type ErrKeySpaceDoesNotExist. Instead, error was %v", err)
 	}
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1637,7 +1637,7 @@ func TestGetKeyspaceMetadataFails(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
 
-	keyspaceMetadata, err := getKeyspaceMetadata(session, "gocql_keyspace_does_not_exist")
+	_, err := getKeyspaceMetadata(session, "gocql_keyspace_does_not_exist")
 
 	if err != ErrKeyspaceDoesNotExist || err == nil {
 		t.Fatalf("Expected error of type ErrKeySpaceDoesNotExist. Instead, error was %v", err)

--- a/metadata.go
+++ b/metadata.go
@@ -416,6 +416,9 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 		var replication map[string]string
 
 		iter := session.control.query(stmt, keyspaceName)
+		if iter.NumRows() == 0 {
+			return nil, ErrKeyspaceDoesNotExist
+		}
 		iter.Scan(&keyspace.DurableWrites, &replication)
 		err := iter.Close()
 		if err != nil {
@@ -438,6 +441,9 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 		var strategyOptionsJSON []byte
 
 		iter := session.control.query(stmt, keyspaceName)
+		if iter.NumRows() == 0 {
+			return nil, ErrKeyspaceDoesNotExist
+		}
 		iter.Scan(&keyspace.DurableWrites, &keyspace.StrategyClass, &strategyOptionsJSON)
 		err := iter.Close()
 		if err != nil {

--- a/session.go
+++ b/session.go
@@ -389,7 +389,7 @@ func (s *Session) executeQuery(qry *Query) *Iter {
 	return iter
 }
 
-// KeyspaceMetadata returns the schema metadata for the keyspace specified.
+// KeyspaceMetadata returns the schema metadata for the keyspace specified. Returns an error if the keyspace does not exist.
 func (s *Session) KeyspaceMetadata(keyspace string) (*KeyspaceMetadata, error) {
 	// fail fast
 	if s.Closed() {

--- a/session.go
+++ b/session.go
@@ -1570,15 +1570,16 @@ func (e Error) Error() string {
 }
 
 var (
-	ErrNotFound      = errors.New("not found")
-	ErrUnavailable   = errors.New("unavailable")
-	ErrUnsupported   = errors.New("feature not supported")
-	ErrTooManyStmts  = errors.New("too many statements")
-	ErrUseStmt       = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
-	ErrSessionClosed = errors.New("session has been closed")
-	ErrNoConnections = errors.New("gocql: no hosts available in the pool")
-	ErrNoKeyspace    = errors.New("no keyspace provided")
-	ErrNoMetadata    = errors.New("no metadata available")
+	ErrNotFound             = errors.New("not found")
+	ErrUnavailable          = errors.New("unavailable")
+	ErrUnsupported          = errors.New("feature not supported")
+	ErrTooManyStmts         = errors.New("too many statements")
+	ErrUseStmt              = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
+	ErrSessionClosed        = errors.New("session has been closed")
+	ErrNoConnections        = errors.New("gocql: no hosts available in the pool")
+	ErrNoKeyspace           = errors.New("no keyspace provided")
+	ErrKeyspaceDoesNotExist = errors.New("keyspace does not exist")
+	ErrNoMetadata           = errors.New("no metadata available")
 )
 
 type ErrProtocol struct{ error }

--- a/session.go
+++ b/session.go
@@ -1574,7 +1574,7 @@ var (
 	ErrUnavailable          = errors.New("unavailable")
 	ErrUnsupported          = errors.New("feature not supported")
 	ErrTooManyStmts         = errors.New("too many statements")
-	ErrUseStmt              = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explaination.")
+	ErrUseStmt              = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explanation.")
 	ErrSessionClosed        = errors.New("session has been closed")
 	ErrNoConnections        = errors.New("gocql: no hosts available in the pool")
 	ErrNoKeyspace           = errors.New("no keyspace provided")


### PR DESCRIPTION
Previously if a keyspace did not exist a partially empty `KeyspaceMetadata` struct was returned. From what I could see, the more appropriate behaviour would be to return an error indicating so.

Detecting if the keyspace actual exists is done by checking the number of rows returned from the query to the system table `system_schema.keyspaces`. If there were no rows returned then that indicates the keyspace doesn't exist.

No unit tests exist for the called function (`geKeyspaceMetadata`) though an integration test exists for `KeyspaceMetadata()`. A subsequent integration test was added which attempts to get the metadata for a keyspace that is known to not exist.

A slight update to the godoc for KeyspaceMetadata() was added detailing this new behaviour.

Solves issue #849.