### PR TITLE
Avoided RLock being taken twice for same mutex variable of same host which leads to deadlock if any WLock is requested inbetween two RLock by other routine

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,3 +92,4 @@ Raphael Gavache <raphael.gavache@gmail.com>
 Yasser Abdolmaleki <yasser@yasser.ca>
 Krishnanand Thommandra <devtkrishna@gmail.com>
 Blake Atkinson <me@blakeatkinson.com>
+Dharmendra Parsaila <d4dharmu@gmail.com>

--- a/host_source.go
+++ b/host_source.go
@@ -123,8 +123,14 @@ type HostInfo struct {
 func (h *HostInfo) Equal(host *HostInfo) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	host.mu.RLock()
-	defer host.mu.RUnlock()
+	//If both hosts pointers are same then lock is required only once because of below reasons:
+	//Reason 1: There is no point taking lock twice on same mutex variable.
+	//Reason 2: It may leads to deadlock e.g. if WLock is requested by other routine in between 1st & 2nd RLock
+	//So WLock will be blocked on 1st RLock and 2nd RLock will be blocked on reuested WLock.
+	if h != host {
+		host.mu.RLock()
+		defer host.mu.RUnlock()
+	}
 
 	return h.ConnectAddress().Equal(host.ConnectAddress())
 }

--- a/host_source.go
+++ b/host_source.go
@@ -125,8 +125,8 @@ func (h *HostInfo) Equal(host *HostInfo) bool {
 	defer h.mu.RUnlock()
 	//If both hosts pointers are same then lock is required only once because of below reasons:
 	//Reason 1: There is no point taking lock twice on same mutex variable.
-	//Reason 2: It may leads to deadlock e.g. if WLock is requested by other routine in between 1st & 2nd RLock
-	//So WLock will be blocked on 1st RLock and 2nd RLock will be blocked on reuested WLock.
+	//Reason 2: It may lead to deadlock e.g. if WLock is requested by other routine in between 1st & 2nd RLock
+	//So WLock will be blocked on 1st RLock and 2nd RLock will be blocked on requested WLock.
 	if h != host {
 		host.mu.RLock()
 		defer host.mu.RUnlock()


### PR DESCRIPTION
We found that gocql gets deadlocked in our load testing in production setup.
Below is the scenario description:

**Scenario:**
We have 5 node cassandra cluster all went down, our gocql client has logic to create session again with new cassandra ip list if session is closed. Until cassandra cluster comes up there are multiple host-up & down handling happens and during this one of the gocql client was deadlocked which we figured it out through pprof goroutine analysis.

**Issue Description**:
On host-up, gocql compares it with existing host list and takes RLock on both host before comparision.
If both host are same then RLock will be taken twice on same mutex variable (that's fine till now).
But on host-down gocql takes WLock on that host and if this lock is requested in-between two RLock then it's a deadlock.
i.e. WLock will be blocked due to 1st RLock and 2nd RLock will be blocked due to WLock request.
We have done some fix in gocql to avoid taking RLock twice on same mutex variable to avoid deadlock.

**Fix Description:**
I have just added a check that if host pointers are same then don't take read-lock twice because:
**Reason 1**: There is no point taking lock twice on same mutex variable.
**Reason 2:** It may leads to deadlock e.g. if WLock is requested by other routine in between 1st & 2nd RLock, So WLock will be blocked on 1st RLock and 2nd RLock will be blocked on reuested WLock.

**pprof blocked goroutine back trace:**
**Routine 1:**
	0x43dfff	sync.runtime_Semacquire+0x2f													/usr/local/go/src/runtime/sema.go:47
	0x5839dc	sync.(*RWMutex).RLock+0x5c													/usr/local/go/src/sync/rwmutex.go:43
	0x6e412f	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*HostInfo).Equal+0x6f							vendor/github.com/gocql/gocql/host_source.go
	0x70b776	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*cowHostList).add+0x126						vendor/github.com/gocql/gocql/policies.go
	0x70bee6	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*roundRobinHostPolicy).AddHost+0x36					vendor/github.com/gocql/gocql/policies.go
	0x70bfa4	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*roundRobinHostPolicy).HostUp+0x34					vendor/github.com/gocql/gocql/policies.go
	0x6cfdac	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*Session).handleNodeUp+0xfc						vendor/github.com/gocql/gocql/events.go
	0x70e48b	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*Session).init+0x18b							vendor/github.com/gocql/gocql/session.go
	0x70dc60	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.NewSession+0x870							vendor/github.com/gocql/gocql/session.go
	0x6bf2d1	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession+0x61					vendor/github.com/gocql/gocql/cluster.go

**Routine 2:**
	0x43dfff	sync.runtime_Semacquire+0x2f								/usr/local/go/src/runtime/sema.go:47
	0x583b77	sync.(*RWMutex).Lock+0x97								/usr/local/go/src/sync/rwmutex.go:91
	0x6e4729	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*HostInfo).setState+0x39	vendor/github.com/gocql/gocql/host_source.go
	0x6cff9e	stash.verizon.com/dkt/data/vendor/github.com/gocql/gocql.(*Session).handleNodeDown+0x8e	vendor/github.com/gocql/gocql/events.go