### PR TITLE
Separate ConnectTimeout from Timeout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,3 +85,4 @@ Nathan Davies <nathanjamesdavies@gmail.com>
 Bo Blanton <bo.blanton@gmail.com>
 Vincent Rischmann <me@vrischmann.me>
 Jesse Claven <jesse.claven@gmail.com>
+Derrick Wippler <thrawn01@gmail.com>

--- a/cluster.go
+++ b/cluster.go
@@ -46,6 +46,7 @@ type ClusterConfig struct {
 	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
 	ProtoVersion      int
 	Timeout           time.Duration     // connection timeout (default: 600ms)
+	ConnectTimeout    time.Duration     // initial connection timeout, used during initial dial to server (default: 600ms)
 	Port              int               // port (default: 9042)
 	Keyspace          string            // initial keyspace (optional)
 	NumConns          int               // number of connections per host (default: 2)
@@ -132,6 +133,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		Hosts:                  hosts,
 		CQLVersion:             "3.0.0",
 		Timeout:                600 * time.Millisecond,
+		ConnectTimeout:         600 * time.Millisecond,
 		Port:                   9042,
 		NumConns:               2,
 		Consistency:            Quorum,

--- a/conn.go
+++ b/conn.go
@@ -93,13 +93,14 @@ type SslOptions struct {
 }
 
 type ConnConfig struct {
-	ProtoVersion  int
-	CQLVersion    string
-	Timeout       time.Duration
-	Compressor    Compressor
-	Authenticator Authenticator
-	Keepalive     time.Duration
-	tlsConfig     *tls.Config
+	ProtoVersion   int
+	CQLVersion     string
+	Timeout        time.Duration
+	ConnectTimeout time.Duration
+	Compressor     Compressor
+	Authenticator  Authenticator
+	Keepalive      time.Duration
+	tlsConfig      *tls.Config
 }
 
 type ConnErrorHandler interface {
@@ -167,7 +168,7 @@ func Connect(host *HostInfo, cfg *ConnConfig, errorHandler ConnErrorHandler, ses
 	)
 
 	dialer := &net.Dialer{
-		Timeout: cfg.Timeout,
+		Timeout: cfg.ConnectTimeout,
 	}
 
 	// TODO(zariel): handle ipv6 zone
@@ -212,8 +213,8 @@ func Connect(host *HostInfo, cfg *ConnConfig, errorHandler ConnErrorHandler, ses
 		ctx    context.Context
 		cancel func()
 	)
-	if c.timeout > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), c.timeout)
+	if cfg.ConnectTimeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), cfg.ConnectTimeout)
 	} else {
 		ctx, cancel = context.WithCancel(context.Background())
 	}

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -85,13 +85,14 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 	}
 
 	return &ConnConfig{
-		ProtoVersion:  cfg.ProtoVersion,
-		CQLVersion:    cfg.CQLVersion,
-		Timeout:       cfg.Timeout,
-		Compressor:    cfg.Compressor,
-		Authenticator: cfg.Authenticator,
-		Keepalive:     cfg.SocketKeepalive,
-		tlsConfig:     tlsConfig,
+		ProtoVersion:   cfg.ProtoVersion,
+		CQLVersion:     cfg.CQLVersion,
+		Timeout:        cfg.Timeout,
+		ConnectTimeout: cfg.ConnectTimeout,
+		Compressor:     cfg.Compressor,
+		Authenticator:  cfg.Authenticator,
+		Keepalive:      cfg.SocketKeepalive,
+		tlsConfig:      tlsConfig,
 	}, nil
 }
 
@@ -395,8 +396,8 @@ func (pool *hostConnPool) fill() {
 			// probably unreachable host
 			pool.fillingStopped(true)
 
-			// this is calle with the connetion pool mutex held, this call will
-			// then recursivly try to lock it again. FIXME
+			// this is call with the connection pool mutex held, this call will
+			// then recursively try to lock it again. FIXME
 			go pool.session.handleNodeDown(pool.host.Peer(), pool.port)
 			return
 		}

--- a/logger.go
+++ b/logger.go
@@ -1,12 +1,25 @@
 package gocql
 
-import "log"
+import (
+	"bytes"
+	"fmt"
+	"log"
+)
 
 type StdLogger interface {
 	Print(v ...interface{})
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
 }
+
+type testLogger struct {
+	capture bytes.Buffer
+}
+
+func (l *testLogger) Print(v ...interface{})                 { fmt.Fprint(&l.capture, v...) }
+func (l *testLogger) Printf(format string, v ...interface{}) { fmt.Fprintf(&l.capture, format, v...) }
+func (l *testLogger) Println(v ...interface{})               { fmt.Fprintln(&l.capture, v...) }
+func (l *testLogger) String() string                         { return l.capture.String() }
 
 type defaultLogger struct{}
 


### PR DESCRIPTION
## Purpose
In large clusters with busy nodes it is not uncommon to have a high connection timeout to tolerate large or longer running queries. With such a configuration and with nodes under heavy load `CreateSession()` can block for the duration of the high timeout `x3` for each node not responding in a timely manner. This can cause issues (See #839) where either a temporary network issue causes connection issues or the connection was successful but Cassandra doesn't respond with the startup frame in a timely manner.

## Implementation
* Introduced a new timeout `ClusterConfig.ConnectTimeout` which is only applied during the initial dial and exchange of startup frames.
* Added a test called `TestStartupTimeout` to ensure timeout while waiting for startup frame works and is separate from `ClusterConfig.Timeout`