### PR TITLE
Improve query pool

### DIFF
--- a/session.go
+++ b/session.go
@@ -311,12 +311,14 @@ func (s *Session) SetTrace(trace Tracer) {
 // value before the query is executed. Query is automatically prepared
 // if it has not previously been executed.
 func (s *Session) Query(stmt string, values ...interface{}) *Query {
-	s.mu.RLock()
+	// these can be done outside the lock to reduce lock holding time.
 	qry := queryPool.Get().(*Query)
 	qry.stmt = stmt
 	qry.values = values
-	qry.cons = s.cons
 	qry.session = s
+
+	s.mu.RLock()
+	qry.cons = s.cons
 	qry.pageSize = s.pageSize
 	qry.trace = s.trace
 	qry.observer = s.queryObserver

--- a/session.go
+++ b/session.go
@@ -1053,25 +1053,7 @@ func (q *Query) Release() {
 
 // reset zeroes out all fields of a query so that it can be safely pooled.
 func (q *Query) reset() {
-	q.stmt = ""
-	q.values = nil
-	q.cons = 0
-	q.pageSize = 0
-	q.routingKey = nil
-	q.routingKeyBuffer = nil
-	q.pageState = nil
-	q.prefetch = 0
-	q.trace = nil
-	q.session = nil
-	q.rt = nil
-	q.binding = nil
-	q.attempts = 0
-	q.totalLatency = 0
-	q.serialCons = 0
-	q.defaultTimestamp = false
-	q.disableSkipMetadata = false
-	q.disableAutoPage = false
-	q.context = nil
+	*q = Query{}
 }
 
 // Iter represents an iterator that can be used to iterate over all rows that

--- a/session.go
+++ b/session.go
@@ -334,7 +334,7 @@ type QueryInfo struct {
 // During execution, the meta data of the prepared query will be routed to the
 // binding callback, which is responsible for producing the query argument values.
 func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]interface{}, error)) *Query {
-	qry := new(Query)
+	qry := queryPool.Get().(*Query)
 	qry.session = s
 	qry.stmt = stmt
 	qry.binding = b


### PR DESCRIPTION
So query creation is more efficient as well as as identical as possible in Session.Bind and Session.Query.