### PR TITLE
Add Go 1.8 as supported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Go/Cassandra | 2.1.x | 2.2.x | 3.0.x
 -------------| -------| ------| ---------
 1.6  | yes | yes | yes
 1.7  | yes | yes | yes
+1.8  | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
Based on .travis.yml change it looks like 1.8 is supported right?