### PR TITLE
Fix session level tracer.

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -173,6 +173,16 @@ func TestTracing(t *testing.T) {
 	} else if buf.Len() == 0 {
 		t.Fatal("select: failed to obtain any tracing")
 	}
+
+	// also works from session tracer
+	session.SetTrace(trace)
+	buf.Reset()
+	if err := session.Query(`SELECT id FROM trace WHERE id = ?`, 42).Scan(&value); err != nil {
+		t.Fatal("select:", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("select: failed to obtain any tracing")
+	}
 }
 
 func TestPaging(t *testing.T) {

--- a/control.go
+++ b/control.go
@@ -402,7 +402,7 @@ func (c *controlConn) withConn(fn func(*Conn) *Iter) *Iter {
 
 // query will return nil if the connection is closed or nil
 func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter) {
-	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{})
+	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{}).Trace(nil)
 
 	for {
 		iter = c.withConn(func(conn *Conn) *Iter {


### PR DESCRIPTION
It was getting stuck when the trace queries via control connection
re-entered the trace code (since they use the same session). Fix by
unsetting Trace on the control connection queries so it doesn't try to
trace the traces.