### PR TITLE
Fix spelling for DCAwareRoundRobinPolicy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,3 +91,4 @@ Ron Kuris <swcafe@gmail.com>
 Raphael Gavache <raphael.gavache@gmail.com>
 Yasser Abdolmaleki <yasser@yasser.ca>
 Krishnanand Thommandra <devtkrishna@gmail.com>
+Blake Atkinson <me@blakeatkinson.com>

--- a/policies.go
+++ b/policies.go
@@ -544,10 +544,10 @@ type dcAwareRR struct {
 	remoteHosts map[string]*HostInfo
 }
 
-// DCAwareRoundRobbinPolicy is a host selection policies which will priorities and
+// DCAwareRoundRobinPolicy is a host selection policies which will priorities and
 // return hosts which are in the local datacentre before returning hosts in all
 // other datercentres
-func DCAwareRoundRobbinPolicy(localDC string) HostSelectionPolicy {
+func DCAwareRoundRobinPolicy(localDC string) HostSelectionPolicy {
 	return &dcAwareRR{
 		local:       localDC,
 		localHosts:  make(map[string]*HostInfo),

--- a/policies_test.go
+++ b/policies_test.go
@@ -303,7 +303,7 @@ func TestExponentialBackoffPolicy(t *testing.T) {
 }
 
 func TestDCAwareRR(t *testing.T) {
-	p := DCAwareRoundRobbinPolicy("local")
+	p := DCAwareRoundRobinPolicy("local")
 	p.AddHost(&HostInfo{connectAddress: net.ParseIP("10.0.0.1"), dataCenter: "local"})
 	p.AddHost(&HostInfo{connectAddress: net.ParseIP("10.0.0.2"), dataCenter: "remote"})
 


### PR DESCRIPTION
Spelling nit so DCAwareRoundRobinPolicy lines up with regular RoundRobinHostPolicy.

Update AUTHORS.md