### PR TITLE
conn: hold mutex while creating calls

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -590,11 +590,11 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 		call = streamPool.Get().(*callReq)
 	}
 	c.calls[stream] = call
-	c.mu.Unlock()
 
 	call.framer = framer
 	call.timeout = make(chan struct{})
 	call.streamID = stream
+	c.mu.Unlock()
 
 	if tracer != nil {
 		framer.trace()


### PR DESCRIPTION
closeWithError will hold the lock and close the channel, which we could
be assigning at the same time.

fixes #852