### PR TITLE
Fix setting batch timestamp.

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -4,6 +4,7 @@ package gocql
 
 import (
 	"testing"
+	"time"
 )
 
 func TestBatch_Errors(t *testing.T) {
@@ -22,5 +23,36 @@ func TestBatch_Errors(t *testing.T) {
 	b.Query("SELECT * FROM batch_errors WHERE id=2 AND val=?", nil)
 	if err := session.ExecuteBatch(b); err == nil {
 		t.Fatal("expected to get error for invalid query in batch")
+	}
+}
+
+func TestBatch_WithTimestamp(t *testing.T) {
+	if *flagProto < protoVersion3 {
+		t.Skip("Batch timestamps are only available on protocol >= 3")
+	}
+
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, `CREATE TABLE gocql_test.batch_ts (id int primary key, val text)`); err != nil {
+		t.Fatal(err)
+	}
+
+	micros := time.Now().UnixNano()/1e3 - 1000
+
+	b := session.NewBatch(LoggedBatch)
+	b.WithTimestamp(micros)
+	b.Query("INSERT INTO batch_ts (id, val) VALUES (?, ?)", 1, "val")
+	if err := session.ExecuteBatch(b); err != nil {
+		t.Fatal(err)
+	}
+
+	var storedTs int64
+	if err := session.Query(`SELECT writetime(val) FROM batch_ts WHERE id = ?`, 1).Scan(&storedTs); err != nil {
+		t.Fatal(err)
+	}
+
+	if storedTs != micros {
+		t.Errorf("got ts %d, expected %d", storedTs, micros)
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -961,11 +961,12 @@ func (c *Conn) executeBatch(batch *Batch) *Iter {
 
 	n := len(batch.Entries)
 	req := &writeBatchFrame{
-		typ:               batch.Type,
-		statements:        make([]batchStatment, n),
-		consistency:       batch.Cons,
-		serialConsistency: batch.serialCons,
-		defaultTimestamp:  batch.defaultTimestamp,
+		typ:                   batch.Type,
+		statements:            make([]batchStatment, n),
+		consistency:           batch.Cons,
+		serialConsistency:     batch.serialCons,
+		defaultTimestamp:      batch.defaultTimestamp,
+		defaultTimestampValue: batch.defaultTimestampValue,
 	}
 
 	stmts := make(map[string]string, len(batch.Entries))


### PR DESCRIPTION
Wasn't passing along defaultColumnTimestampValue when creating the
batch frame.