### PR TITLE
WhiteListHostFilter: use IP.String() for the filter key

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -48,10 +48,10 @@ func WhiteListHostFilter(hosts ...string) HostFilter {
 
 	m := make(map[string]bool, len(hostInfos))
 	for _, host := range hostInfos {
-		m[string(host.ConnectAddress())] = true
+		m[host.ConnectAddress().String()] = true
 	}
 
 	return HostFilterFunc(func(host *HostInfo) bool {
-		return m[string(host.ConnectAddress())]
+		return m[host.ConnectAddress().String()]
 	})
 }


### PR DESCRIPTION
Fixes #911