### PR TITLE
executeBatch return proper err for RequestErrUnprepared

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1052,7 +1052,7 @@ func (c *Conn) executeBatch(batch *Batch) *Iter {
 		if found {
 			return c.executeBatch(batch)
 		} else {
-			return &Iter{err: err, framer: framer}
+			return &Iter{err: x, framer: framer}
 		}
 	case *resultRowsFrame:
 		iter := &Iter{


### PR DESCRIPTION
To address #902
Make executeBatch behaves the same as executeQuery when C* returns RequestErrUnprepared