### PR TITLE
Update vgo go.mod and go.modverify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
-module "github.com/gocql/gocql"
+module github.com/gocql/gocql
 
 require (
-	"github.com/golang/snappy" v0.0.0-20170215233205-553a64147049
-	"github.com/hailocab/go-hostpool" v0.0.0-20160125115350-e80d13ce29ed
-	"gopkg.in/inf.v0" v1.9.1-gopkgin-v0.9.1
+	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.modverify
+++ b/go.modverify
@@ -1,3 +1,3 @@
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
-gopkg.in/inf.v0 v1.9.1-gopkgin-v0.9.1 h1:v5V5uqBldcybGI9tCBuizXlXYQYLztR7zNxeL/5C3g8=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=


### PR DESCRIPTION
What
===
Update the vgo files, go.mod and go.modverify using the latest version
of vgo, `vgo:2018-02-20.1`.

Why
===
A recent version of vgo shipped changes to how go.modverify is populated
for packages hosted as gopkg.in, and removed quotes from package names.

Resolves #1130.

cc @dahankzter @myitcv @nightlyone