### PR TITLE
conn: fix potential framer reuse in prepare

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1107,9 +1107,8 @@ func (c *Conn) executeBatch(batch *Batch) *Iter {
 			c.session.stmtsLRU.remove(key)
 		}
 
-		framerPool.Put(framer)
-
 		if found {
+			framerPool.Put(framer)
 			return c.executeBatch(batch)
 		} else {
 			return &Iter{err: x, framer: framer}


### PR DESCRIPTION
Don't put the framer into the pool when we may return it on the iter which when closed will return it to the pool.

updates #1103