### PR TITLE
Add Go 1.9 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 go:
   - 1.7
   - 1.8
+  - 1.9
 
 install:
   - pip install --user cql PyYAML six

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
       AUTH=false
 
 go:
-  - 1.7
   - 1.8
   - 1.9
 


### PR DESCRIPTION
Latest stable version is Go 1.9, so I propose to officially support it.