### PR TITLE
hostsource: remove hosts no longer in peers

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -53,6 +53,16 @@ func (r *ring) allHosts() []*HostInfo {
 	return hosts
 }
 
+func (r *ring) currentHosts() map[string]*HostInfo {
+	r.mu.RLock()
+	hosts := make(map[string]*HostInfo, len(r.hosts))
+	for k, v := range r.hosts {
+		hosts[k] = v
+	}
+	r.mu.RUnlock()
+	return hosts
+}
+
 func (r *ring) addHost(host *HostInfo) bool {
 	if host.invalidConnectAddr() {
 		panic(fmt.Sprintf("invalid host: %v", host))

--- a/session.go
+++ b/session.go
@@ -384,6 +384,12 @@ func (s *Session) executeQuery(qry *Query) *Iter {
 	return iter
 }
 
+func (s *Session) removeHost(h *HostInfo) {
+	s.policy.RemoveHost(h)
+	s.pool.removeHost(h.ConnectAddress())
+	s.ring.removeHost(h.ConnectAddress())
+}
+
 // KeyspaceMetadata returns the schema metadata for the keyspace specified. Returns an error if the keyspace does not exist.
 func (s *Session) KeyspaceMetadata(keyspace string) (*KeyspaceMetadata, error) {
 	// fail fast


### PR DESCRIPTION
When refreshing the ring remove hosts from the drivers ring cache to
prevent it from trying to connect to removed hosts if it does not
receive a down host event.