### PR TITLE
marshal: fix is nullable check

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -177,7 +177,7 @@ func isNullableValue(value interface{}) bool {
 }
 
 func isNullData(info TypeInfo, data []byte) bool {
-	return len(data) == 0
+	return data == nil
 }
 
 func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -543,7 +543,7 @@ var marshalTests = []struct {
 	},
 	{
 		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte{},
+		[]byte(nil),
 		(*string)(nil),
 		nil,
 		nil,
@@ -574,7 +574,7 @@ var marshalTests = []struct {
 	},
 	{
 		NativeType{proto: 2, typ: TypeTimeUUID},
-		[]byte{},
+		[]byte(nil),
 		(*UUID)(nil),
 		nil,
 		nil,
@@ -855,6 +855,16 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeBlob},
 		[]byte(nil),
 		([]byte)(nil),
+		nil,
+		nil,
+	},
+	{
+		NativeType{proto: 2, typ: TypeVarchar},
+		[]byte{},
+		func() interface{} {
+			var s string
+			return &s
+		}(),
 		nil,
 		nil,
 	},


### PR DESCRIPTION
When we read null from the wire it is encoded as -1 which gets returned
from the frame as []byte(nil), this is distinct from the framer reading
a length 0 byte which is returned as []byte{}, these both have 0 length
but one is nil the other is empty.

Fix marshalling to correctly handle nil and empty values.

fixes #954 