### PR TITLE
Run travis tests against go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ env:
       AUTH=false
 
 go:
-  - 1.8
-  - 1.9
+  - "1.8"
+  - "1.9"
+  - "1.10"
 
 install:
   - pip install --user cql PyYAML six


### PR DESCRIPTION
Start testing against go 1.10. Note quotes are required due to travis-ci/travis-ci#9247

 - I've not updated the readme to include 1.10 until we're happy it all passes
 - I'm already in the AUTHORS file 😄 