### PR TITLE
flight.err should still be set even if flight is removed from cache

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -711,6 +711,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 
 	framer, err := c.exec(ctx, prep, tracer)
 	if err != nil {
+		flight.err = err
 		flight.wg.Done()
 		c.session.stmtsLRU.remove(stmtCacheKey)
 		return nil, err


### PR DESCRIPTION
This is a correction for #892 
If we remove flight.err = err
This [code](https://github.com/gocql/gocql/blob/master/conn.go#L703-L706) may accidentally return no err, when it should return one.