### PR TITLE
avoid SIGSEGV by not tracing unless query is trace enabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,3 +90,4 @@ Leigh McCulloch <leigh@leighmcculloch.com>
 Ron Kuris <swcafe@gmail.com>
 Raphael Gavache <raphael.gavache@gmail.com>
 Yasser Abdolmaleki <yasser@yasser.ca>
+Krishnanand Thommandra <devtkrishna@gmail.com>

--- a/conn.go
+++ b/conn.go
@@ -845,7 +845,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 		return &Iter{err: err}
 	}
 
-	if len(framer.traceID) > 0 {
+	if len(framer.traceID) > 0 && qry.trace != nil {
 		qry.trace.Trace(framer.traceID)
 	}
 


### PR DESCRIPTION
When 'nodetool settraceprobability' is used,
it's possible to get a response frame with trace information
even though client did not specifically mark the query
for tracing.

There are two places in conn.go where this can cause SIGSEGV, prepareStatement and executeQuery. 

The prepareStatement path was fixed in https://github.com/gocql/gocql/commit/990865929b372dba9393b0ba8e4967288594b59b