### PR TITLE
Get rid of ReconnectInterval

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,3 +85,4 @@ Nathan Davies <nathanjamesdavies@gmail.com>
 Bo Blanton <bo.blanton@gmail.com>
 Vincent Rischmann <me@vrischmann.me>
 Jesse Claven <jesse.claven@gmail.com>
+Pavel Sapezhko <amelius0712@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -570,26 +570,6 @@ func TestCreateSessionTimeout(t *testing.T) {
 	}
 }
 
-func TestReconnection(t *testing.T) {
-	cluster := createCluster()
-	cluster.ReconnectInterval = 1 * time.Second
-	session := createSessionFromCluster(cluster, t)
-	defer session.Close()
-
-	h := session.ring.allHosts()[0]
-	session.handleNodeDown(h.Peer(), h.Port())
-
-	if h.State() != NodeDown {
-		t.Fatal("Host should be NodeDown but not.")
-	}
-
-	time.Sleep(cluster.ReconnectInterval + h.Version().nodeUpDelay() + 1*time.Second)
-
-	if h.State() != NodeUp {
-		t.Fatal("Host should be NodeUp but not. Failed to reconnect.")
-	}
-}
-
 type FullName struct {
 	FirstName string
 	LastName  string

--- a/cluster.go
+++ b/cluster.go
@@ -64,9 +64,6 @@ type ClusterConfig struct {
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
 
-	// If not zero, gocql attempt to reconnect known DOWN nodes in every ReconnectSleep.
-	ReconnectInterval time.Duration
-
 	// The maximum amount of time to wait for schema agreement in a cluster after
 	// receiving a schema change frame. (deault: 60s)
 	MaxWaitSchemaAgreement time.Duration
@@ -140,7 +137,6 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		PageSize:               5000,
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
-		ReconnectInterval:      60 * time.Second,
 	}
 	return cfg
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,9 +1,9 @@
 package gocql
 
 import (
+	"net"
 	"testing"
 	"time"
-	"net"
 )
 
 func TestNewCluster_Defaults(t *testing.T) {
@@ -18,7 +18,6 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
 	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
-	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
 }
 
 func TestNewCluster_WithHosts(t *testing.T) {


### PR DESCRIPTION
ReconnectInterval parameter and reconnectDownedHosts goroutine was deprecated because of usage control conn. Furthermore, reconnectDownedHosts does not try to connect, but called handleNodeUp callback. Thus really downed host added into policy pool and marked us "UP" that of cause wasn't true.