### PR TITLE
CreateSession() will now attempt to resolve all host names

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -141,6 +141,62 @@ func newTestSession(addr string, proto protoVersion) (*Session, error) {
 	return testCluster(addr, proto).CreateSession()
 }
 
+func TestDNSLookupConnected(t *testing.T) {
+	log := &testLogger{}
+	Logger = log
+	defer func() {
+		Logger = &defaultLogger{}
+	}()
+
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	cluster := NewCluster("cassandra1.invalid", srv.Address, "cassandra2.invalid")
+	cluster.ProtoVersion = int(defaultProto)
+	cluster.disableControlConn = true
+
+	// CreateSession() should attempt to resolve the DNS name "cassandraX.invalid"
+	// and fail, but continue to connect via srv.Address
+	_, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal("CreateSession() should have connected")
+	}
+
+	if !strings.Contains(log.String(), "gocql: dns error") {
+		t.Fatalf("Expected to receive dns error log message  - got '%s' instead", log.String())
+	}
+}
+
+func TestDNSLookupError(t *testing.T) {
+	log := &testLogger{}
+	Logger = log
+	defer func() {
+		Logger = &defaultLogger{}
+	}()
+
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	cluster := NewCluster("cassandra1.invalid", "cassandra2.invalid")
+	cluster.ProtoVersion = int(defaultProto)
+	cluster.disableControlConn = true
+
+	// CreateSession() should attempt to resolve each DNS name "cassandraX.invalid"
+	// and fail since it could not resolve any dns entries
+	_, err := cluster.CreateSession()
+	if err == nil {
+		t.Fatal("CreateSession() should have returned an error")
+	}
+
+	if !strings.Contains(log.String(), "gocql: dns error") {
+		t.Fatalf("Expected to receive dns error log message  - got '%s' instead", log.String())
+	}
+
+	if err.Error() != "gocql: unable to create session: failed to resolve any of the provided hostnames" {
+		t.Fatalf("Expected CreateSession() to fail with message  - got '%s' instead", err.Error())
+	}
+}
+
 func TestStartupTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	log := &testLogger{}

--- a/session.go
+++ b/session.go
@@ -92,7 +92,7 @@ func addrsToHosts(addrs []string, defaultPort int) ([]*HostInfo, error) {
 		hosts = append(hosts, host)
 	}
 	if len(hosts) == 0 {
-		return nil, errors.New("gocql: failed to resolve any of the provided hostnames")
+		return nil, errors.New("failed to resolve any of the provided hostnames")
 	}
 	return hosts, nil
 }

--- a/session.go
+++ b/session.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -76,16 +77,23 @@ var queryPool = &sync.Pool{
 }
 
 func addrsToHosts(addrs []string, defaultPort int) ([]*HostInfo, error) {
-	hosts := make([]*HostInfo, len(addrs))
-	for i, hostport := range addrs {
+	var hosts []*HostInfo
+	for _, hostport := range addrs {
 		host, err := hostInfo(hostport, defaultPort)
 		if err != nil {
+			// Try other hosts if unable to resolve DNS name
+			if _, ok := err.(*net.DNSError); ok {
+				Logger.Printf("gocql: dns error: %v\n", err)
+				continue
+			}
 			return nil, err
 		}
 
-		hosts[i] = host
+		hosts = append(hosts, host)
 	}
-
+	if len(hosts) == 0 {
+		return nil, errors.New("gocql: failed to resolve any of the provided hostnames")
+	}
 	return hosts, nil
 }
 


### PR DESCRIPTION
## Purpose
`CreateSession()` would exit prematurely if it encountered a hostname it could not resolve. With this patch all host names will be resolved before an error is returned. fixes #873 

## Implementation
* `addrsToHosts()` will log and continue to the next host if `hostInfo()` returns a `DNSError`
* Added an error if none of the host names can be resolved