### PR TITLE
Respect exponential retry Max

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,3 +93,4 @@ Yasser Abdolmaleki <yasser@yasser.ca>
 Krishnanand Thommandra <devtkrishna@gmail.com>
 Blake Atkinson <me@blakeatkinson.com>
 Dharmendra Parsaila <d4dharmu@gmail.com>
+Nayef Ghattas <nayef.ghattas@datadoghq.com>

--- a/policies.go
+++ b/policies.go
@@ -187,6 +187,9 @@ func (e *ExponentialBackoffRetryPolicy) napTime(attempts int) time.Duration {
 	napDuration := minFloat * math.Pow(2, float64(attempts-1))
 	// add some jitter
 	napDuration += rand.Float64()*minFloat - (minFloat / 2)
+	if napDuration > float64(e.Max) {
+		return time.Duration(e.Max)
+	}
 	return time.Duration(napDuration)
 }
 


### PR DESCRIPTION
This PR makes sure that the sleep time for ExponentialBackoffRetryPolicy never exceeds Max.

Max was already defined in the struct but not used.