### PR TITLE
Consistency no panic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,3 +94,4 @@ Krishnanand Thommandra <devtkrishna@gmail.com>
 Blake Atkinson <me@blakeatkinson.com>
 Dharmendra Parsaila <d4dharmu@gmail.com>
 Nayef Ghattas <nayef.ghattas@datadoghq.com>
+Michał Matczuk <mmatczuk@gmail.com>

--- a/frame.go
+++ b/frame.go
@@ -196,45 +196,50 @@ func (c Consistency) String() string {
 	}
 }
 
-func ParseConsistency(s string) Consistency {
-	switch strings.ToUpper(s) {
+func (c Consistency) MarshalText() (text []byte, err error) {
+	return []byte(c.String()), nil
+}
+
+func (c *Consistency) UnmarshalText(text []byte) error {
+	switch string(text) {
 	case "ANY":
-		return Any
+		*c = Any
 	case "ONE":
-		return One
+		*c = One
 	case "TWO":
-		return Two
+		*c = Two
 	case "THREE":
-		return Three
+		*c = Three
 	case "QUORUM":
-		return Quorum
+		*c = Quorum
 	case "ALL":
-		return All
+		*c = All
 	case "LOCAL_QUORUM":
-		return LocalQuorum
+		*c = LocalQuorum
 	case "EACH_QUORUM":
-		return EachQuorum
+		*c = EachQuorum
 	case "LOCAL_ONE":
-		return LocalOne
+		*c = LocalOne
 	default:
-		panic("invalid consistency: " + s)
+		return fmt.Errorf("invalid consistency %q", string(text))
 	}
+
+	return nil
+}
+
+func ParseConsistency(s string) Consistency {
+	var c Consistency
+	if err := c.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
+		panic(err)
+	}
+	return c
 }
 
 // ParseConsistencyWrapper wraps gocql.ParseConsistency to provide an err
 // return instead of a panic
 func ParseConsistencyWrapper(s string) (consistency Consistency, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			var ok bool
-			err, ok = r.(error)
-			if !ok {
-				err = fmt.Errorf("ParseConsistencyWrapper: %v", r)
-			}
-		}
-	}()
-	consistency = ParseConsistency(s)
-	return consistency, nil
+	err = consistency.UnmarshalText([]byte(strings.ToUpper(s)))
+	return
 }
 
 type SerialConsistency uint16
@@ -253,6 +258,23 @@ func (s SerialConsistency) String() string {
 	default:
 		return fmt.Sprintf("UNKNOWN_SERIAL_CONS_0x%x", uint16(s))
 	}
+}
+
+func (s SerialConsistency) MarshalText() (text []byte, err error) {
+	return []byte(s.String()), nil
+}
+
+func (s *SerialConsistency) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "SERIAL":
+		*s = Serial
+	case "LOCAL_SERIAL":
+		*s = LocalSerial
+	default:
+		return fmt.Errorf("invalid consistency %q", string(text))
+	}
+
+	return nil
 }
 
 const (

--- a/frame.go
+++ b/frame.go
@@ -227,19 +227,20 @@ func (c *Consistency) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func ParseConsistency(s string) Consistency {
-	var c Consistency
-	if err := c.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
+func ParseConsistency(s string) (consistency Consistency, err error) {
+	err = consistency.UnmarshalText([]byte(strings.ToUpper(s)))
+	return
+}
+
+// ParseConsistencyWrapper is deprecated use ParseConsistency instead.
+var ParseConsistencyWrapper = ParseConsistency
+
+func MustParseConsistency(s string) Consistency {
+	c, err := ParseConsistency(s)
+	if err != nil {
 		panic(err)
 	}
 	return c
-}
-
-// ParseConsistencyWrapper wraps gocql.ParseConsistency to provide an err
-// return instead of a panic
-func ParseConsistencyWrapper(s string) (consistency Consistency, err error) {
-	err = consistency.UnmarshalText([]byte(strings.ToUpper(s)))
-	return
 }
 
 type SerialConsistency uint16

--- a/frame_test.go
+++ b/frame_test.go
@@ -97,10 +97,3 @@ func TestFrameReadTooLong(t *testing.T) {
 		t.Fatalf("expected to get header %v got %v", opReady, head.op)
 	}
 }
-
-func TestParseConsistencyErrorInsteadOfPanic(t *testing.T) {
-	_, err := ParseConsistencyWrapper("TEST")
-	if err == nil {
-		t.Fatal("expected ParseConsistencyWrapper error got nil")
-	}
-}


### PR DESCRIPTION
This PR adds text marshaller and unmarshaller for `Consistency` and `SerialConsistency` it removes panic recover behavior while parsing. https://github.com/gocql/gocql/pull/983/commits/ab2b96ae82252983855b8291290d4b12fe8d3c75 changes the parsing method naming to more common ones.