### PR TITLE
Replace golang.org/x/net/context with stdlib context

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -4,6 +4,7 @@ package gocql
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"math"
 	"math/big"
@@ -15,8 +16,6 @@ import (
 	"testing"
 	"time"
 	"unicode"
-
-	"golang.org/x/net/context"
 
 	"gopkg.in/inf.v0"
 )

--- a/conn.go
+++ b/conn.go
@@ -6,6 +6,7 @@ package gocql
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -17,8 +18,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/gocql/gocql/internal/lru"
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,6 +6,7 @@
 package gocql
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -17,8 +18,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/control.go
+++ b/control.go
@@ -1,6 +1,7 @@
 package gocql
 
 import (
+	"context"
 	crand "crypto/rand"
 	"errors"
 	"fmt"
@@ -8,12 +9,9 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
-
-	"sync"
-
-	"golang.org/x/net/context"
 )
 
 var (

--- a/session.go
+++ b/session.go
@@ -6,6 +6,7 @@ package gocql
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -15,8 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 	"unicode"
-
-	"golang.org/x/net/context"
 
 	"github.com/gocql/gocql/internal/lru"
 )

--- a/session_connect_test.go
+++ b/session_connect_test.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"net"
 	"strconv"
 	"sync"


### PR DESCRIPTION
Remove an external dependency since it's been incorporated into the stdlib.