### PR TITLE
conn: fix memory leak when using long timeouts

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -536,6 +536,10 @@ func (c *Conn) releaseStream(stream int) {
 	delete(c.calls, stream)
 	c.mu.Unlock()
 
+	if call.timer != nil {
+		call.timer.Stop()
+	}
+
 	streamPool.Put(call)
 	c.streams.Clear(stream)
 }


### PR DESCRIPTION
A timer will only be garbage collected once it has fired, if a call
returns before the timeout is reached then it will not be garbage
collected, leading to potentially many timers on the heap.

fixes #851