### PR TITLE
Support for UnSet columns

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2590,6 +2590,9 @@ func TestControl_DiscoverProtocol(t *testing.T) {
 
 // TestUnsetCol verify unset column will not replace an existing column
 func TestUnsetCol(t *testing.T) {
+	if *flagProto < 4 {
+		t.Skip("Unset Values are not supported in protocol < 4")
+	}
 	session := createSession(t)
 	defer session.Close()
 
@@ -2615,6 +2618,9 @@ func TestUnsetCol(t *testing.T) {
 
 // TestUnsetColBatch verify unset column will not replace a column in batch
 func TestUnsetColBatch(t *testing.T) {
+	if *flagProto < 4 {
+		t.Skip("Unset Values are not supported in protocol < 4")
+	}
 	session := createSession(t)
 	defer session.Close()
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1631,29 +1631,6 @@ func TestNilInQuery(t *testing.T) {
 	}
 }
 
-// Tests gocql.UnSetCol sucsessfully inserts into cassandra.
-func TestUnsetCol(t *testing.T) {
-	session := createSession(t)
-	defer session.Close()
-
-	if err := createTable(session, "CREATE TABLE gocql_test.testUnSetInsert (id int, my_int int, my_text text, PRIMARY KEY (id))"); err != nil {
-		t.Fatalf("failed to create table with error '%v'", err)
-	}
-	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1,i UnSetCol, UnSetCol, UnSetCol).Exec(); err != nil {
-		t.Fatalf("failed to insert with err: %v", err)
-	}
-
-	var id, mInt int
-	var mText string
-
-	if err := session.Query("SELECT id, my_int ,my_text FROM testNilInsert").Scan(&id, &mInt, &mText); err != nil {
-		t.Fatalf("failed to select with err: %v", err)
-	} else if id != 1 {
-		t.Fatalf("expected id to be 1, got %v", id)
-	}
-
-}
-
 // Don't initialize time.Time bind variable if cassandra timestamp column is empty
 func TestEmptyTimestamp(t *testing.T) {
 	session := createSession(t)
@@ -2608,5 +2585,70 @@ func TestControl_DiscoverProtocol(t *testing.T) {
 
 	if session.cfg.ProtoVersion == 0 {
 		t.Fatal("did not discovery protocol")
+	}
+}
+
+// TestUnsetCol verify unset column will not replace an existing column
+func TestUnsetCol(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE gocql_test.testUnsetInsert (id int, my_int int, my_text text, PRIMARY KEY (id))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1, 2, "3").Exec(); err != nil {
+		t.Fatalf("failed to insert with err: %v", err)
+	}
+	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1, UnsetValue(), UnsetValue()).Exec(); err != nil {
+		t.Fatalf("failed to insert with err: %v", err)
+	}
+
+	var id, mInt int
+	var mText string
+
+	if err := session.Query("SELECT id, my_int ,my_text FROM testUnsetInsert").Scan(&id, &mInt, &mText); err != nil {
+		t.Fatalf("failed to select with err: %v", err)
+	} else if id != 1 || mInt != 2 || mText != "3" {
+		t.Fatalf("Expected results: 1, 2, \"3\", got %v, %v, %v", id, mInt, mText)
+	}
+}
+
+// TestUnsetColBatch verify unset column will not replace a column in batch
+func TestUnsetColBatch(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE gocql_test.batchUnsetInsert (id int, my_int int, my_text text, PRIMARY KEY (id))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+
+	b := session.NewBatch(LoggedBatch)
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, 1, UnsetValue())
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, UnsetValue(), "")
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 2, 2, UnsetValue())
+
+	if err := session.ExecuteBatch(b); err != nil {
+		t.Fatalf("query failed. %v", err)
+	} else {
+		if b.Attempts() < 1 {
+			t.Fatal("expected at least 1 attempt, but got 0")
+		}
+		if b.Latency() <= 0 {
+			t.Fatalf("expected latency to be greater than 0, but got %v instead.", b.Latency())
+		}
+	}
+	var id, mInt, count int
+	var mText string
+
+	if err := session.Query("SELECT count(*) FROM gocql_test.batchUnsetInsert;").Scan(&count); err != nil {
+		t.Fatalf("Failed to select with err: %v", err)
+	} else if count != 2 {
+		t.Fatalf("Expected Batch Insert count 2, got %v", count)
+	}
+
+	if err := session.Query("SELECT id, my_int ,my_text FROM gocql_test.batchUnsetInsert where id=1;").Scan(&id, &mInt, &mText); err != nil {
+		t.Fatalf("failed to select with err: %v", err)
+	} else if id != mInt {
+		t.Fatalf("expected id, my_int to be 1, got %v and %v", id, mInt)
 	}
 }

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2602,7 +2602,7 @@ func TestUnsetCol(t *testing.T) {
 	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1, 2, "3").Exec(); err != nil {
 		t.Fatalf("failed to insert with err: %v", err)
 	}
-	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1, UnsetValue(), UnsetValue()).Exec(); err != nil {
+	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1, UnsetValue, UnsetValue).Exec(); err != nil {
 		t.Fatalf("failed to insert with err: %v", err)
 	}
 
@@ -2629,9 +2629,9 @@ func TestUnsetColBatch(t *testing.T) {
 	}
 
 	b := session.NewBatch(LoggedBatch)
-	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, 1, UnsetValue())
-	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, UnsetValue(), "")
-	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 2, 2, UnsetValue())
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, 1, UnsetValue)
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 1, UnsetValue, "")
+	b.Query("INSERT INTO gocql_test.batchUnsetInsert(id, my_int, my_text) VALUES (?,?,?)", 2, 2, UnsetValue)
 
 	if err := session.ExecuteBatch(b); err != nil {
 		t.Fatalf("query failed. %v", err)

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1631,6 +1631,29 @@ func TestNilInQuery(t *testing.T) {
 	}
 }
 
+// Tests gocql.UnSetCol sucsessfully inserts into cassandra.
+func TestUnsetCol(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE gocql_test.testUnSetInsert (id int, my_int int, my_text text, PRIMARY KEY (id))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+	if err := session.Query("INSERT INTO testUnSetInsert (id,my_int,my_text) VALUES (?,?,?)", 1,i UnSetCol, UnSetCol, UnSetCol).Exec(); err != nil {
+		t.Fatalf("failed to insert with err: %v", err)
+	}
+
+	var id, mInt int
+	var mText string
+
+	if err := session.Query("SELECT id, my_int ,my_text FROM testNilInsert").Scan(&id, &mInt, &mText); err != nil {
+		t.Fatalf("failed to select with err: %v", err)
+	} else if id != 1 {
+		t.Fatalf("expected id to be 1, got %v", id)
+	}
+
+}
+
 // Don't initialize time.Time bind variable if cassandra timestamp column is empty
 func TestEmptyTimestamp(t *testing.T) {
 	session := createSession(t)

--- a/conn.go
+++ b/conn.go
@@ -810,13 +810,6 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 
 		params.values = make([]queryValues, len(values))
 		for i := 0; i < len(values); i++ {
-			if _, ok := values[i].(UnsetColumn); ok {
-				v := &params.values[i]
-
-				v.value = nil
-				v.isUnset = true
-				continue
-			}
 			val, err := Marshal(info.request.columns[i].TypeInfo, values[i])
 			if err != nil {
 				return &Iter{err: err}
@@ -824,6 +817,9 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 
 			v := &params.values[i]
 			v.value = val
+			if _, ok := values[i].(UnsetColumn); ok {
+				v.isUnset = true
+			}
 			// TODO: handle query binding names
 		}
 
@@ -1020,6 +1016,9 @@ func (c *Conn) executeBatch(batch *Batch) *Iter {
 				}
 
 				b.values[j].value = val
+				if _, ok := values[j].(UnsetColumn); ok {
+					b.values[j].isUnset = true
+				}
 				// TODO: add names
 			}
 		} else {

--- a/conn.go
+++ b/conn.go
@@ -810,6 +810,13 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 
 		params.values = make([]queryValues, len(values))
 		for i := 0; i < len(values); i++ {
+			if _, ok := values[i].(UnsetColumn); ok {
+				v := &params.values[i]
+
+				v.value = nil
+				v.isUnset = true
+				continue
+			}
 			val, err := Marshal(info.request.columns[i].TypeInfo, values[i])
 			if err != nil {
 				return &Iter{err: err}

--- a/conn.go
+++ b/conn.go
@@ -817,7 +817,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 
 			v := &params.values[i]
 			v.value = val
-			if _, ok := values[i].(UnsetColumn); ok {
+			if _, ok := values[i].(unsetColumn); ok {
 				v.isUnset = true
 			}
 			// TODO: handle query binding names
@@ -1016,7 +1016,7 @@ func (c *Conn) executeBatch(batch *Batch) *Iter {
 				}
 
 				b.values[j].value = val
-				if _, ok := values[j].(UnsetColumn); ok {
+				if _, ok := values[j].(unsetColumn); ok {
 					b.values[j].isUnset = true
 				}
 				// TODO: add names

--- a/frame.go
+++ b/frame.go
@@ -16,6 +16,12 @@ import (
 	"time"
 )
 
+type UnsetColumn struct{}
+
+func UnsetValue() UnsetColumn {
+	return UnsetColumn{}
+}
+
 const (
 	protoDirectionMask = 0x80
 	protoVersionMask   = 0x7F
@@ -1255,8 +1261,10 @@ func (f *framer) writeAuthResponseFrame(streamID int, data []byte) error {
 
 type queryValues struct {
 	value []byte
+
 	// optional name, will set With names for values flag
-	name string
+	name    string
+	isUnset bool
 }
 
 type queryParams struct {
@@ -1319,11 +1327,16 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 
 	if n := len(opts.values); n > 0 {
 		f.writeShort(uint16(n))
+
 		for i := 0; i < n; i++ {
 			if names {
 				f.writeString(opts.values[i].name)
 			}
-			f.writeBytes(opts.values[i].value)
+			if opts.values[i].isUnset {
+				f.writeUnset()
+			} else {
+				f.writeBytes(opts.values[i].value)
+			}
 		}
 	}
 
@@ -1404,7 +1417,11 @@ func (f *framer) writeExecuteFrame(streamID int, preparedID []byte, params *quer
 		n := len(params.values)
 		f.writeShort(uint16(n))
 		for i := 0; i < n; i++ {
-			f.writeBytes(params.values[i].value)
+			if params.values[i].isUnset {
+				f.writeUnset()
+			} else {
+				f.writeBytes(params.values[i].value)
+			}
 		}
 		f.writeConsistency(params.consistency)
 	}
@@ -1463,7 +1480,11 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame) error {
 				flags |= flagWithNameValues
 				f.writeString(col.name)
 			}
-			f.writeBytes(col.value)
+			if col.isUnset {
+				f.writeUnset()
+			} else {
+				f.writeBytes(col.value)
+			}
 		}
 	}
 
@@ -1784,6 +1805,14 @@ func (f *framer) writeStringList(l []string) {
 	for _, s := range l {
 		f.writeString(s)
 	}
+}
+
+func (f *framer) writeUnset() {
+	// Protocol version 4 specifies that bind variables do not require having a
+	// value when executing a statement.   Bind variables without a value are
+	// called 'unset'. The 'unset' bind variable is serialized as the int
+	// value '-2' without following bytes.
+	f.writeInt(-2)
 }
 
 func (f *framer) writeBytes(p []byte) {

--- a/frame.go
+++ b/frame.go
@@ -16,11 +16,9 @@ import (
 	"time"
 )
 
-type UnsetColumn struct{}
+type unsetColumn struct{}
 
-func UnsetValue() UnsetColumn {
-	return UnsetColumn{}
-}
+var UnsetValue = unsetColumn{}
 
 const (
 	protoDirectionMask = 0x80

--- a/marshal.go
+++ b/marshal.go
@@ -57,6 +57,10 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 	}
 
+	if _, ok := value.(UnsetColumn); ok {
+		return nil, nil
+	}
+
 	if v, ok := value.(Marshaler); ok {
 		return v.MarshalCQL(info)
 	}
@@ -1127,21 +1131,21 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 		return v.MarshalCQL(info)
 	case int64:
 		timestamp = v
-		x := timestamp/86400000 + int64(1 << 31)
+		x := timestamp/86400000 + int64(1<<31)
 		return encInt(int32(x)), nil
 	case time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1 << 31)
+		x := timestamp/86400000 + int64(1<<31)
 		return encInt(int32(x)), nil
 	case *time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1 << 31)
+		x := timestamp/86400000 + int64(1<<31)
 		return encInt(int32(x)), nil
 	case string:
 		if v == "" {
@@ -1152,7 +1156,7 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("can not marshal %T into %s, date layout must be '2006-01-02'", value, info)
 		}
 		timestamp = int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1 << 31)
+		x := timestamp/86400000 + int64(1<<31)
 		return encInt(int32(x)), nil
 	}
 

--- a/marshal.go
+++ b/marshal.go
@@ -57,10 +57,6 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 	}
 
-	if _, ok := value.(UnsetColumn); ok {
-		return nil, nil
-	}
-
 	if v, ok := value.(Marshaler); ok {
 		return v.MarshalCQL(info)
 	}
@@ -201,6 +197,8 @@ func marshalVarchar(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case string:
 		return []byte(v), nil
 	case []byte:
@@ -266,6 +264,8 @@ func marshalSmallInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int16:
 		return encShort(v), nil
 	case uint16:
@@ -342,6 +342,8 @@ func marshalTinyInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int8:
 		return []byte{byte(v)}, nil
 	case uint8:
@@ -424,6 +426,8 @@ func marshalInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int:
 		if v > math.MaxInt32 || v < math.MinInt32 {
 			return nil, marshalErrorf("marshal int: value %d out of range", v)
@@ -526,6 +530,8 @@ func marshalBigInt(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int:
 		return encBigInt(int64(v)), nil
 	case uint:
@@ -642,6 +648,8 @@ func marshalVarint(info TypeInfo, value interface{}) ([]byte, error) {
 	)
 
 	switch v := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case uint64:
 		if v > uint64(math.MaxInt64) {
 			retBytes = make([]byte, 9)
@@ -861,6 +869,8 @@ func marshalBool(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case bool:
 		return encBool(v), nil
 	}
@@ -916,6 +926,8 @@ func marshalFloat(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case float32:
 		return encInt(int32(math.Float32bits(v))), nil
 	}
@@ -957,6 +969,8 @@ func marshalDouble(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case float64:
 		return encBigInt(int64(math.Float64bits(v))), nil
 	}
@@ -1000,6 +1014,8 @@ func marshalDecimal(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case inf.Dec:
 		unscaled := encBigInt2C(v.UnscaledBig())
 		if unscaled == nil {
@@ -1071,6 +1087,8 @@ func marshalTimestamp(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int64:
 		return encBigInt(v), nil
 	case time.Time:
@@ -1129,6 +1147,8 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, nil
 	case int64:
 		timestamp = v
 		x := timestamp/86400000 + int64(1<<31)
@@ -1213,6 +1233,8 @@ func marshalList(info TypeInfo, value interface{}) ([]byte, error) {
 	}
 
 	if value == nil {
+		return nil, nil
+	} else if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1330,6 +1352,8 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 
 	if value == nil {
 		return nil, nil
+	} else if _, ok := value.(unsetColumn); ok {
+		return nil, nil
 	}
 
 	rv := reflect.ValueOf(value)
@@ -1424,6 +1448,8 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 
 func marshalUUID(info TypeInfo, value interface{}) ([]byte, error) {
 	switch val := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case UUID:
 		return val.Bytes(), nil
 	case []byte:
@@ -1504,6 +1530,8 @@ func marshalInet(info TypeInfo, value interface{}) ([]byte, error) {
 	// ip address here otherwise the db value will be prefixed
 	// with the remaining byte values e.g. ::ffff:127.0.0.1 and not 127.0.0.1
 	switch val := value.(type) {
+	case unsetColumn:
+		return nil, nil
 	case net.IP:
 		t := val.To4()
 		if t == nil {
@@ -1564,6 +1592,8 @@ func unmarshalInet(info TypeInfo, data []byte, value interface{}) error {
 func marshalTuple(info TypeInfo, value interface{}) ([]byte, error) {
 	tuple := info.(TupleTypeInfo)
 	switch v := value.(type) {
+	case unsetColumn:
+		return nil, unmarshalErrorf("Invalid request: UnsetValue is unsupported for tuples")
 	case []interface{}:
 		var buf []byte
 
@@ -1642,6 +1672,8 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
+	case unsetColumn:
+		return nil, unmarshalErrorf("Invalid request: UnsetValue is unsupported for user defined types")
 	case UDTMarshaler:
 		var buf []byte
 		for _, e := range udt.Elements {


### PR DESCRIPTION
# Purpose 
Adding support for the UNSET_VALUE in gocql.  See #861 and [Cassandra Jira issue](https://issues.apache.org/jira/browse/CASSANDRA-7304)

## Tests to Add:
- [x] Insert Unset column does not replace existing column
- [x] Insert Batch with unset
