### PR TITLE
Provide a way to limit per-query-attempt deadlines

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,3 +106,5 @@ Chang Liu <changliu.it@gmail.com>
 Ingo Oeser <nightlyone@gmail.com>
 Luke Hines <lukehines@protonmail.com>
 Jacob Greenleaf <jacob@jacobgreenleaf.com>
+Andreas Jaekle <andreas@jaekle.net>
+Daniel Lohse <daniel.lohse@alfatraining.de>

--- a/conn.go
+++ b/conn.go
@@ -585,6 +585,10 @@ type callReq struct {
 }
 
 func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*framer, error) {
+	if ctx != nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	// TODO: move tracer onto conn
 	stream, ok := c.streams.GetStream()
 	if !ok {

--- a/conn.go
+++ b/conn.go
@@ -795,12 +795,12 @@ func marshalQueryValue(typ TypeInfo, value interface{}, dst *queryValues) error 
 
 func (c *Conn) executeQuery(qry *Query) *Iter {
 	ctx := qry.context
-	if qry.attemptTimeout > 0 {
+	if rt, ok := qry.rt.(RetryPolicyWithAttemptTimeout); ok && rt.AttemptTimeout() > 0 {
 		if ctx == nil {
 			ctx = context.Background()
 		}
 		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, qry.attemptTimeout)
+		ctx, cancel = context.WithTimeout(ctx, rt.AttemptTimeout())
 		defer cancel()
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -337,7 +337,7 @@ func TestQueryRetry(t *testing.T) {
 	}()
 
 	rt := &testRetryPolicy{numRetries: 10, t: t, attemptTimeout: time.Millisecond * 25}
-	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*90)
 	defer cancel()
 	qry := db.Query("slow").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx)
 	if err := qry.Exec(); err == nil {
@@ -350,7 +350,7 @@ func TestQueryRetry(t *testing.T) {
 
 	numQueries := atomic.LoadUint64(&srv.nQueries)
 
-	// the 100ms timeout allows at most 4 retries
+	// the 90ms timeout allows at most 4 retries
 	if numQueries > 4 {
 		t.Fatalf("Too many retries executed for query. Query executed %v times", numQueries)
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -334,7 +334,7 @@ func TestQueryRetry(t *testing.T) {
 	rt := &testRetryPolicy{NumRetries: 10, t: t}
 	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 	defer cancel()
-	qry := db.Query("killaftertimeout").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx).AttemptTimeout(time.Millisecond * 30)
+	qry := db.Query("killaftertimeout").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx).AttemptTimeout(time.Millisecond * 35)
 	if err := qry.Exec(); err == nil {
 		t.Fatalf("expected error")
 	}
@@ -345,6 +345,7 @@ func TestQueryRetry(t *testing.T) {
 		t.Fatalf("expected requests %v to match query attempts %v", requests, attempts)
 	}
 
+	// the 200ms timeout allows at most 8 retries
 	if requests > 8 {
 		t.Fatalf("too many retries executed for query. Query executed %v times", requests)
 	}
@@ -932,7 +933,7 @@ func (srv *TestServer) process(f *framer) {
 			f.writeInt(0x1001)
 			f.writeString("query killed")
 			rand.Seed(time.Now().UnixNano())
-			sleepFor := time.Duration(time.Millisecond * time.Duration((rand.Intn(30) + 20)))
+			sleepFor := time.Duration(time.Millisecond * time.Duration((rand.Intn(20) + 25)))
 			<-time.After(sleepFor)
 		case "use":
 			f.writeInt(resultKindKeyspace)

--- a/conn_test.go
+++ b/conn_test.go
@@ -280,7 +280,7 @@ func TestTimeout(t *testing.T) {
 }
 
 type testRetryPolicy struct {
-	NumRetries     int //Number of times to retry a query
+	numRetries     int // maximum number of times to retry a query
 	attemptTimeout time.Duration
 	t              *testing.T
 }
@@ -288,7 +288,7 @@ type testRetryPolicy struct {
 // Attempt tells gocql to attempt the query again based on query.Attempts being less
 // than the NumRetries defined in the policy.
 func (s *testRetryPolicy) Attempt(q RetryableQuery) bool {
-	return q.Attempts() <= s.NumRetries
+	return q.Attempts() <= s.numRetries
 }
 
 func (s *testRetryPolicy) GetRetryType(err error) RetryType {
@@ -337,7 +337,7 @@ func TestQueryRetry(t *testing.T) {
 		}
 	}()
 
-	rt := &testRetryPolicy{NumRetries: 10, t: t, attemptTimeout: time.Millisecond * 35}
+	rt := &testRetryPolicy{numRetries: 10, t: t, attemptTimeout: time.Millisecond * 35}
 	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 	defer cancel()
 	qry := db.Query("killaftertimeout").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx)

--- a/conn_test.go
+++ b/conn_test.go
@@ -353,7 +353,11 @@ func TestQueryRetry(t *testing.T) {
 
 	// the 200ms timeout allows at most 8 retries
 	if requests > 8 {
-		t.Fatalf("too many retries executed for query. Query executed %v times", requests)
+		t.Fatalf("Too many retries executed for query. Query executed %v times", requests)
+	}
+	// make sure query is retried to guard against regressions
+	if requests < 5 {
+		t.Fatalf("Not enough retries executed for query. Query executed %v times", requests)
 	}
 }
 

--- a/policies.go
+++ b/policies.go
@@ -131,7 +131,7 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
-	GetContext() context.Context
+	Context() context.Context
 }
 
 type RetryType uint16

--- a/policies.go
+++ b/policies.go
@@ -161,6 +161,7 @@ type RetryPolicy interface {
 // It's not part of the RetryPolicy interface to remain backwards compatible.
 type RetryPolicyWithAttemptTimeout interface {
 	AttemptTimeout() time.Duration
+	RetryPolicy
 }
 
 // SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.

--- a/policies.go
+++ b/policies.go
@@ -155,6 +155,14 @@ type RetryPolicy interface {
 	GetRetryType(error) RetryType
 }
 
+// RetryPolicyWithAttemptTimeout is an optional interface retry policies can implement
+// in order to control the duration to use before a query attempt is considered
+// as a timeout and will potentially be retried.
+// It's not part of the RetryPolicy interface to remain backwards compatible.
+type RetryPolicyWithAttemptTimeout interface {
+	AttemptTimeout() time.Duration
+}
+
 // SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.
 //
 // See below for examples of usage:

--- a/policies.go
+++ b/policies.go
@@ -5,6 +5,7 @@
 package gocql
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -130,6 +131,7 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
+	GetContext() context.Context
 }
 
 type RetryType uint16

--- a/query_executor.go
+++ b/query_executor.go
@@ -30,6 +30,8 @@ func (q *queryExecutor) attemptQuery(qry ExecutableQuery, conn *Conn) *Iter {
 	return iter
 }
 
+// ErrUnknownRetryType is returned if the retry policy returns a retry type
+// unknown to the query executor.
 var ErrUnknownRetryType = errors.New("unknown retry type returned by retry policy")
 
 type retryPolicyWrapper struct {
@@ -37,6 +39,8 @@ type retryPolicyWrapper struct {
 	ctx context.Context
 }
 
+// Attempt is used by the query executor to determine with retrying a query.
+// It consults the query context and the query's retry policy.
 func (w *retryPolicyWrapper) Attempt(rq RetryableQuery, err error) (RetryType, error) {
 	ctx := rq.GetContext()
 	if ctx != nil && ctx.Err() != nil { // context on query expired or was canceled, bail

--- a/query_executor.go
+++ b/query_executor.go
@@ -36,7 +36,7 @@ func (q *queryExecutor) attemptQuery(qry ExecutableQuery, conn *Conn) *Iter {
 // checkRetryPolicy is used by the query executor to determine how a failed query should be handled.
 // It consults the query context and the query's retry policy.
 func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryType, error) {
-	if ctx := rq.GetContext(); ctx != nil {
+	if ctx := rq.Context(); ctx != nil {
 		if ctx.Err() != nil {
 			return Rethrow, ctx.Err()
 		}

--- a/query_executor.go
+++ b/query_executor.go
@@ -53,9 +53,12 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 		// Update host
 		hostResponse.Mark(iter.err)
 
-		if rt == nil {
-			iter.host = host
-			break
+		// note host the query was issued against
+		iter.host = host
+
+		// exit for loop if the query was successful
+		if iter.err == nil {
+			return iter, nil
 		}
 
 		switch rt.GetRetryType(iter.err) {
@@ -77,12 +80,6 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 			return iter, nil
 		case RetryNextHost:
 		default:
-		}
-
-		// Exit for loop if the query was successful
-		if iter.err == nil {
-			iter.host = host
-			return iter, nil
 		}
 
 		if !rt.Attempt(qry) {

--- a/session.go
+++ b/session.go
@@ -803,8 +803,8 @@ func (q *Query) WithContext(ctx context.Context) *Query {
 	return q
 }
 
-// GetContext satisfies the ExecutableQuery interface.
-func (q *Query) GetContext() context.Context {
+// Context satisfies the ExecutableQuery interface.
+func (q *Query) Context() context.Context {
 	return q.context
 }
 
@@ -1490,8 +1490,8 @@ func (b *Batch) WithContext(ctx context.Context) *Batch {
 	return b
 }
 
-// GetContext satisfies the ExecutableQuery interface.
-func (b *Batch) GetContext() context.Context {
+// Context satisfies the ExecutableQuery interface.
+func (b *Batch) Context() context.Context {
 	return b.context
 }
 

--- a/session.go
+++ b/session.go
@@ -681,6 +681,7 @@ type Query struct {
 	disableSkipMetadata   bool
 	context               context.Context
 	idempotent            bool
+	attemptTimeout        time.Duration
 
 	disableAutoPage bool
 }
@@ -931,6 +932,11 @@ func (q *Query) shouldPrepare() bool {
 // automatically.
 func (q *Query) Prefetch(p float64) *Query {
 	q.prefetch = p
+	return q
+}
+
+func (q *Query) AttemptTimeout(timeout time.Duration) *Query {
+	q.attemptTimeout = timeout
 	return q
 }
 

--- a/session.go
+++ b/session.go
@@ -804,6 +804,11 @@ func (q *Query) WithContext(ctx context.Context) *Query {
 	return q
 }
 
+// GetContext satisfies the ExecutableQuery interface.
+func (q *Query) GetContext() context.Context {
+	return q.context
+}
+
 func (q *Query) execute(conn *Conn) *Iter {
 	return conn.executeQuery(q)
 }
@@ -1489,6 +1494,11 @@ func (b *Batch) RetryPolicy(r RetryPolicy) *Batch {
 func (b *Batch) WithContext(ctx context.Context) *Batch {
 	b.context = ctx
 	return b
+}
+
+// GetContext satisfies the ExecutableQuery interface.
+func (b *Batch) GetContext() context.Context {
+	return b.context
 }
 
 // Size returns the number of batch statements to be executed by the batch operation.

--- a/session.go
+++ b/session.go
@@ -681,6 +681,7 @@ type Query struct {
 	disableSkipMetadata   bool
 	context               context.Context
 	idempotent            bool
+	attemptTimeoutTimer   *time.Timer
 
 	disableAutoPage bool
 }

--- a/session.go
+++ b/session.go
@@ -940,6 +940,8 @@ func (q *Query) Prefetch(p float64) *Query {
 	return q
 }
 
+// AttemptTimeout sets the duration to use before a query attempt is considered
+// as a timeout and will potentially be retried (according to the retry policy).
 func (q *Query) AttemptTimeout(timeout time.Duration) *Query {
 	q.attemptTimeout = timeout
 	return q

--- a/session.go
+++ b/session.go
@@ -681,7 +681,6 @@ type Query struct {
 	disableSkipMetadata   bool
 	context               context.Context
 	idempotent            bool
-	attemptTimeout        time.Duration
 
 	disableAutoPage bool
 }
@@ -937,13 +936,6 @@ func (q *Query) shouldPrepare() bool {
 // automatically.
 func (q *Query) Prefetch(p float64) *Query {
 	q.prefetch = p
-	return q
-}
-
-// AttemptTimeout sets the duration to use before a query attempt is considered
-// as a timeout and will potentially be retried (according to the retry policy).
-func (q *Query) AttemptTimeout(timeout time.Duration) *Query {
-	q.attemptTimeout = timeout
 	return q
 }
 


### PR DESCRIPTION
This adds the ability to constrain the runtime of individual query attempts. Right now we have the situation that there are no retries if the coordinator times out responding as there's only the possibility to time out a query via the context. This is also somewhat related to https://github.com/gocql/gocql/issues/812#issuecomment-257107273.

In working with this we found and fixed a couple of related problems:
1. Contexts expiring or canceled while the query executor was in the retry loop were not respected and always resulted in the `conn.exec` to still write the query to the connection because the context was checked too late.
2. The query executor's attempt loop was simplified to bail earlier.

The test we implemented to check whether retries are done and respect the per-attempt timeout is rather crude. Pointers on how to go about testing this are appreciated.