### PR TITLE
add the constructor NewNativeType

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1799,6 +1799,10 @@ type NativeType struct {
 	custom string // only used for TypeCustom
 }
 
+func NewNativeType(proto byte, typ Type, custom string) NativeType {
+	return NativeType{proto, typ, custom}
+}
+
 func (t NativeType) New() interface{} {
 	return reflect.New(goType(t)).Interface()
 }


### PR DESCRIPTION
In order to test an implementation of `gocql.Unmarshaler` or `gocql.Marshaler` I need to pass it a `gocql.TypeInfo`.

Until today I just did that indirectly by creating tables and querying cassandra directly, but it's taking  a long time to spin up a Cassandra for my CI builds.

So I looked at a way to build the `gocql.TypeInfo` myself, and turns out the interface is not that complicated so I made my own type for it.

But, it's kind of a waste because I ended up duplicating [this](https://github.com/gocql/gocql/blob/6a9363e0c9b27431ce2ed5872279f85248115b9e/helpers.go#L22), and my TypeInfo was basically just [this](https://github.com/gocql/gocql/blob/master/marshal.go#L1796) copied. 

`NativeType` is the only type with fields not exposed so I can't use it directly, which is why I'm suggesting creating a constructor `NewNativeType` for it. Or we could expose all fields but that's more invasive work.