### PR TITLE
reset the context when calling Query.reset

### DIFF
--- a/session.go
+++ b/session.go
@@ -1022,6 +1022,7 @@ func (q *Query) reset() {
 	q.defaultTimestamp = false
 	q.disableSkipMetadata = false
 	q.disableAutoPage = false
+	q.context = nil
 }
 
 // Iter represents an iterator that can be used to iterate over all rows that


### PR DESCRIPTION
I started using contexts in my code which uses gocql and noticed a lot of my unit tests failed recently with errors like `gocql: unable to create session: context canceled` and sometimes it logged lines like `gocql: events: unable to fetch host info for (127.0.0.1:9042): context canceled`.

My code does something like this:

```go
    ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
    defer cancelFn()

    qry := session.Query(q, apiKey.Key, apiKey.Platform).WithContext(ctx).Consistency(cons)
    defer qry.Release()

    session.Close()
``` 

in each test. With `reset()` not clearing the context, the next test has a chance to fail because the context has been canceled, but it's still there in the query I just released. It happens almost everytime in my unit tests.