### PR TITLE
fix failing murmur tests on 32-bit platforms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,3 +97,4 @@ Nayef Ghattas <nayef.ghattas@datadoghq.com>
 Michał Matczuk <mmatczuk@gmail.com>
 Ben Krebsbach <ben.krebsbach@gmail.com>
 Vivian Mathews <vivian.mathews.3@gmail.com>
+Sascha Steinbiss <satta@debian.org>

--- a/internal/murmur/murmur_test.go
+++ b/internal/murmur/murmur_test.go
@@ -66,8 +66,8 @@ func BenchmarkMurmur3H1(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			h1 := Murmur3H1(data)
-			if h1 != 7627370222079200297 {
-				b.Fatalf("expected %d got %d", 7627370222079200297, h1)
+			if h1 != uint64(7627370222079200297) {
+				b.Fatalf("expected %d got %d", uint64(7627370222079200297), h1)
 			}
 		}
 	})


### PR DESCRIPTION
During Debian autobuilds on 32-bit platforms (armhf, i386) we noticed that one of the expected result hash values, when given as a literal number, overflows `int`. This causes the build of the testing code to fail on such platforms. Explicitly requiring the value to be 64-bit fixes this.