### PR TITLE
conn: fix memory leak when using long timeouts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -536,6 +536,7 @@ func (c *Conn) releaseStream(stream int) {
 	delete(c.calls, stream)
 	c.mu.Unlock()
 
+	call.timer.Stop()
 	streamPool.Put(call)
 	c.streams.Clear(stream)
 }


### PR DESCRIPTION
A timer will on be garbage collected once it has fired, if a call returns before the timeout is reached then it will not be garbage collected, leading to potentially many timers on the heap.

fixes #851