### PR TITLE
WIP: Stop retrying errors that are fatal

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -876,7 +876,7 @@ func (c *Conn) executeQuery(qry *Query) *Iter {
 		}
 
 		if len(values) != info.request.actualColCount {
-			return &Iter{err: fmt.Errorf("gocql: expected %d values send got %d", info.request.actualColCount, len(values))}
+			return &Iter{err: NewErrProtocol("gocql: expected %d values send got %d", info.request.actualColCount, len(values))}
 		}
 
 		params.values = make([]queryValues, len(values))

--- a/errors.go
+++ b/errors.go
@@ -117,3 +117,8 @@ type RequestErrFunctionFailure struct {
 	Function string
 	ArgTypes []string
 }
+
+// RequestErrSyntax denotes a syntax error returned by Cassandra.
+type RequestErrSyntax struct {
+	errorFrame
+}

--- a/errors.go
+++ b/errors.go
@@ -29,6 +29,9 @@ type RequestError interface {
 	error
 }
 
+// make sure errorFrame satisfies error interface
+var _ error = (*errorFrame)(nil)
+
 type errorFrame struct {
 	frameHeader
 

--- a/errors.go
+++ b/errors.go
@@ -26,7 +26,7 @@ const (
 type RequestError interface {
 	Code() int
 	Message() string
-	Error() string
+	error
 }
 
 type errorFrame struct {

--- a/frame.go
+++ b/frame.go
@@ -664,8 +664,13 @@ func (f *framer) parseErrorFrame() frame {
 		res.Function = f.readString()
 		res.ArgTypes = f.readStringList()
 		return res
+	case errSyntax:
+		res := &RequestErrSyntax{
+			errorFrame: errD,
+		}
+		return res
 	case errInvalid, errBootstrapping, errConfig, errCredentials, errOverloaded,
-		errProtocol, errServer, errSyntax, errTruncate, errUnauthorized:
+		errProtocol, errServer, errTruncate, errUnauthorized:
 		// TODO(zariel): we should have some distinct types for these errors
 		return errD
 	default:

--- a/frame.go
+++ b/frame.go
@@ -657,7 +657,7 @@ func (f *framer) parseErrorFrame() frame {
 		res.WriteType = f.readString()
 		return res
 	case errFunctionFailure:
-		res := RequestErrFunctionFailure{
+		res := &RequestErrFunctionFailure{
 			errorFrame: errD,
 		}
 		res.Keyspace = f.readString()

--- a/query_executor.go
+++ b/query_executor.go
@@ -36,10 +36,8 @@ func (q *queryExecutor) attemptQuery(qry ExecutableQuery, conn *Conn) *Iter {
 // checkRetryPolicy is used by the query executor to determine how a failed query should be handled.
 // It consults the query context and the query's retry policy.
 func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryType, error) {
-	if ctx := rq.Context(); ctx != nil {
-		if ctx.Err() != nil {
-			return Rethrow, ctx.Err()
-		}
+	if ctx := rq.Context(); ctx != nil && ctx.Err() != nil {
+		return Rethrow, ctx.Err()
 	}
 	p := rq.retryPolicy()
 	if p == nil {

--- a/query_executor.go
+++ b/query_executor.go
@@ -46,7 +46,8 @@ func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryTy
 	if p.Attempt(rq) {
 		return p.GetRetryType(err), nil
 	}
-	return p.GetRetryType(err), err
+	// retry policy decided to not attempt a retry above, return error to the caller
+	return Rethrow, err
 }
 
 func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {

--- a/session.go
+++ b/session.go
@@ -1784,7 +1784,6 @@ func (e Error) Error() string {
 
 var (
 	ErrNotFound             = errors.New("not found")
-	ErrUnavailable          = errors.New("unavailable")
 	ErrUnsupported          = errors.New("feature not supported")
 	ErrTooManyStmts         = errors.New("too many statements")
 	ErrUseStmt              = errors.New("use statements aren't supported. Please see https://github.com/gocql/gocql for explanation.")

--- a/session.go
+++ b/session.go
@@ -1797,7 +1797,7 @@ var (
 type ErrProtocol struct{ error }
 
 func NewErrProtocol(format string, args ...interface{}) error {
-	return ErrProtocol{fmt.Errorf(format, args...)}
+	return &ErrProtocol{fmt.Errorf(format, args...)}
 }
 
 // BatchSizeMaximum is the maximum number of statements a batch operation can have.

--- a/udt_test.go
+++ b/udt_test.go
@@ -155,7 +155,7 @@ func TestUDT_Proto2error(t *testing.T) {
 	// TODO(zariel): move this to marshal test?
 	_, err := Marshal(NativeType{custom: "org.apache.cassandra.db.marshal.UserType.Type", proto: 2}, 1)
 	if err != ErrorUDTUnavailable {
-		t.Fatalf("expected %v got %v", ErrUnavailable, err)
+		t.Fatalf("expected %v got %v", ErrorUDTUnavailable, err)
 	}
 }
 


### PR DESCRIPTION
This will fix #1161. The code that's there now fixes that specific issue but there's more to come.

So, this was fun. The good news is that we're retrying too many query failures after merging #1151 but masking the real error in case it's fatal and should not be retried wasn't very good.

This isn't finished yet but the basics are there. I scoured the codebase for more errors that could be returned by the various parts that run when executing a query and already got a bunch of those that shouldn't be retried.

The next step is grouping all the errors defined in errors.go where most are also already wrapped in custom error structs that can be type switched against (also by retry policies but more on that later). I looked at DataStax's Java driver implementation – specifically at https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/policies/RetryPolicy.java – that was very enlightening. I also want to group those errors into the four categories read timeout/write timeout/unavailable/request failure which in the Java implementation also each subsume a bunch of errors returned by Cassandra. That'll make it easier to decide what's retryable and what's not. What might be interesting to pursue is making those groupings available to the retry policy – I'll come up with something.

I know now that even for a given error it's possible to decide in a multitude of ways with how to handle the retry or return it to the caller and I don't want to lose that. I'll also be looking at the more sophisticated retry policies available in the codebase and decide whether it makes sense to move some of that logic up to here. A good retry policy is a pretty hard thing to write.