### PR TITLE
Add hosts to policy pool on ring refreshring

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -389,6 +389,7 @@ func (r *ringDescriber) refreshRing() error {
 		if r.session.cfg.HostFilter == nil || r.session.cfg.HostFilter.Accept(h) {
 			if host, ok := r.session.ring.addHostIfMissing(h); !ok {
 				r.session.pool.addHost(h)
+				r.session.policy.AddHost(h)
 			} else {
 				host.update(h)
 			}


### PR DESCRIPTION
While ring refreshing if we have found hosts not added to ring yet, we need add them not only to connection pool but into policy poll too.