### PR TITLE
Connect to multiple hosts behind a DNS name

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -732,11 +732,11 @@ func (srv *TestServer) session() (*Session, error) {
 }
 
 func (srv *TestServer) host() *HostInfo {
-	host, err := hostInfo(srv.Address, 9042)
+	hosts, err := hostInfo(srv.Address, 9042)
 	if err != nil {
 		srv.t.Fatal(err)
 	}
-	return host
+	return hosts[0]
 }
 
 func (srv *TestServer) closeWatch() {

--- a/control_test.go
+++ b/control_test.go
@@ -18,12 +18,13 @@ func TestHostInfo_Lookup(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		host, err := hostInfo(test.addr, 1)
+		hosts, err := hostInfo(test.addr, 1)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue
 		}
 
+		host := hosts[0]
 		if !host.ConnectAddress().Equal(test.ip) {
 			t.Errorf("expected ip %v got %v for addr %q", test.ip, host.ConnectAddress(), test.addr)
 		}

--- a/session.go
+++ b/session.go
@@ -78,7 +78,7 @@ var queryPool = &sync.Pool{
 func addrsToHosts(addrs []string, defaultPort int) ([]*HostInfo, error) {
 	var hosts []*HostInfo
 	for _, hostport := range addrs {
-		host, err := hostInfo(hostport, defaultPort)
+		resolvedHosts, err := hostInfo(hostport, defaultPort)
 		if err != nil {
 			// Try other hosts if unable to resolve DNS name
 			if _, ok := err.(*net.DNSError); ok {
@@ -88,7 +88,7 @@ func addrsToHosts(addrs []string, defaultPort int) ([]*HostInfo, error) {
 			return nil, err
 		}
 
-		hosts = append(hosts, host)
+		hosts = append(hosts, resolvedHosts...)
 	}
 	if len(hosts) == 0 {
 		return nil, errors.New("failed to resolve any of the provided hostnames")


### PR DESCRIPTION
When using a DNS name as your connection point, this allows the client to attempt to connect to multiple nodes in the cluster when creating the control connection.

We've encountered an issue where our DNS will sometimes return a temporarily offline host first from DNS.  During this time, any client that attempts to bootstrap will return an error as it will only try to connect to that host.  Since we return many hosts in our DNS, the client should attempt to connect to several of them, as if we had passed in a list of IP addresses.