### PR TITLE
send frame should not block

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,3 +101,4 @@ Sascha Steinbiss <satta@debian.org>
 Seth Rosenblum <seth.t.rosenblum@gmail.com>
 Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
 Luke Hines <lukehines@protonmail.com>
+Zhixin Wen <john.wenzhixin@hotmail.com>

--- a/conn.go
+++ b/conn.go
@@ -220,18 +220,20 @@ func (s *Session) dial(ip net.IP, port int, cfg *ConnConfig, errorHandler ConnEr
 	startupErr := make(chan error)
 	// need to call before we write to net.Conn
 	go func() {
-		select {
-		case args := <- c.frameWriteArgChan:
-			if err := args.req.writeFrame(args.framer, args.stream); err != nil{
-				// I think this is the correct thing to do, im not entirely sure. It is not
-				// ideal as readers might still get some data, but they probably wont.
-				// Here we need to be careful as the stream is not available and if all
-				// writes just timeout or fail then the pool might use this connection to
-				// send a frame on, with all the streams used up and not returned.
-				c.closeWithError(err)
+		for {
+			select {
+			case args := <- c.frameWriteArgChan:
+				if err := args.req.writeFrame(args.framer, args.stream); err != nil{
+					// I think this is the correct thing to do, im not entirely sure. It is not
+					// ideal as readers might still get some data, but they probably wont.
+					// Here we need to be careful as the stream is not available and if all
+					// writes just timeout or fail then the pool might use this connection to
+					// send a frame on, with all the streams used up and not returned.
+					c.closeWithError(err)
+				}
+			case <-c.quit:
+				return
 			}
-		case <-c.quit:
-			return
 		}
 	}()
 

--- a/conn.go
+++ b/conn.go
@@ -230,6 +230,7 @@ func (s *Session) dial(ip net.IP, port int, cfg *ConnConfig, errorHandler ConnEr
 					// writes just timeout or fail then the pool might use this connection to
 					// send a frame on, with all the streams used up and not returned.
 					c.closeWithError(err)
+					return
 				}
 			case <-c.quit:
 				return

--- a/conn.go
+++ b/conn.go
@@ -641,23 +641,6 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 
 func (c *Conn) getResp(ctx context.Context, call *callReq) error {
 	timeoutCh := c.resetTimeout(call)
-	if c.timeout > 0 {
-		if call.timer == nil {
-			call.timer = time.NewTimer(0)
-			<-call.timer.C
-		} else {
-			if !call.timer.Stop() {
-				select {
-				case <-call.timer.C:
-				default:
-				}
-			}
-		}
-
-		call.timer.Reset(c.timeout)
-		timeoutCh = call.timer.C
-	}
-
 	var ctxDone <-chan struct{}
 	if ctx != nil {
 		ctxDone = ctx.Done()


### PR DESCRIPTION
Issue: https://github.com/gocql/gocql/issues/896
Send the frame asynchronously, so a request can timeout properly when network is slow 