### PR TITLE
Query metric per host 1155

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
       AUTH=false
     - CASS=3.0.8
       AUTH=false
+    - CASS=3.11.3
+      AUTH=false
 
 go:
   - "1.9"

--- a/AUTHORS
+++ b/AUTHORS
@@ -106,3 +106,4 @@ Chang Liu <changliu.it@gmail.com>
 Ingo Oeser <nightlyone@gmail.com>
 Luke Hines <lukehines@protonmail.com>
 Jacob Greenleaf <jacob@jacobgreenleaf.com>
+Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -539,7 +539,7 @@ func TestBatch(t *testing.T) {
 		t.Fatal("create table:", err)
 	}
 
-	batch := NewBatch(LoggedBatch)
+	batch := session.NewBatch(LoggedBatch)
 	for i := 0; i < 100; i++ {
 		batch.Query(`INSERT INTO batch_table (id) VALUES (?)`, i)
 	}
@@ -571,9 +571,9 @@ func TestUnpreparedBatch(t *testing.T) {
 
 	var batch *Batch
 	if session.cfg.ProtoVersion == 2 {
-		batch = NewBatch(CounterBatch)
+		batch = session.NewBatch(CounterBatch)
 	} else {
-		batch = NewBatch(UnloggedBatch)
+		batch = session.NewBatch(UnloggedBatch)
 	}
 
 	for i := 0; i < 100; i++ {
@@ -612,7 +612,7 @@ func TestBatchLimit(t *testing.T) {
 		t.Fatal("create table:", err)
 	}
 
-	batch := NewBatch(LoggedBatch)
+	batch := session.NewBatch(LoggedBatch)
 	for i := 0; i < 65537; i++ {
 		batch.Query(`INSERT INTO batch_table2 (id) VALUES (?)`, i)
 	}
@@ -1817,7 +1817,7 @@ func TestBatchObserve(t *testing.T) {
 
 	var observedBatch *observation
 
-	batch := NewBatch(LoggedBatch)
+	batch := session.NewBatch(LoggedBatch)
 	batch.Observer(funcBatchObserver(func(ctx context.Context, o ObservedBatch) {
 		if observedBatch != nil {
 			t.Fatal("batch observe called more than once")

--- a/control.go
+++ b/control.go
@@ -453,7 +453,8 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 			Logger.Printf("control: error executing %q: %v\n", statement, iter.err)
 		}
 
-		q.attempts++
+		metric := q.getHostMetrics(c.getConn().host)
+		metric.Attempts++
 		if iter.err == nil || !c.retry.Attempt(q) {
 			break
 		}

--- a/policies_test.go
+++ b/policies_test.go
@@ -263,8 +263,9 @@ func TestSimpleRetryPolicy(t *testing.T) {
 		{5, false},
 	}
 
+	q.metrics = make(map[string]*queryMetrics)
 	for _, c := range cases {
-		q.attempts = c.attempts
+		q.metrics["127.0.0.1"] = &queryMetrics{Attempts: c.attempts}
 		if c.allow && !rt.Attempt(q) {
 			t.Fatalf("should allow retry after %d attempts", c.attempts)
 		}
@@ -347,8 +348,9 @@ func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
 		{16, false, reu1, Retry},
 	}
 
+	q.metrics = make(map[string]*queryMetrics)
 	for _, c := range cases {
-		q.attempts = c.attempts
+		q.metrics["127.0.0.1"] = &queryMetrics{Attempts: c.attempts}
 		if c.retryType != rt.GetRetryType(c.err) {
 			t.Fatalf("retry type should be %v", c.retryType)
 		}

--- a/session.go
+++ b/session.go
@@ -846,8 +846,8 @@ func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 			End:       end,
 			Rows:      iter.numRows,
 			Host:      host,
+			Metrics:   hostMetrics,
 			Err:       iter.err,
-			Attempt:   q.attempts,
 		})
 	}
 }
@@ -1593,8 +1593,8 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
 		Host:    host,
+		Metrics: hostMetrics,
 		Err:     iter.err,
-		Attempt: b.attempts,
 	})
 }
 
@@ -1746,13 +1746,12 @@ type ObservedQuery struct {
 	// Host is the informations about the host that performed the query
 	Host *HostInfo
 
+	// The metrics per this host
+	Metrics *queryMetrics
 
 	// Err is the error in the query.
 	// It only tracks network errors or errors of bad cassandra syntax, in particular selects with no match return nil error
 	Err error
-
-	// Attempt contains the number of times the query has been attempted so far.
-	Attempt int
 }
 
 // QueryObserver is the interface implemented by query observers / stat collectors.
@@ -1779,8 +1778,8 @@ type ObservedBatch struct {
 	// It only tracks network errors or errors of bad cassandra syntax, in particular selects with no match return nil error
 	Err error
 
-	// Attempt contains the number of times the query has been attempted so far.
-	Attempt int
+	// The metrics per this host
+	Metrics *queryMetrics
 }
 
 // BatchObserver is the interface implemented by batch observers / stat collectors.

--- a/session.go
+++ b/session.go
@@ -738,8 +738,8 @@ func (q *Query) Attempts() int {
 
 //Latency returns the average amount of nanoseconds per attempt of the query.
 func (q *Query) Latency() int64 {
-	attempts := 0
-	var latency int64 = 0
+	var attempts int
+	var latency int64
 	for _, metric := range q.metrics {
 		attempts += metric.Attempts
 		latency += metric.TotalLatency

--- a/session.go
+++ b/session.go
@@ -658,6 +658,11 @@ func (s *Session) connect(host *HostInfo, errorHandler ConnErrorHandler) (*Conn,
 	return s.dial(host, s.connCfg, errorHandler)
 }
 
+type queryMetrics struct {
+	Attempts     int
+	TotalLatency int64
+}
+
 // Query represents a CQL statement that can be executed.
 type Query struct {
 	stmt                  string
@@ -673,14 +678,13 @@ type Query struct {
 	session               *Session
 	rt                    RetryPolicy
 	binding               func(q *QueryInfo) ([]interface{}, error)
-	attempts              int
-	totalLatency          int64
 	serialCons            SerialConsistency
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	disableSkipMetadata   bool
 	context               context.Context
 	idempotent            bool
+	metrics               map[string]*queryMetrics
 
 	disableAutoPage bool
 }
@@ -698,7 +702,19 @@ func (q *Query) defaultsFromSession() {
 	q.serialCons = s.cfg.SerialConsistency
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
+	q.metrics = make(map[string]*queryMetrics)
 	s.mu.RUnlock()
+}
+
+func (q *Query) getHostMetrics(host *HostInfo) *queryMetrics {
+	hostMetrics, exists := q.metrics[host.ConnectAddress().String()]
+	if !exists {
+		// if the host is not in the map, it means it's been accessed for the first time
+		hostMetrics = &queryMetrics{Attempts: 0, TotalLatency: 0}
+		q.metrics[host.ConnectAddress().String()] = hostMetrics
+	}
+
+	return hostMetrics
 }
 
 // Statement returns the statement that was used to generate this query.
@@ -713,13 +729,23 @@ func (q Query) String() string {
 
 //Attempts returns the number of times the query was executed.
 func (q *Query) Attempts() int {
-	return q.attempts
+	attempts := 0
+	for _, metric := range q.metrics {
+		attempts += metric.Attempts
+	}
+	return attempts
 }
 
 //Latency returns the average amount of nanoseconds per attempt of the query.
 func (q *Query) Latency() int64 {
-	if q.attempts > 0 {
-		return q.totalLatency / int64(q.attempts)
+	attempts := 0
+	var latency int64 = 0
+	for _, metric := range q.metrics {
+		attempts += metric.Attempts
+		latency += metric.TotalLatency
+	}
+	if attempts > 0 {
+		return latency / int64(attempts)
 	}
 	return 0
 }
@@ -808,9 +834,9 @@ func (q *Query) execute(conn *Conn) *Iter {
 }
 
 func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
-	q.attempts++
-	q.totalLatency += end.Sub(start).Nanoseconds()
-	// TODO: track latencies per host and things as well instead of just total
+	hostMetrics := q.getHostMetrics(host)
+	hostMetrics.Attempts++
+	hostMetrics.TotalLatency += end.Sub(start).Nanoseconds()
 
 	if q.observer != nil {
 		q.observer.ObserveQuery(q.context, ObservedQuery{
@@ -1388,13 +1414,12 @@ type Batch struct {
 	Cons                  Consistency
 	rt                    RetryPolicy
 	observer              BatchObserver
-	attempts              int
-	totalLatency          int64
 	serialCons            SerialConsistency
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	context               context.Context
 	keyspace              string
+	metrics               map[string]*queryMetrics
 }
 
 // NewBatch creates a new batch operation without defaults from the cluster
@@ -1415,9 +1440,21 @@ func (s *Session) NewBatch(typ BatchType) *Batch {
 		Cons:             s.cons,
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
+		metrics:          make(map[string]*queryMetrics),
 	}
 	s.mu.RUnlock()
 	return batch
+}
+
+func (b *Batch) getHostMetrics(host *HostInfo) *queryMetrics {
+	hostMetrics, exists := b.metrics[host.ConnectAddress().String()]
+	if !exists {
+		// if the host is not in the map, it means it's been accessed for the first time
+		hostMetrics = &queryMetrics{Attempts: 0, TotalLatency: 0}
+		b.metrics[host.ConnectAddress().String()] = hostMetrics
+	}
+
+	return hostMetrics
 }
 
 // Observer enables batch-level observer on this batch.
@@ -1433,13 +1470,23 @@ func (b *Batch) Keyspace() string {
 
 // Attempts returns the number of attempts made to execute the batch.
 func (b *Batch) Attempts() int {
-	return b.attempts
+	attempts := 0
+	for _, metric := range b.metrics {
+		attempts += metric.Attempts
+	}
+	return attempts
 }
 
 //Latency returns the average number of nanoseconds to execute a single attempt of the batch.
 func (b *Batch) Latency() int64 {
-	if b.attempts > 0 {
-		return b.totalLatency / int64(b.attempts)
+	attempts := 0
+	var latency int64 = 0
+	for _, metric := range b.metrics {
+		attempts += metric.Attempts
+		latency += metric.TotalLatency
+	}
+	if attempts > 0 {
+		return latency / int64(attempts)
 	}
 	return 0
 }
@@ -1526,9 +1573,9 @@ func (b *Batch) WithTimestamp(timestamp int64) *Batch {
 }
 
 func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
-	b.attempts++
-	b.totalLatency += end.Sub(start).Nanoseconds()
-	// TODO: track latencies per host and things as well instead of just total
+	hostMetrics := b.getHostMetrics(host)
+	hostMetrics.Attempts++
+	hostMetrics.TotalLatency += end.Sub(start).Nanoseconds()
 
 	if b.observer == nil {
 		return
@@ -1698,6 +1745,7 @@ type ObservedQuery struct {
 
 	// Host is the informations about the host that performed the query
 	Host *HostInfo
+
 
 	// Err is the error in the query.
 	// It only tracks network errors or errors of bad cassandra syntax, in particular selects with no match return nil error

--- a/session_test.go
+++ b/session_test.go
@@ -99,12 +99,18 @@ func (f funcQueryObserver) ObserveQuery(ctx context.Context, o ObservedQuery) {
 func TestQueryBasicAPI(t *testing.T) {
 	qry := &Query{}
 
+	// Initialise metrics map
+	qry.metrics = make(map[string]*queryMetrics)
+
+	// Initiate host
+	ip := "127.0.0.1"
+
+	qry.metrics[ip] = &queryMetrics{Attempts: 0, TotalLatency: 0}
 	if qry.Latency() != 0 {
 		t.Fatalf("expected Query.Latency() to return 0, got %v", qry.Latency())
 	}
 
-	qry.attempts = 2
-	qry.totalLatency = 4
+	qry.metrics[ip] = &queryMetrics{Attempts: 2, TotalLatency: 4}
 	if qry.Attempts() != 2 {
 		t.Fatalf("expected Query.Attempts() to return 2, got %v", qry.Attempts())
 	}
@@ -191,15 +197,17 @@ func TestBatchBasicAPI(t *testing.T) {
 	}
 
 	// Test LoggedBatch
-	b = NewBatch(LoggedBatch)
+	b = s.NewBatch(LoggedBatch)
 	if b.Type != LoggedBatch {
 		t.Fatalf("expected batch.Type to be '%v', got '%v'", LoggedBatch, b.Type)
 	}
 
+	ip := "127.0.0.1"
+
 	// Test attempts
-	b.attempts = 1
+	b.metrics[ip] = &queryMetrics{Attempts: 1}
 	if b.Attempts() != 1 {
-		t.Fatalf("expceted batch.Attempts() to return %v, got %v", 1, b.Attempts())
+		t.Fatalf("expected batch.Attempts() to return %v, got %v", 1, b.Attempts())
 	}
 
 	// Test latency
@@ -207,7 +215,7 @@ func TestBatchBasicAPI(t *testing.T) {
 		t.Fatalf("expected batch.Latency() to be 0, got %v", b.Latency())
 	}
 
-	b.totalLatency = 4
+	b.metrics[ip] = &queryMetrics{Attempts: 1, TotalLatency: 4}
 	if b.Latency() != 4 {
 		t.Fatalf("expected batch.Latency() to return %v, got %v", 4, b.Latency())
 	}


### PR DESCRIPTION
Attempt to solve #1155 

This ended up being a bit bigger than initially expected.

Nevertheless, the majority of work was to update the tests to fetch the correct host they're doing the work for and sending it over as a parameter to other functions. Additionally, it should be somewhat easier to add new metrics to the query execution.

The tests seem to pass successfully now.

@Zariel would love your feedback on this.