### PR TITLE
conn: add missing remove prepared statement from cache on error

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -766,6 +766,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer)
 	if err != nil {
 		flight.err = err
 		flight.wg.Done()
+		c.session.stmtsLRU.remove(stmtCacheKey)
 		return nil, err
 	}
 


### PR DESCRIPTION
It was done everywhere else, except here.