### PR TITLE
add conviction policy interface

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -54,6 +54,7 @@ type ClusterConfig struct {
 	Compressor        Compressor        // compression algorithm (default: nil)
 	Authenticator     Authenticator     // authenticator (default: nil)
 	RetryPolicy       RetryPolicy       // Default retry policy to use for queries (default: 0)
+	ConvictionPolicy   ConvictionPolicy   // Decide whether to mark node as down based on the error (default: SimpleConvictionPolicy)
 	SocketKeepalive   time.Duration     // The keepalive period to use, enabled if > 0 (default: 0)
 	MaxPreparedStmts  int               // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
 	MaxRoutingKeyInfo int               // Sets the maximum cache size for query info about statements for each session (default: 1000)
@@ -151,6 +152,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		DefaultTimestamp:       true,
 		MaxWaitSchemaAgreement: 60 * time.Second,
 		ReconnectInterval:      60 * time.Second,
+		ConvictionPolicy:       &SimpleConvictionPolicy{},
 	}
 	return cfg
 }

--- a/cluster.go
+++ b/cluster.go
@@ -54,7 +54,7 @@ type ClusterConfig struct {
 	Compressor         Compressor         // compression algorithm (default: nil)
 	Authenticator      Authenticator      // authenticator (default: nil)
 	RetryPolicy        RetryPolicy        // Default retry policy to use for queries (default: 0)
-	ConvictionPolicy   ConvictionPolicy   // Decide whether to mark node as down based on the error (default: SimpleConvictionPolicy)
+	ConvictionPolicy   ConvictionPolicy   // Decide whether to mark host as down based on the error and host info (default: SimpleConvictionPolicy)
 	ReconnectionPolicy ReconnectionPolicy // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
 	SocketKeepalive    time.Duration      // The keepalive period to use, enabled if > 0 (default: 0)
 	MaxPreparedStmts   int                // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 	"time"
+	"reflect"
 )
 
 func TestNewCluster_Defaults(t *testing.T) {
@@ -19,6 +20,10 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
+	assertTrue(t, "cluster config reconnection policy",
+		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
+	assertTrue(t, "cluster config conviction policy",
+		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }
 
 func TestNewCluster_WithHosts(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -20,8 +20,6 @@ func TestNewCluster_Defaults(t *testing.T) {
 	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
 	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
 	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
-	assertTrue(t, "cluster config reconnection policy",
-		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 10, Interval: 2 * time.Second}, cfg.ReconnectionPolicy))
 	assertTrue(t, "cluster config conviction policy",
 		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
 }

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -420,7 +420,9 @@ func (pool *hostConnPool) fill() {
 
 			// this is call with the connection pool mutex held, this call will
 			// then recursively try to lock it again. FIXME
-			go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
+			if pool.session.cfg.ConvictionPolicy.AddFailure(err) {
+				go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
+			}
 			return
 		}
 

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -420,7 +420,7 @@ func (pool *hostConnPool) fill() {
 
 			// this is call with the connection pool mutex held, this call will
 			// then recursively try to lock it again. FIXME
-			if pool.session.cfg.ConvictionPolicy.AddFailure(err) {
+			if pool.session.cfg.ConvictionPolicy.AddFailure(err, pool.host) {
 				go pool.session.handleNodeDown(pool.host.ConnectAddress(), pool.port)
 			}
 			return

--- a/control.go
+++ b/control.go
@@ -341,7 +341,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 	if host != nil {
 		// try to connect to the old host
 		conn, err := c.session.connect(host, c)
-		if err != nil && c.session.cfg.ConvictionPolicy.AddFailure(err) {
+		if err != nil && c.session.cfg.ConvictionPolicy.AddFailure(err, host) {
 			// host is dead
 			// TODO: this is replicated in a few places
 			c.session.handleNodeDown(host.ConnectAddress(), host.Port())

--- a/control.go
+++ b/control.go
@@ -341,7 +341,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 	if host != nil {
 		// try to connect to the old host
 		conn, err := c.session.connect(host, c)
-		if err != nil {
+		if err != nil && c.session.cfg.ConvictionPolicy.AddFailure(err) {
 			// host is dead
 			// TODO: this is replicated in a few places
 			c.session.handleNodeDown(host.ConnectAddress(), host.Port())

--- a/policies.go
+++ b/policies.go
@@ -706,3 +706,20 @@ func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 		return (*selectedHost)(host)
 	}
 }
+
+type ConvictionPolicy interface {
+	// Implementations should return `true` if the host should be convicted, `false` otherwise.
+	AddFailure(error error) bool
+	//Implementations should clear out any convictions or state regarding the host.
+	Reset()
+}
+
+//return true on any error
+type SimpleConvictionPolicy struct {
+}
+
+func (e *SimpleConvictionPolicy) AddFailure(error error) bool {
+	return true
+}
+
+func (e *SimpleConvictionPolicy) Reset() {}

--- a/policies.go
+++ b/policies.go
@@ -793,7 +793,7 @@ func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 
 type ConvictionPolicy interface {
 	// Implementations should return `true` if the host should be convicted, `false` otherwise.
-	AddFailure(error error) bool
+	AddFailure(error error, host *HostInfo) bool
 	//Implementations should clear out any convictions or state regarding the host.
 	Reset()
 }
@@ -802,7 +802,7 @@ type ConvictionPolicy interface {
 type SimpleConvictionPolicy struct {
 }
 
-func (e *SimpleConvictionPolicy) AddFailure(error error) bool {
+func (e *SimpleConvictionPolicy) AddFailure(error error, host *HostInfo) bool {
 	return true
 }
 

--- a/policies.go
+++ b/policies.go
@@ -791,14 +791,17 @@ func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 	}
 }
 
+// ConvictionPolicy interface is used by gocql to determine if a host should be
+// marked as DOWN based on the error and host info
 type ConvictionPolicy interface {
 	// Implementations should return `true` if the host should be convicted, `false` otherwise.
 	AddFailure(error error, host *HostInfo) bool
 	//Implementations should clear out any convictions or state regarding the host.
-	Reset()
+	Reset(host *HostInfo)
 }
 
-//return true on any error
+// SimpleConvictionPolicy implements a ConvictionPolicy which convicts all hosts
+// regardless of error
 type SimpleConvictionPolicy struct {
 }
 
@@ -806,7 +809,8 @@ func (e *SimpleConvictionPolicy) AddFailure(error error, host *HostInfo) bool {
 	return true
 }
 
-func (e *SimpleConvictionPolicy) Reset() {}
+func (e *SimpleConvictionPolicy) Reset(host *HostInfo) {}
+
 // ReconnectionPolicy interface is used by gocql to determine if reconnection
 // can be attempted after connection error. The interface allows gocql users
 // to implement their own logic to determine how to attempt reconnection.


### PR DESCRIPTION
#1079 

Conviction policy: 

decide when to mark the host as 'down' based on the error. Default:  `SimpleConvictionPolicy` - mark host as 'down' on any error.

Opened interface in policies.go for user to implement their own policies.