### PR TITLE
Add exponential backoff retry policy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,3 +87,4 @@ Vincent Rischmann <me@vrischmann.me>
 Jesse Claven <jesse.claven@gmail.com>
 Derrick Wippler <thrawn01@gmail.com>
 Leigh McCulloch <leigh@leighmcculloch.com>
+Ron Kuris <swcafe@gmail.com>


### PR DESCRIPTION
To improve reliability in the event of a flaky network, we want to use this retry policy, which has a configurable backoff and uses some jitter to mitigate thundering herds when the network is misbehaving.