### PR TITLE
metadata: fix all types being NativeType

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,74 @@
+package gocql
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetCassandraType_Set(t *testing.T) {
+	typ := getCassandraType("set<text>")
+	set, ok := typ.(CollectionType)
+	if !ok {
+		t.Fatalf("expected CollectionType got %T", typ)
+	} else if set.typ != TypeSet {
+		t.Fatalf("expected type %v got %v", TypeSet, set.typ)
+	}
+
+	inner, ok := set.Elem.(NativeType)
+	if !ok {
+		t.Fatalf("expected to get NativeType got %T", set.Elem)
+	} else if inner.typ != TypeText {
+		t.Fatalf("expected to get %v got %v for set value", TypeText, set.typ)
+	}
+}
+
+func TestGetCassandraType(t *testing.T) {
+	tests := []struct {
+		input string
+		exp   TypeInfo
+	}{
+		{
+			"set<text>", CollectionType{
+				NativeType: NativeType{typ: TypeSet},
+
+				Elem: NativeType{typ: TypeText},
+			},
+		},
+		{
+			"map<text, varchar>", CollectionType{
+				NativeType: NativeType{typ: TypeMap},
+
+				Key:  NativeType{typ: TypeText},
+				Elem: NativeType{typ: TypeVarchar},
+			},
+		},
+		{
+			"list<int>", CollectionType{
+				NativeType: NativeType{typ: TypeList},
+				Elem:       NativeType{typ: TypeInt},
+			},
+		},
+		{
+			"tuple<int, int, text>", TupleTypeInfo{
+				NativeType: NativeType{typ: TypeTuple},
+
+				Elems: []TypeInfo{
+					NativeType{typ: TypeInt},
+					NativeType{typ: TypeInt},
+					NativeType{typ: TypeText},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			got := getCassandraType(test.input)
+
+			// TODO(zariel): define an equal method on the types?
+			if !reflect.DeepEqual(got, test.exp) {
+				t.Fatalf("expected %v got %v", test.exp, got)
+			}
+		})
+	}
+}

--- a/marshal.go
+++ b/marshal.go
@@ -2053,6 +2053,17 @@ type TupleTypeInfo struct {
 	Elems []TypeInfo
 }
 
+func (t TupleTypeInfo) String() string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s(", t.typ))
+	for _, elem := range t.Elems {
+		buf.WriteString(fmt.Sprintf("%s, ", elem))
+	}
+	buf.Truncate(buf.Len() - 2)
+	buf.WriteByte(')')
+	return buf.String()
+}
+
 func (t TupleTypeInfo) New() interface{} {
 	return reflect.New(goType(t)).Interface()
 }

--- a/metadata.go
+++ b/metadata.go
@@ -226,25 +226,26 @@ func compileMetadata(
 
 	// add columns from the schema data
 	for i := range columns {
+		col := &columns[i]
 		// decode the validator for TypeInfo and order
-		if columns[i].ClusteringOrder != "" { // Cassandra 3.x+
-			columns[i].Type = NativeType{typ: getCassandraType(columns[i].Validator)}
-			columns[i].Order = ASC
-			if columns[i].ClusteringOrder == "desc" {
-				columns[i].Order = DESC
+		if col.ClusteringOrder != "" { // Cassandra 3.x+
+			col.Type = getCassandraType(col.Validator)
+			col.Order = ASC
+			if col.ClusteringOrder == "desc" {
+				col.Order = DESC
 			}
 		} else {
-			validatorParsed := parseType(columns[i].Validator)
-			columns[i].Type = validatorParsed.types[0]
-			columns[i].Order = ASC
+			validatorParsed := parseType(col.Validator)
+			col.Type = validatorParsed.types[0]
+			col.Order = ASC
 			if validatorParsed.reversed[0] {
-				columns[i].Order = DESC
+				col.Order = DESC
 			}
 		}
 
-		table := keyspace.Tables[columns[i].Table]
-		table.Columns[columns[i].Name] = &columns[i]
-		table.OrderedColumns = append(table.OrderedColumns, columns[i].Name)
+		table := keyspace.Tables[col.Table]
+		table.Columns[col.Name] = col
+		table.OrderedColumns = append(table.OrderedColumns, col.Name)
 	}
 
 	if protoVersion == protoVersion1 {


### PR DESCRIPTION
Parse the correct TypeInfo from the cassandra string in the db. Fixing
representation to recursivly parse the nested types.