### PR TITLE
return deep copy of ssl config

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -58,7 +58,10 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 
 	sslOpts.InsecureSkipVerify = !sslOpts.EnableHostVerification
 
-	return sslOpts.Config, nil
+	// Return deep copy to avoid potential races
+	sslCopy := *sslOpts.Config
+
+	return &sslCopy, nil
 }
 
 type policyConnPool struct {

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -58,10 +58,8 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 
 	sslOpts.InsecureSkipVerify = !sslOpts.EnableHostVerification
 
-	// Return deep copy to avoid potential races
-	sslCopy := *sslOpts.Config
-
-	return &sslCopy, nil
+	// return clone to avoid race
+	return sslOpts.Config.Clone(), nil
 }
 
 type policyConnPool struct {


### PR DESCRIPTION
I built this with `-race` and ran it against a cassandra node with SSL enabled.

```go

package main

import (
    "fmt"

    "github.com/gocql/gocql"
)

func main() {

    cluster := gocql.NewCluster("host")
    cluster.Keyspace = "Keyspace"
    cluster.ProtoVersion = 4
    cluster.SslOpts = &gocql.SslOptions{EnableHostVerification: false}
    cluster.Authenticator = &gocql.PasswordAuthenticator{Username: "Username", Password: "Password"}

    for i := 0; i < 10; i++ {
        session, err := cluster.CreateSession()
        if err != nil {
            fmt.Println(err)
        }
        session.Close()
    }
}
```

It trips a race.

Every time gocql starts a session it sets InsecureSkipVerify. That value is then read later by TLS in goroutines.

On a subsequent session, InsecureSkipVerify is updated again in the main routine. Now I've mixed a  load and store across routines without synchronization.

I understand InsecureSkipVerify is set with the same value, and that this race is benign. 

I'm working on something that needs to reconnect a session (long story) and I'd like to fix all the races.

One possible solution is for setupTLSConfig to return a pointer to a deep copy of the TLS Config.

```
==================
WARNING: DATA RACE
Write at 0x00c420001b98 by main goroutine:
  vendor/github.com/gocql/gocql.setupTLSConfig()
      vendor/github.com/gocql/gocql/connectionpool.go:59 +0x3f3
  vendor/github.com/gocql/gocql.connConfig()
      vendor/github.com/gocql/gocql/connectionpool.go:85 +0x2d3
  vendor/github.com/gocql/gocql.NewSession()
      vendor/github.com/gocql/gocql/session.go:143 +0xeb4
  vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      vendor/github.com/gocql/gocql/cluster.go:168 +0x7f
  main.main()
      main/main.go:18 +0x2a1

Previous read at 0x00c420001b98 by goroutine 50:
  crypto/tls.(*Config).Clone()
      /usr/local/go/src/crypto/tls/common.go:566 +0x5d6
  crypto/tls.DialWithDialer()
      /usr/local/go/src/crypto/tls/tls.go:138 +0x49e
  vendor/github.com/gocql/gocql.(*Session).dial()
      vendor/github.com/gocql/gocql/conn.go:176 +0x2ce
  vendor/github.com/gocql/gocql.(*Session).connect()
      vendor/github.com/gocql/gocql/session.go:642 +0x100
  vendor/github.com/gocql/gocql.(*hostConnPool).connect()
      vendor/github.com/gocql/gocql/connectionpool.go:506 +0x161
  vendor/github.com/gocql/gocql.(*hostConnPool).connectMany.func1()
      vendor/github.com/gocql/gocql/connectionpool.go:483 +0x66

Goroutine 50 (running) created at:
  vendor/github.com/gocql/gocql.(*hostConnPool).connectMany()
      vendor/github.com/gocql/gocql/connectionpool.go:481 +0x155
  vendor/github.com/gocql/gocql.(*hostConnPool).fill.func1()
      vendor/github.com/gocql/gocql/connectionpool.go:435 +0x42
==================
Found 1 data race(s)
```