### PR TITLE
Fix data race between event processing and session when concurrent go…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -20,9 +20,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/nullaus/gocql/internal/lru"
 
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/nullaus/gocql/internal/streams"
 )
 
 var (

--- a/events.go
+++ b/events.go
@@ -106,6 +106,9 @@ func (s *Session) handleEvent(framer *framer) {
 }
 
 func (s *Session) handleSchemaEvent(frames []frame) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.schemaDescriber == nil {
 		return
 	}

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/nullaus/gocql/internal/ccm"
 )
 
 func TestEventDiscovery(t *testing.T) {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/nullaus/gocql/internal/lru"
 	"sync"
 )
 

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/nullaus/gocql/internal/lru"
 )
 
 // Session is the interface used by users to interact with the database.

--- a/token.go
+++ b/token.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gocql/gocql/internal/murmur"
+	"github.com/nullaus/gocql/internal/murmur"
 )
 
 // a token partitioner


### PR DESCRIPTION
…routines are potentially accessing schema details or creating, altering keyspaces and tables.