### PR TITLE
marshal: fix marshalling of ints with a wrong type

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -330,7 +330,7 @@ func marshalSmallInt(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("marshal smallint: value %d out of range", v)
 		}
 		return encShort(int16(v)), nil
-	default:
+	case reflect.Ptr:
 		if rv.IsNil() {
 			return nil, nil
 		}
@@ -414,7 +414,7 @@ func marshalTinyInt(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("marshal tinyint: value %d out of range", v)
 		}
 		return []byte{byte(v)}, nil
-	default:
+	case reflect.Ptr:
 		if rv.IsNil() {
 			return nil, nil
 		}
@@ -486,7 +486,7 @@ func marshalInt(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("marshal int: value %d out of range", v)
 		}
 		return encInt(int32(v)), nil
-	default:
+	case reflect.Ptr:
 		if rv.IsNil() {
 			return nil, nil
 		}


### PR DESCRIPTION
When trying to marshal a value with the wrong type into a int, smallint or tinyint, marshalInt, marshalSmallint and marshalTinyint fail with a panic because IsNil is called on a non-pointer value.

Test program:

    package main
    import (
            "log"
            "github.com/gocql/gocql"
    )
    func main() {
            cfg := gocql.NewCluster("localhost:9042")
            session, err := cfg.CreateSession()
            if err != nil {
                    log.Fatal(err)
            }
            const (
                    tableDDL = `CREATE TABLE test.foobar (id text PRIMARY KEY, val int, val2 tinyint, val3 smallint)`
            )
            if err := session.Query(tableDDL).Exec(); err != nil {
                    log.Printf("unable to create table: %v", err)
            }
            err = session.Query("UPDATE test.foobar SET val = ? WHERE id = ?", float64(456), "foobar").Exec()
            if err != nil {
                    log.Print(err)
            }
            err = session.Query("UPDATE test.foobar SET val2 = ? WHERE id = ?", float64(456), "foobar").Exec()
            if err != nil {
                    log.Print(err)
            }
            err = session.Query("UPDATE test.foobar SET val3 = ? WHERE id = ?", float64(456), "foobar").Exec()
            if err != nil {
                    log.Print(err)
            }
    }

And here's the panic I get:

    panic: reflect: call of reflect.Value.IsNil on float64 Value
    goroutine 1 [running]:
    reflect.Value.IsNil(0x6470e0, 0x6cbce0, 0x8e, 0x7c5040)
            /usr/local/go/src/reflect/value.go:1001 +0x12e
    github.com/gocql/gocql.marshalSmallInt(0x7c14e0, 0xc42019e1e0, 0x6470e0, 0x6cbce0, 0x0, 0x0, 0x672dc0, 0x10, 0xe0000000010)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:334 +0x2ed
    github.com/gocql/gocql.Marshal(0x7c14e0, 0xc42019e1e0, 0x6470e0, 0x6cbce0, 0xc4200a9ad0, 0x441cc7, 0x60, 0x672dc0, 0xc4201e6001)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:73 +0xd4a
    github.com/gocql/gocql.marshalQueryValue(0x7c14e0, 0xc42019e1e0, 0x6470e0, 0x6cbce0, 0xc4200fc6c0, 0x2, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/conn.go:760 +0xc6
    github.com/gocql/gocql.(*Conn).executeQuery(0xc4201901c0, 0xc4201a4480, 0xb7c3396)
            /home/vincent/dev/go/src/github.com/gocql/gocql/conn.go:829 +0x3e1
    github.com/gocql/gocql.(*Query).execute(0xc4201a4480, 0xc4201901c0, 0x7db860)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:773 +0x35
    github.com/gocql/gocql.(*queryExecutor).attemptQuery(0xc42000cf00, 0x7c2a80, 0xc4201a4480, 0xc4201901c0, 0x7fdbb28256c8)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:23 +0x6a
    github.com/gocql/gocql.(*queryExecutor).executeQuery(0xc42000cf00, 0x7c2a80, 0xc4201a4480, 0xc4200a9e88, 0x61237f, 0x6a7a1b)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:52 +0x189
    github.com/gocql/gocql.(*Session).executeQuery(0xc4200f8000, 0xc4201a4480, 0xc4200a9e00)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:398 +0xc1
    github.com/gocql/gocql.(*Query).Iter(0xc4201a4480, 0xc4201a4480)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:965 +0xbf
    github.com/gocql/gocql.(*Query).Exec(0xc4201a4480, 0x6a7a1b, 0x2c)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:948 +0x2b
    main.main()
            /home/vincent/tmp/gocql-marshal-bug/main.go:26 +0x250
    exit status 2

After applying the fix:

    2018/02/05 14:17:00 can not marshal float64 into int
    2018/02/05 14:17:00 can not marshal float64 into tinyint
    2018/02/05 14:17:00 can not marshal float64 into smallint
