### PR TITLE
metadata: key_aliases are only relevant with proto version 1

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1756,7 +1756,7 @@ func TestGetTableMetadata(t *testing.T) {
 	if testTable == nil {
 		t.Fatal("Expected table metadata for name 'test_table_metadata'")
 	}
-	if *flagProto < protoVersion4 {
+	if *flagProto == protoVersion1 {
 		if testTable.KeyValidator != "org.apache.cassandra.db.marshal.Int32Type" {
 			t.Errorf("Expected test_table_metadata key validator to be 'org.apache.cassandra.db.marshal.Int32Type' but was '%s'", testTable.KeyValidator)
 		}

--- a/metadata.go
+++ b/metadata.go
@@ -247,7 +247,7 @@ func compileMetadata(
 		table.OrderedColumns = append(table.OrderedColumns, columns[i].Name)
 	}
 
-	if protoVersion == 1 {
+	if protoVersion == protoVersion1 {
 		compileV1Metadata(tables)
 	} else {
 		compileV2Metadata(tables)
@@ -505,9 +505,8 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 			}
 			return r
 		}
-	} else if session.cfg.ProtoVersion < protoVersion4 {
+	} else if session.cfg.ProtoVersion == protoVersion1 {
 		// we have key aliases
-		// TODO: Do we need key_aliases?
 		stmt = `
 		SELECT
 			columnfamily_name,


### PR DESCRIPTION
Decided to run `go test -tags all` with a Cassandra 2.2.9 running tonight. A failing test caught my attention:

    G:\Gopath\src\github.com\gocql\gocql [fix-table-metadata]> go test -v -tags "all" -run="TestGetTableMetadata"
    === RUN   TestGetTableMetadata
    2017/03/16 00:54:27 common_test.go:121: closing keyspace session
    --- FAIL: TestGetTableMetadata (4.41s)
            cassandra_test.go:1705: failed to query the table metadata with err: Error querying table schema: Undefined name key_aliases in selection clause
    FAIL
    exit status 1
    FAIL    github.com/gocql/gocql  4.590s

This simple program exhibits the problem too:

```go
package main

import (
	"log"

	"github.com/gocql/gocql"
)

func main() {
	cfg := gocql.NewCluster("127.0.0.1:9042")
	cfg.ProtoVersion = 2
	session, err := cfg.CreateSession()
	if err != nil {
		log.Fatal(err)
	}

	md, err := session.KeyspaceMetadata("system")
	if err != nil {
		log.Fatal(err)
	}

	log.Printf("md: %+v", md)

	session.Close()
}
```

I spent some time trying to understand the relation between the protocol version and the system schemas. The current check doesn't work because starting with Cassandra 2.2, the aliases fields aren't there anymore regardless of the protocol version.
For the snippet above to work you have to use protocol version 4 or use Cassandra 3.X

After some careful grepping I'm almost sure no one uses the `KeyAliases`, `ColumnAliases` or `ValueAlias` outside of [compileV1Metadata](https://github.com/gocql/gocql/blob/master/metadata.go#L262) which in turns is only ever called [when the proto version is 1](https://github.com/gocql/gocql/blob/master/metadata.go#L250).

By the way, looking at the [Datastax Java driver](https://github.com/datastax/java-driver/blob/3.1.x/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java#L150) they decide to parse the aliases based on the Cassandra version, but I didn't see where to get this information from a session.