### PR TITLE
Add reconnection policies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,3 +102,4 @@ Seth Rosenblum <seth.t.rosenblum@gmail.com>
 Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
 Luke Hines <lukehines@protonmail.com>
 Zhixin Wen <john.wenzhixin@hotmail.com>
+Chang Liu <changliu.it@gmail.com>

--- a/cluster.go
+++ b/cluster.go
@@ -54,6 +54,7 @@ type ClusterConfig struct {
 	Compressor        Compressor        // compression algorithm (default: nil)
 	Authenticator     Authenticator     // authenticator (default: nil)
 	RetryPolicy       RetryPolicy       // Default retry policy to use for queries (default: 0)
+	ReconnectionPolicy ReconnectionPolicy // Default reconnection policy to use for reconnecting before marking host as down (default: see below)
 	SocketKeepalive   time.Duration     // The keepalive period to use, enabled if > 0 (default: 0)
 	MaxPreparedStmts  int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
 	MaxRoutingKeyInfo int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
@@ -151,6 +152,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
+		ReconnectionPolicy:     &ConstantReconnectionPolicy{10, 2 * time.Second},
 	}
 	return cfg
 }

--- a/cluster.go
+++ b/cluster.go
@@ -55,7 +55,6 @@ type ClusterConfig struct {
 	Authenticator      Authenticator      // authenticator (default: nil)
 	RetryPolicy        RetryPolicy        // Default retry policy to use for queries (default: 0)
 	ReconnectionPolicy ReconnectionPolicy // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
-	ConvictionPolicy   ConvictionPolicy   // Decide whether to mark node as down based on the error (default: SimpleConvictionPolicy)
 	SocketKeepalive    time.Duration      // The keepalive period to use, enabled if > 0 (default: 0)
 	MaxPreparedStmts   int                // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
 	MaxRoutingKeyInfo  int                // Sets the maximum cache size for query info about statements for each session (default: 1000)
@@ -154,7 +153,6 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
-		ConvictionPolicy:       &SimpleConvictionPolicy{},
 	}
 	return cfg
 }

--- a/cluster.go
+++ b/cluster.go
@@ -44,24 +44,25 @@ type ClusterConfig struct {
 	// If it is 0 or unset (the default) then the driver will attempt to discover the
 	// highest supported protocol for the cluster. In clusters with nodes of different
 	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
-	ProtoVersion      int
-	Timeout           time.Duration     // connection timeout (default: 600ms)
-	ConnectTimeout    time.Duration     // initial connection timeout, used during initial dial to server (default: 600ms)
-	Port              int               // port (default: 9042)
-	Keyspace          string            // initial keyspace (optional)
-	NumConns          int               // number of connections per host (default: 2)
-	Consistency       Consistency       // default consistency level (default: Quorum)
-	Compressor        Compressor        // compression algorithm (default: nil)
-	Authenticator     Authenticator     // authenticator (default: nil)
-	RetryPolicy       RetryPolicy       // Default retry policy to use for queries (default: 0)
-	ReconnectionPolicy ReconnectionPolicy // Default reconnection policy to use for reconnecting before marking host as down (default: see below)
-	SocketKeepalive   time.Duration     // The keepalive period to use, enabled if > 0 (default: 0)
-	MaxPreparedStmts  int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
-	MaxRoutingKeyInfo int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
-	PageSize          int               // Default page size to use for created sessions (default: 5000)
-	SerialConsistency SerialConsistency // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
-	SslOpts           *SslOptions
-	DefaultTimestamp  bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
+	ProtoVersion       int
+	Timeout            time.Duration      // connection timeout (default: 600ms)
+	ConnectTimeout     time.Duration      // initial connection timeout, used during initial dial to server (default: 600ms)
+	Port               int                // port (default: 9042)
+	Keyspace           string             // initial keyspace (optional)
+	NumConns           int                // number of connections per host (default: 2)
+	Consistency        Consistency        // default consistency level (default: Quorum)
+	Compressor         Compressor         // compression algorithm (default: nil)
+	Authenticator      Authenticator      // authenticator (default: nil)
+	RetryPolicy        RetryPolicy        // Default retry policy to use for queries (default: 0)
+	ReconnectionPolicy ReconnectionPolicy // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
+	ConvictionPolicy   ConvictionPolicy   // Decide whether to mark node as down based on the error (default: SimpleConvictionPolicy)
+	SocketKeepalive    time.Duration      // The keepalive period to use, enabled if > 0 (default: 0)
+	MaxPreparedStmts   int                // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
+	MaxRoutingKeyInfo  int                // Sets the maximum cache size for query info about statements for each session (default: 1000)
+	PageSize           int                // Default page size to use for created sessions (default: 5000)
+	SerialConsistency  SerialConsistency  // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
+	SslOpts            *SslOptions
+	DefaultTimestamp   bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
@@ -152,7 +153,8 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
-		ReconnectionPolicy:     &ConstantReconnectionPolicy{10, 2 * time.Second},
+		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second},
+		ConvictionPolicy:       &SimpleConvictionPolicy{},
 	}
 	return cfg
 }

--- a/cluster.go
+++ b/cluster.go
@@ -153,7 +153,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
-		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second},
+		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 2 * time.Second},
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 	}
 	return cfg

--- a/cluster.go
+++ b/cluster.go
@@ -153,7 +153,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
-		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 2 * time.Second},
+		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 	}
 	return cfg

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 	"time"
+	"reflect"
 )
 
 func TestNewCluster_Defaults(t *testing.T) {
@@ -19,6 +20,10 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
+	assertTrue(t, "cluster config reconnection policy",
+		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
+	assertTrue(t, "cluster config conviction policy",
+		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }
 
 func TestNewCluster_WithHosts(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -21,7 +21,7 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
 	assertTrue(t, "cluster config reconnection policy",
-		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
+		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second}, cfg.ReconnectionPolicy))
 	assertTrue(t, "cluster config conviction policy",
 		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -22,8 +22,6 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
 	assertTrue(t, "cluster config reconnection policy",
 		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second}, cfg.ReconnectionPolicy))
-	assertTrue(t, "cluster config conviction policy",
-		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }
 
 func TestNewCluster_WithHosts(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -21,7 +21,7 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
 	assertTrue(t, "cluster config reconnection policy",
-		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
+		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
 	assertTrue(t, "cluster config conviction policy",
 		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -497,10 +497,9 @@ func (pool *hostConnPool) connectMany(count int) error {
 func (pool *hostConnPool) connect() (err error) {
 	// TODO: provide a more robust connection retry mechanism, we should also
 	// be able to detect hosts that come up by trying to connect to downed ones.
-	const maxAttempts = 3
 	// try to connect
 	var conn *Conn
-	for i := 0; i < maxAttempts; i++ {
+	for i := 0; i < pool.session.cfg.ReconnectionPolicy.GetMaxRetries(); i++ {
 		conn, err = pool.session.connect(pool.host, pool)
 		if err == nil {
 			break
@@ -512,6 +511,7 @@ func (pool *hostConnPool) connect() (err error) {
 				break
 			}
 		}
+		time.Sleep(pool.session.cfg.ReconnectionPolicy.GetInterval(i))
 	}
 
 	if err != nil {

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -420,9 +420,7 @@ func (pool *hostConnPool) fill() {
 
 			// this is call with the connection pool mutex held, this call will
 			// then recursively try to lock it again. FIXME
-			if pool.session.cfg.ConvictionPolicy.AddFailure(err) {
-				go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
-			}
+			go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
 			return
 		}
 

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -420,7 +420,9 @@ func (pool *hostConnPool) fill() {
 
 			// this is call with the connection pool mutex held, this call will
 			// then recursively try to lock it again. FIXME
-			go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
+			if pool.session.cfg.ConvictionPolicy.AddFailure(err) {
+				go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
+			}
 			return
 		}
 
@@ -513,7 +515,7 @@ func (pool *hostConnPool) connect() (err error) {
 			}
 		}
 		if gocqlDebug {
-			Logger.Printf("connection failed %q: %v, reconnecting with specified ReconnectionPolicy %T\n",
+			Logger.Printf("connection failed %q: %v, reconnecting with %T\n",
 				pool.host.ConnectAddress(), err, reconnectionPolicy)
 		}
 		time.Sleep(reconnectionPolicy.GetInterval(i))

--- a/control.go
+++ b/control.go
@@ -341,7 +341,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 	if host != nil {
 		// try to connect to the old host
 		conn, err := c.session.connect(host, c)
-		if err != nil {
+		if err != nil && c.session.cfg.ConvictionPolicy.AddFailure(err) {
 			// host is dead
 			// TODO: this is replicated in a few places
 			c.session.handleNodeDown(host.ConnectAddress(), host.Port())

--- a/control.go
+++ b/control.go
@@ -341,7 +341,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 	if host != nil {
 		// try to connect to the old host
 		conn, err := c.session.connect(host, c)
-		if err != nil && c.session.cfg.ConvictionPolicy.AddFailure(err) {
+		if err != nil {
 			// host is dead
 			// TODO: this is replicated in a few places
 			c.session.handleNodeDown(host.ConnectAddress(), host.Port())

--- a/policies.go
+++ b/policies.go
@@ -726,7 +726,7 @@ type ReconnectionPolicy interface {
 //
 // Examples of usage:
 //
-//     cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{MaxRetries: 10, Interval: 8}
+//     cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{MaxRetries: 10, Interval: 8 * time.Second}
 //
 type ConstantReconnectionPolicy struct {
 	MaxRetries int

--- a/policies.go
+++ b/policies.go
@@ -732,12 +732,12 @@ type ConstantReconnectionPolicy struct {
 	Interval   time.Duration
 }
 
-func (e *ConstantReconnectionPolicy) GetInterval(currentRetry int) time.Duration {
-	return e.Interval
+func (c *ConstantReconnectionPolicy) GetInterval(currentRetry int) time.Duration {
+	return c.Interval
 }
 
-func (e *ConstantReconnectionPolicy) GetMaxRetries() int {
-	return e.MaxRetries
+func (c *ConstantReconnectionPolicy) GetMaxRetries() int {
+	return c.MaxRetries
 }
 
 // ExponentialReconnectionPolicy returns a growing reconnection interval.

--- a/policies.go
+++ b/policies.go
@@ -754,20 +754,3 @@ func (e *ExponentialReconnectionPolicy) GetInterval(currentRetry int) time.Durat
 func (e *ExponentialReconnectionPolicy) GetMaxRetries() int {
 	return e.MaxRetries
 }
-
-type ConvictionPolicy interface {
-	// Implementations should return `true` if the host should be convicted, `false` otherwise.
-	AddFailure(error error) bool
-	//Implementations should clear out any convictions or state regarding the host.
-	Reset()
-}
-
-//return true on any error
-type SimpleConvictionPolicy struct {
-}
-
-func (e *SimpleConvictionPolicy) AddFailure(error error) bool {
-	return true
-}
-
-func (e *SimpleConvictionPolicy) Reset() {}

--- a/policies.go
+++ b/policies.go
@@ -198,29 +198,6 @@ func (e *ExponentialBackoffRetryPolicy) napTime(attempts int) time.Duration {
 	return getExponentialTime(e.Min, e.Max, attempts)
 }
 
-// Will move this to a new branch
-//
-//type DowngradingConsistencyRetryPolicy struct {
-//	CurrentConsistencyLevel Consistency
-//}
-//
-//func (e *DowngradingConsistencyRetryPolicy) ConsistencyLevel (numResponses int, cons Consistency) Consistency {
-//	if numResponses >= 3 {
-//		return Three
-//	}
-//	if numResponses >= 2 {
-//		return Two
-//	}
-//	if numResponses >= 1 {
-//		return One
-//	}
-//	return cons
-//}
-//
-//func (e *DowngradingConsistencyRetryPolicy) Attempt(q RetryableQuery) bool {
-//
-//	return true
-//}
 type HostStateNotifier interface {
 	AddHost(host *HostInfo)
 	RemoveHost(host *HostInfo)

--- a/policies.go
+++ b/policies.go
@@ -193,6 +193,10 @@ func (e *ExponentialBackoffRetryPolicy) napTime(attempts int) time.Duration {
 	return time.Duration(napDuration)
 }
 
+type DowngradingConsistencyRetryPolicy struct {
+	
+}
+
 type HostStateNotifier interface {
 	AddHost(host *HostInfo)
 	RemoveHost(host *HostInfo)

--- a/policies.go
+++ b/policies.go
@@ -712,10 +712,9 @@ func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 	}
 }
 
-// ReconnectionPolicy interface is used by gocql to determine if a host can be attempted
-// again after connection error. The interface allows gocql
-// users to implement their own logic to determine if a query can be attempted
-// again.
+// ReconnectionPolicy interface is used by gocql to determine if reconnection
+// can be attempted after connection error. The interface allows gocql users
+// to implement their own logic to determine how to attempt reconnection.
 //
 type ReconnectionPolicy interface {
 	GetInterval(currentRetry int) time.Duration

--- a/policies.go
+++ b/policies.go
@@ -194,9 +194,26 @@ func (e *ExponentialBackoffRetryPolicy) napTime(attempts int) time.Duration {
 }
 
 type DowngradingConsistencyRetryPolicy struct {
-	
+	CurrentConsistencyLevel Consistency
 }
 
+func (e *DowngradingConsistencyRetryPolicy) ConsistencyLevel (numResponses int) Consistency {
+	if numResponses >= 3 {
+		return Three
+	}
+	if numResponses >= 2 {
+		return Two
+	}
+	if numResponses >= 1 {
+		return One
+	}
+	return nil
+}
+
+func (e *DowngradingConsistencyRetryPolicy) Attempt(q RetryableQuery) bool {
+
+	return true
+}
 type HostStateNotifier interface {
 	AddHost(host *HostInfo)
 	RemoveHost(host *HostInfo)


### PR DESCRIPTION
PR for #1079 

Reconnection policy: 

decides how to reconnect before marking host as 'down'.  Implemented 2 reconnection policies - `ConstantReconnectionPolicy` (default) and `ExponentialReconnectionPolicy`. Refactored the existing policies and gave the exponential retry logic a separate function to be shared by `ExponentialReconnectionPolicy` and `ExponentialBackoffRetryPolicy`.

Opened interface in policies.go for user to implement their own policies.