### PR TITLE
Fix data race between event processing and session when concurrent go…

### DIFF
--- a/events.go
+++ b/events.go
@@ -106,6 +106,9 @@ func (s *Session) handleEvent(framer *framer) {
 }
 
 func (s *Session) handleSchemaEvent(frames []frame) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.schemaDescriber == nil {
 		return
 	}


### PR DESCRIPTION
…routines are potentially accessing schema details or creating, altering keyspaces and tables.