### PR TITLE
marshall: correctly handle null tuple elements

### DIFF
--- a/tuple_test.go
+++ b/tuple_test.go
@@ -43,13 +43,50 @@ func TestTupleSimple(t *testing.T) {
 
 	if id != 1 {
 		t.Errorf("expected to get id=1 got: %v", id)
-	}
-	if coord.x != 100 {
+	} else if coord.x != 100 {
 		t.Errorf("expected to get coord.x=100 got: %v", coord.x)
-	}
-	if coord.y != -100 {
+	} else if coord.y != -100 {
 		t.Errorf("expected to get coord.y=-100 got: %v", coord.y)
 	}
+
+}
+
+func TestTuple_NullTuple(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+	if session.cfg.ProtoVersion < protoVersion3 {
+		t.Skip("tuple types are only available of proto>=3")
+	}
+
+	err := createTable(session, `CREATE TABLE gocql_test.tuple_nil_test(
+		id int,
+		coord frozen<tuple<int, int>>,
+
+		primary key(id))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const id = 1
+
+	err = session.Query("INSERT INTO tuple_nil_test(id, coord) VALUES(?, (?, ?))", id, nil, nil).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x := new(int)
+	y := new(int)
+	iter := session.Query("SELECT coord FROM tuple_nil_test WHERE id=?", id)
+	if err := iter.Scan(&x, &y); err != nil {
+		t.Fatal(err)
+	}
+
+	if x != nil {
+		t.Fatalf("should be nil got %+#v", x)
+	} else if y != nil {
+		t.Fatalf("should be nil got %+#v", y)
+	}
+
 }
 
 func TestTupleMapScan(t *testing.T) {


### PR DESCRIPTION
UDT and Tuple values are [byte] which can return nil. UDT handled this
and lots of special handling for the slicing the data. Create readBytes
which correctly reads the bytes and handles nil. Use this in tuple and
UDT. Add testcase for tuples.