### PR TITLE
Potentially fixing the flakiness in TestConnClosedBlocked

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -403,9 +403,14 @@ func (c *Conn) closeWithError(err error) {
 	}
 
 	// if error was nil then unblock the quit channel
-	close(c.quit)
+	if err == nil {
+		close(c.quit)
+	}
+
+	// Now close the connection and save the error
 	cerr := c.close()
 
+	// Handle the original error or the channel-closure error
 	if err != nil {
 		c.errorHandler.HandleError(c, err, true)
 	} else if cerr != nil {


### PR DESCRIPTION
Fixes #1088 

It seems this change fixes the most of the "connection closed waiting for response" errors as in the original report.

Running the single test with high `-count` seems to lead to " no response received from cassandra within timeout period", possibly due to a rapid execution in fast succession. It seems that running with `-cpu=1` solves this problem.

Signed-off-by: Alex Lourie <alex@instaclustr.com>