### PR TITLE
Fix no connection being made due to host replacement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,4 @@ Ben Krebsbach <ben.krebsbach@gmail.com>
 Vivian Mathews <vivian.mathews.3@gmail.com>
 Sascha Steinbiss <satta@debian.org>
 Seth Rosenblum <seth.t.rosenblum@gmail.com>
+Luke Hines <lukehines@protonmail.com>

--- a/session.go
+++ b/session.go
@@ -194,7 +194,7 @@ func (s *Session) init() error {
 					filteredHosts = append(filteredHosts, host)
 				}
 			}
-			hosts = filteredHosts
+			hosts = append(hosts, filteredHosts...)
 		}
 	}
 


### PR DESCRIPTION
When trying to connect to a cluster some users of this package receive
"no connections were made when creating the session"

This issue was introduced in commit  [Remove HostFilter for supplied hosts (#1012)](https://github.com/gocql/gocql/commit/aa93acc8f067e9233982b9a7de370e4d64b9c33e)
because hosts are now completely replaced by the 'list of hosts the cluster knows about' as apposed to being appended to the existing list.

This pull request resolves this issue and resolve issue #1020 