### PR TITLE
Add vgo support

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,6 @@
 
 // Package gocql implements a fast and robust Cassandra driver for the
 // Go programming language.
-package gocql
+package gocql // import "github.com/gocql/gocql"
 
 // TODO(tux21b): write more docs.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module "github.com/gocql/gocql"
+
+require (
+	"github.com/golang/snappy" v0.0.0-20170215233205-553a64147049
+	"github.com/hailocab/go-hostpool" v0.0.0-20160125115350-e80d13ce29ed
+	"gopkg.in/inf.v0" v1.9.1-gopkgin-v0.9.1
+)

--- a/go.modverify
+++ b/go.modverify
@@ -1,0 +1,3 @@
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
+gopkg.in/inf.v0 v1.9.1-gopkgin-v0.9.1 h1:v5V5uqBldcybGI9tCBuizXlXYQYLztR7zNxeL/5C3g8=


### PR DESCRIPTION
What
===
Add vgo files `go.mod` and `go.modverify` and import comment.

Why
===
The import comment seems to be becoming the standard way to define the canonical import path and the vgo files allow for easy use of the prototype vgo tool that will be built into go in a future version of go and these file formats will continue to be supported.