### PR TITLE
Replace tolower

### DIFF
--- a/session.go
+++ b/session.go
@@ -953,7 +953,7 @@ func isUseStatement(stmt string) bool {
 		return false
 	}
 
-	return strings.ToLower(stmt[0:3]) == "use"
+	return strings.EqualFold(stmt[0:3], "use")
 }
 
 // Iter executes the query and returns an iterator capable of iterating

--- a/session_test.go
+++ b/session_test.go
@@ -263,3 +263,30 @@ func TestConsistencyNames(t *testing.T) {
 		}
 	}
 }
+
+func TestIsUseStatement(t *testing.T) {
+	testCases := []struct {
+		input string
+		exp   bool
+	}{
+		{"USE foo", true},
+		{"USe foo", true},
+		{"UsE foo", true},
+		{"Use foo", true},
+		{"uSE foo", true},
+		{"uSe foo", true},
+		{"usE foo", true},
+		{"use foo", true},
+		{"SELECT ", false},
+		{"UPDATE ", false},
+		{"INSERT ", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		v := isUseStatement(tc.input)
+		if v != tc.exp {
+			t.Fatalf("expected %v but got %v for statement %q", tc.exp, v, tc.input)
+		}
+	}
+}


### PR DESCRIPTION
While doing some profiling of an application I saw `isUseStatement` popping up in the memory allocation profiling. It doesn't account for much in the profile but for this use case `ToLower` can easily be replaced with `EqualFold`.