### PR TITLE
SslOptions: embed a pointer to the TLS config

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -79,7 +79,7 @@ func (p PasswordAuthenticator) Success(data []byte) error {
 }
 
 type SslOptions struct {
-	tls.Config
+	*tls.Config
 
 	// CertPath and KeyPath are optional depending on server
 	// config, but both fields must be omitted to avoid using a

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -28,6 +28,10 @@ type SetPartitioner interface {
 }
 
 func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
+	if sslOpts.Config == nil {
+		sslOpts.Config = &tls.Config{}
+	}
+
 	// ca cert is optional
 	if sslOpts.CaPath != "" {
 		if sslOpts.RootCAs == nil {

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -54,7 +54,7 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 
 	sslOpts.InsecureSkipVerify = !sslOpts.EnableHostVerification
 
-	return &sslOpts.Config, nil
+	return sslOpts.Config, nil
 }
 
 type policyConnPool struct {


### PR DESCRIPTION
This embeds a pointer to the desired TLS config instead of a concrete value. Because Go copies the arguments of all function calls, this has the side effect of copying the TLS configuration, which copies a mutex. This causes `go vet` to report that `crypto/tls.Config contains sync.Once contains sync.Mutex`.

This patch removes this complaint, but at the cost of needing people to change their Cassandra TLS configuration code to remove the dereference of the TLS config when assigning to the `Config` field of the TLS configuration.

EG:

```go
func createTLSConfig(caCertConfigValue string) *gocql.SslOptions {
	caCertPool := x509.NewCertPool()
	caCertPool.AppendCertsFromPEM([]byte(caCertConfigValue))
	config := &tls.Config{
		RootCAs: caCertPool,
	}
	config.BuildNameToCertificate()
	return &gocql.SslOptions{Config: *config}
}
```

would need to be corrected to:

```go
func createTLSConfig(caCertConfigValue string) *gocql.SslOptions {
	caCertPool := x509.NewCertPool()
	caCertPool.AppendCertsFromPEM([]byte(caCertConfigValue))
	config := &tls.Config{
		RootCAs: caCertPool,
	}
	config.BuildNameToCertificate()
	return &gocql.SslOptions{Config: config}
}
```