### PR TITLE
marshaler: support encoding.TextMarshaler

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -6,6 +6,7 @@ package gocql
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -60,6 +61,13 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 
 	if v, ok := value.(Marshaler); ok {
 		return v.MarshalCQL(info)
+	}
+
+	if v, ok := value.(encoding.TextMarshaler); ok {
+		switch info.Type() {
+		case TypeVarchar, TypeText:
+			return v.MarshalText()
+		}
 	}
 
 	switch info.Type() {
@@ -120,6 +128,13 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 
 	if isNullableValue(value) {
 		return unmarshalNullable(info, data, value)
+	}
+
+	if v, ok := value.(encoding.TextUnmarshaler); ok {
+		switch info.Type() {
+		case TypeVarchar, TypeText:
+			return v.UnmarshalText(data)
+		}
 	}
 
 	switch info.Type() {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -4,6 +4,7 @@ package gocql
 
 import (
 	"bytes"
+	"encoding"
 	"math"
 	"math/big"
 	"net"
@@ -56,6 +57,13 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeVarchar},
 		[]byte("HELLO WORLD"),
 		CustomString("hello world"),
+		nil,
+		nil,
+	},
+	{
+		NativeType{proto: 2, typ: TypeVarchar},
+		[]byte("Hello World"),
+		CustomString2("hello world"),
 		nil,
 		nil,
 	},
@@ -734,6 +742,16 @@ var marshalTests = []struct {
 	},
 	{
 		NativeType{proto: 2, typ: TypeVarchar},
+		[]byte("Hello World"),
+		func() *CustomString2 {
+			customString := CustomString2("hello world")
+			return &customString
+		}(),
+		nil,
+		nil,
+	},
+	{
+		NativeType{proto: 2, typ: TypeVarchar},
 		[]byte(nil),
 		(*CustomString)(nil),
 		nil,
@@ -1131,6 +1149,35 @@ func (c *CustomString) UnmarshalCQL(info TypeInfo, data []byte) error {
 	*c = CustomString(strings.ToLower(string(data)))
 	return nil
 }
+func (c CustomString) MarshalText() ([]byte, error) {
+	return []byte(strings.Title(string(c))), nil
+}
+func (c *CustomString) UnmarshalText(data []byte) error {
+	*c = CustomString(strings.ToLower(string(data)))
+	return nil
+}
+
+var (
+	_ encoding.TextMarshaler   = CustomString("")
+	_ encoding.TextUnmarshaler = new(CustomString)
+	_ Marshaler                = CustomString("")
+	_ Unmarshaler              = new(CustomString)
+)
+
+type CustomString2 string
+
+func (c2 CustomString2) MarshalText() ([]byte, error) {
+	return []byte(strings.Title(string(c2))), nil
+}
+func (c2 *CustomString2) UnmarshalText(data []byte) error {
+	*c2 = CustomString2(strings.ToLower(string(data)))
+	return nil
+}
+
+var (
+	_ encoding.TextMarshaler   = CustomString2("")
+	_ encoding.TextUnmarshaler = new(CustomString2)
+)
 
 type MyString string
 


### PR DESCRIPTION
quite a few users store semantically rich data in cassandra. 

In order to avoid making all these data structures cassandra aware,
support the encoding.TextMarshaler and encoding.TextUnmarshaler interfaces
from the Go standard library.