### PR TITLE
Fixing expected value for TestRebindQueryInfo when q.Bind(24).

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1139,7 +1139,7 @@ func TestRebindQueryInfo(t *testing.T) {
 	}
 
 	if value != "w00t" {
-		t.Fatalf("expected %v but got %v", "quux", value)
+		t.Fatalf("expected %v but got %v", "w00t", value)
 	}
 }
 


### PR DESCRIPTION
Fixing expected value for test case.