### PR TITLE
check frame inUse

### DIFF
--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,69 @@
+// +build all integration
+
+package gocql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+	"github.com/stretchr/testify/require"
+)
+
+func getCassandraSession() *Session {
+
+	cluster := NewCluster("127.0.0.1")
+	cluster.Port = 9042
+	cluster.Timeout = 40 * time.Second
+	cluster.ConnectTimeout = 40 * time.Second
+	cluster.NumConns = 100
+
+	dbSession, err := cluster.CreateSession()
+	if err != nil {
+		fmt.Errorf("failed to get cassandra session: %v", err)
+		return nil
+	}
+	return dbSession
+}
+
+func TestGocqlMViewDataRaceOriginal(t *testing.T) {
+	// keyspace := `keyspace`
+	// table := `table`
+	// view := `view`
+	id1 := `c818ce88-78b5-46a3-8370-18fdbc330828`
+
+	dropKeyspaceStmt := `DROP KEYSPACE IF EXISTS "keyspace"`
+	createKeyspaceStmt := `CREATE KEYSPACE IF NOT EXISTS "keyspace" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 }`
+
+	createTableStmt := `CREATE TABLE IF NOT EXISTS "keyspace"."table" ("ID" uuid, "Name" varchar, PRIMARY KEY (("ID")));`
+
+	insertStmt := `INSERT INTO "keyspace"."table" ("ID", "Name") VALUES (?, ?)`
+
+	s := getCassandraSession()
+	require.NotNil(t, s)
+
+	err := s.Query(dropKeyspaceStmt).Exec()
+	require.NoError(t, err)
+
+	err = s.Query(createKeyspaceStmt).Exec()
+	require.NoError(t, err)
+
+	err = s.Query(createTableStmt).Exec()
+	require.NoError(t, err)
+
+	// increase the number of iterations OR run the test multiple times.
+	for i := 0; i < 100000; i++ {
+		err = s.Query(insertStmt, id1, "name").Exec()
+	}
+}
+
+func TestGocqlMViewDataRaceSession(t *testing.T) {
+	const table = "TestGocqlMViewDataRace"
+	const id1 = "c818ce88-78b5-46a3-8370-18fdbc330828"
+
+	for index := 0; index < 1000; index++ {
+			s := createSession(t)
+			s.Close()
+		}
+	fmt.Println("Iter")
+}
+


### PR DESCRIPTION
Running the test with 
`go test -tags "integration" -run TestGocqlMViewDataRaceOriginal -v` this panics to me @Zariel, although not every time

```
=== RUN   TestGocqlMViewDataRaceOriginal
--- FAIL: TestGocqlMViewDataRaceOriginal (18.70s)
panic: framer already in use [recovered]
	panic: framer already in use

goroutine 5 [running]:
testing.tRunner.func1(0xc4201560f0)
	/usr/local/go/src/testing/testing.go:742 +0x29d
panic(0x7509c0, 0x825930)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/gocql/gocql.newFramer(0x828420, 0xc4203a3960, 0x828440, 0xc4203a3960, 0x0, 0x0, 0x4, 0x0)
	/home/jaume/go/src/github.com/gocql/gocql/frame.go:390 +0x241
github.com/gocql/gocql.(*Conn).exec(0xc4203a3960, 0x0, 0x0, 0x8288c0, 0xc421861420, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/jaume/go/src/github.com/gocql/gocql/conn.go:625 +0xbd
github.com/gocql/gocql.(*Conn).executeQuery(0xc4203a3960, 0xc421876120, 0x45a703994)
	/home/jaume/go/src/github.com/gocql/gocql/conn.go:901 +0x530
github.com/gocql/gocql.(*Query).execute(0xc421876120, 0xc4203a3960, 0x9c58e0)
	/home/jaume/go/src/github.com/gocql/gocql/session.go:791 +0x35
github.com/gocql/gocql.(*queryExecutor).attemptQuery(0xc42011af20, 0x82d360, 0xc421876120, 0xc4203a3960, 0x7fce7356d000)
	/home/jaume/go/src/github.com/gocql/gocql/query_executor.go:23 +0x6a
github.com/gocql/gocql.(*queryExecutor).executeQuery(0xc42011af20, 0x82d360, 0xc421876120, 0x7ead90, 0x2, 0x7d31f0)
	/home/jaume/go/src/github.com/gocql/gocql/query_executor.go:52 +0x191
github.com/gocql/gocql.(*Session).executeQuery(0xc42015a000, 0xc421876120, 0xc42006bf00)
	/home/jaume/go/src/github.com/gocql/gocql/session.go:389 +0xb7
github.com/gocql/gocql.(*Query).Iter(0xc421876120, 0xc421876120)
	/home/jaume/go/src/github.com/gocql/gocql/session.go:997 +0xac
github.com/gocql/gocql.(*Query).Exec(0xc421876120, 0x7ead8f, 0x3b)
	/home/jaume/go/src/github.com/gocql/gocql/session.go:980 +0x2b
github.com/gocql/gocql.TestGocqlMViewDataRaceOriginal(0xc4201560f0)
	/home/jaume/go/src/github.com/gocql/gocql/race_test.go:55 +0x23a
testing.tRunner(0xc4201560f0, 0x7f6540)
	/usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:824 +0x2e0
exit status 2
```