### PR TITLE
Round-robin host selection for token aware policy based

### DIFF
--- a/token_test.go
+++ b/token_test.go
@@ -157,11 +157,11 @@ func TestIntTokenRing(t *testing.T) {
 			intToken(75),
 			intToken(25),
 		},
-		hosts: []*HostInfo{
-			host0,
-			host50,
-			host75,
-			host25,
+		tokenHostMap: map[string]*hostIter{
+			intToken(0).String():  &hostIter{0, []*HostInfo{host0}},
+			intToken(50).String(): &hostIter{0, []*HostInfo{host50}},
+			intToken(75).String(): &hostIter{0, []*HostInfo{host75}},
+			intToken(25).String(): &hostIter{0, []*HostInfo{host25}},
 		},
 	}
 


### PR DESCRIPTION
The murmur3 partitioner in token aware policy does not take advantage of read replicas. It hits the same Cassandra node for a given token/partition. This PR attempts to pick other nodes having the same partition in a round-robin manner.