### PR TITLE
fix consistent high timeout err rate caused by prepareStatement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -711,11 +711,8 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 
 	framer, err := c.exec(ctx, prep, tracer)
 	if err != nil {
-		flight.err = err
 		flight.wg.Done()
-		if err.Error() == "context deadline exceeded" {
-			c.session.stmtsLRU.remove(stmtCacheKey)
-		}
+		c.session.stmtsLRU.remove(stmtCacheKey)
 		return nil, err
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -713,6 +713,9 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 	if err != nil {
 		flight.err = err
 		flight.wg.Done()
+		if err.Error() == "context deadline exceeded" {
+			c.session.stmtsLRU.remove(stmtCacheKey)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently gocql will cache the timeout err caused by network instability when prepare a statement.

As a result, if gocql fails to prepare a statement due to network issue at the first time on a connection, the rest of the call to that statement on that connection would return "context deadline exceeded”. 

It can result in high and consistent err rate and can only fixed by restart a host.

We have been suffering from this in production for a while.