### PR TITLE
Add frame header observer for per-frame instrumentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,3 +104,4 @@ Luke Hines <lukehines@protonmail.com>
 Zhixin Wen <john.wenzhixin@hotmail.com>
 Chang Liu <changliu.it@gmail.com>
 Ingo Oeser <nightlyone@gmail.com>
+Jacob Greenleaf <jacob@jacobgreenleaf.com>

--- a/cluster.go
+++ b/cluster.go
@@ -122,8 +122,12 @@ type ClusterConfig struct {
 	QueryObserver QueryObserver
 
 	// BatchObserver will set the provided batch observer on all queries created from this session.
-	// Use it to collect metrics / stats from batche queries by providing an implementation of BatchObserver.
+	// Use it to collect metrics / stats from batch queries by providing an implementation of BatchObserver.
 	BatchObserver BatchObserver
+
+	// FrameHeaderObserver will set the provided frame header observer on all frames' headers created from this session.
+	// Use it to collect metrics / stats from frames by providing an implementation of FrameHeaderObserver.
+	FrameHeaderObserver FrameHeaderObserver
 
 	// Default idempotence for queries
 	DefaultIdempotence bool

--- a/frame.go
+++ b/frame.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"context"
 )
 
 type unsetColumn struct{}
@@ -355,6 +356,27 @@ var framerPool = sync.Pool{
 	},
 }
 
+type ObservedFrameHeader struct {
+	Version byte
+	Flags byte
+	Stream int16
+	Opcode byte
+	Length int32
+
+	// StartHeader is the time we started reading the frame header off the network connection.
+	Start time.Time
+	// EndHeader is the time we finished reading the frame header off the network connection.
+	End time.Time
+}
+
+// FrameHeaderObserver is the interface implemented by frame observers / stat collectors.
+//
+// Experimental, this interface and use may change
+type FrameHeaderObserver interface {
+	// ObserveFrameHeader gets called on every received frame header.
+	ObserveFrameHeader(context.Context, ObservedFrameHeader)
+}
+
 // a framer is responsible for reading, writing and parsing frames on a single stream
 type framer struct {
 	r io.Reader
@@ -458,6 +480,7 @@ func readHeader(r io.Reader, p []byte) (head frameHeader, err error) {
 		head.op = frameOp(p[3])
 		head.length = int(readInt(p[4:]))
 	}
+
 
 	return head, nil
 }

--- a/session.go
+++ b/session.go
@@ -39,6 +39,7 @@ type Session struct {
 	trace               Tracer
 	queryObserver       QueryObserver
 	batchObserver       BatchObserver
+	frameObserver       FrameHeaderObserver
 	hostSource          *ringDescriber
 	stmtsLRU            *preparedLRU
 
@@ -138,6 +139,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 
 	s.queryObserver = cfg.QueryObserver
 	s.batchObserver = cfg.BatchObserver
+	s.frameObserver = cfg.FrameHeaderObserver
 
 	//Check the TLS Config before trying to connect to anything external
 	connCfg, err := connConfig(&s.cfg)


### PR DESCRIPTION
Continuing with #1023, add per-frame instrumentation to allow client libraries to instrument e.g. frame body lengths, to tune query page size and observe effects of compression, as well as monitor the authentication handshake frames. 

This PR doesn't include instrumentation for the authentication handshake but introduces the interface and adds the observer hook into the query response path. I wasn't sure whether I should put the hook into `exec` or `recv` or both since `startup` uses `exec` but queries seem to go through `recv` and they seem to be doing the same thing. 