### PR TITLE
host: use broadcast_address in ConnectAddress

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -153,9 +153,10 @@ func (h *HostInfo) ConnectAddress() net.IP {
 		// Use 'rpc_address' if provided and it's not 0.0.0.0
 		if h.rpcAddress != nil && !h.rpcAddress.IsUnspecified() {
 			return h.rpcAddress
-		}
-		// Peer should always be set if this from 'system.peer'
-		if h.peer != nil {
+		} else if h.broadcastAddress != nil && !h.broadcastAddress.IsUnspecified() {
+			return h.broadcastAddress
+		} else if h.peer != nil {
+			// Peer should always be set if this from 'system.peer'
 			return h.peer
 		}
 	}

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -104,3 +104,34 @@ func TestGetHostsWithFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestHostInfo_ConnectAddress(t *testing.T) {
+	var localhost = net.IPv4(127, 0, 0, 1)
+	tests := []struct {
+		name          string
+		connectAddr   net.IP
+		rpcAddr       net.IP
+		broadcastAddr net.IP
+		peer          net.IP
+	}{
+		{name: "rpc_address", rpcAddr: localhost},
+		{name: "connect_address", connectAddr: localhost},
+		{name: "broadcast_address", broadcastAddr: localhost},
+		{name: "peer", peer: localhost},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			host := &HostInfo{
+				connectAddress:   test.connectAddr,
+				rpcAddress:       test.rpcAddr,
+				broadcastAddress: test.broadcastAddr,
+				peer:             test.peer,
+			}
+
+			if addr := host.ConnectAddress(); !addr.Equal(localhost) {
+				t.Fatalf("expected ConnectAddress to be %s got %s", localhost, addr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If the rpc_address is set to 0.0.0.0 then we should use
broadcast_address if it is set.