### PR TITLE
Shorten runtime for long tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -152,6 +152,10 @@ func TestDNSLookupConnected(t *testing.T) {
 		Logger = &defaultLogger{}
 	}()
 
+	// Override the defaul DNS resolver and restore at the end
+	failDNS = true
+	defer func() { failDNS = false }()
+
 	srv := NewTestServer(t, defaultProto, context.Background())
 	defer srv.Stop()
 
@@ -178,8 +182,9 @@ func TestDNSLookupError(t *testing.T) {
 		Logger = &defaultLogger{}
 	}()
 
-	srv := NewTestServer(t, defaultProto, context.Background())
-	defer srv.Stop()
+	// Override the defaul DNS resolver and restore at the end
+	failDNS = true
+	defer func() { failDNS = false }()
 
 	cluster := NewCluster("cassandra1.invalid", "cassandra2.invalid")
 	cluster.ProtoVersion = int(defaultProto)

--- a/control.go
+++ b/control.go
@@ -121,7 +121,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 	}
 
 	// Look up host in DNS
-	ips, err := net.LookupIP(host)
+	ips, err := LookupIP(host)
 	if err != nil {
 		return nil, err
 	} else if len(ips) == 0 {

--- a/helpers.go
+++ b/helpers.go
@@ -7,6 +7,7 @@ package gocql
 import (
 	"fmt"
 	"math/big"
+	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -362,4 +363,14 @@ func copyBytes(p []byte) []byte {
 	b := make([]byte, len(p))
 	copy(b, p)
 	return b
+}
+
+var failDNS = false
+
+func LookupIP(host string) ([]net.IP, error) {
+	if failDNS {
+		return nil, &net.DNSError{}
+	}
+	return net.LookupIP(host)
+
 }


### PR DESCRIPTION
`skipLong` option allows skipping DNS and StartupTimeout tests, making unittests run in under 5s. 

Considering that we run unittests a lot to make sure stuff is not overly broken, this saves a lot of time during dev.

Signed-off-by: Alex Lourie <alex@instaclustr.com>