### PR TITLE
Fix bug in query executor that prevented retries from ceasing

### DIFF
--- a/query_executor.go
+++ b/query_executor.go
@@ -48,7 +48,7 @@ func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryTy
 	if p.Attempt(rq) {
 		return p.GetRetryType(err), nil
 	}
-	return p.GetRetryType(err), err
+	return Rethrow, err
 }
 
 func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {


### PR DESCRIPTION
If a retry policy is defined for the session/query, retries wouldn't stop even if the retry policy returned false in the call to `Attempt()`. The bug was introduced in #1151. As long as queries keep failing and no other condition applies the query would be retried. One such condition being the exhaustion of the host pool but even that might not happen in the case where the retry policy always returns `Retry` and retries are executed on the same connection. This might lead to any number of unexpected behaviors, even going as far as looping endlessly if the session/query doesn't have a timeout defined and no context is used that would eventually be canceled or time out.
The unit test that checks the retries being executed now checks for an exact number of query retries, making it a regression test as well. I shouldn't have gone for testing these things in a fuzzy manner which would likely have prevented it from sneaking in.

I'm sorry for introducing this. As it's quite urgent, may I ask @Zariel to give it a look and merge soon-ish?