### PR TITLE
enable ipv4 preferred lookup using an environment variable

### DIFF
--- a/control.go
+++ b/control.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"sync"
@@ -91,7 +92,7 @@ func (c *controlConn) heartBeat() {
 	}
 }
 
-var hostLookupPreferV4 = false
+var hostLookupPreferV4 = os.Getenv("GOCQL_HOST_LOOKUP_PREFER_V4") == "true"
 
 func hostInfo(addr string, defaultPort int) (*HostInfo, error) {
 	var port int


### PR DESCRIPTION
Read the environment variable `GOCQL_HOST_LOOKUP_PREFER_V4` to prefer ipv4 lookup