### PR TITLE
Add go1.8 to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
       AUTH=false
 
 go:
-  - 1.6
   - 1.7
   - 1.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 go:
   - 1.6
   - 1.7
+  - 1.8
 
 install:
   - pip install --user cql PyYAML six


### PR DESCRIPTION
What
===
Add go1.8 and remove go1.6 from CI tests.

Why
===
It's the latest Go release and we should be ensuring tests pass on it and according to the gocql README the last two major versions will be supported. The last two major versions are go1.7 and go1.8.