### PR TITLE
Revert #1164 and #1151

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,5 +106,3 @@ Chang Liu <changliu.it@gmail.com>
 Ingo Oeser <nightlyone@gmail.com>
 Luke Hines <lukehines@protonmail.com>
 Jacob Greenleaf <jacob@jacobgreenleaf.com>
-Andreas Jaekle <andreas@jaekle.net>
-Daniel Lohse <daniel.lohse@alfatraining.de>

--- a/conn_test.go
+++ b/conn_test.go
@@ -341,7 +341,7 @@ func TestQueryRetry(t *testing.T) {
 		}
 	}()
 
-	rt := &testRetryPolicy{numRetries: 2, t: t, attemptTimeout: time.Millisecond * 25}
+	rt := &testRetryPolicy{numRetries: 10, t: t, attemptTimeout: time.Millisecond * 25}
 	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*90)
 	defer cancel()
 	qry := db.Query("slow").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx)
@@ -355,10 +355,13 @@ func TestQueryRetry(t *testing.T) {
 
 	numQueries := atomic.LoadUint64(&srv.nQueries)
 
-	// the 90ms timeout allows at most 4 retries but the maximum is 2 as per the retry policy
-	// the number of queries therefore needs to be 3 (initial query + 2 retries)
-	if numQueries != 3 {
-		t.Fatalf("Number of queries should be 3 but query executed %v times", numQueries)
+	// the 90ms timeout allows at most 4 retries
+	if numQueries > 4 {
+		t.Fatalf("Too many retries executed for query. Query executed %v times", numQueries)
+	}
+	// make sure query is retried to guard against regressions
+	if numQueries < 2 {
+		t.Fatalf("Not enough retries executed for query. Query executed %v times", numQueries)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -283,45 +282,11 @@ func TestTimeout(t *testing.T) {
 	wg.Wait()
 }
 
-type testRetryPolicy struct {
-	numRetries     int // maximum number of times to retry a query
-	attemptTimeout time.Duration
-	t              *testing.T
-}
-
-// Attempt tells gocql to attempt the query again based on query.Attempts being less
-// than the NumRetries defined in the policy.
-func (s *testRetryPolicy) Attempt(q RetryableQuery) bool {
-	return q.Attempts() <= s.numRetries
-}
-
-func (s *testRetryPolicy) GetRetryType(err error) RetryType {
-	return Retry
-}
-
-// AttemptTimeout satisfies the optional RetryPolicyWithAttemptTimeout interface.
-func (s *testRetryPolicy) AttemptTimeout() time.Duration {
-	return s.attemptTimeout
-}
-
-type testQueryObserver struct{}
-
-func (o *testQueryObserver) ObserveQuery(ctx context.Context, q ObservedQuery) {
-	Logger.Printf("Observed query %q. Returned %v rows, took %v on host %q. Error: %q\n", q.Statement, q.Rows, q.End.Sub(q.Start), q.Host.ConnectAddress().String(), q.Err)
-}
-
 // TestQueryRetry will test to make sure that gocql will execute
 // the exact amount of retry queries designated by the user.
 func TestQueryRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	log := &testLogger{}
-	Logger = log
-	defer func() {
-		Logger = &defaultLogger{}
-		os.Stdout.WriteString(log.String())
-	}()
 
 	srv := NewTestServer(t, defaultProto, ctx)
 	defer srv.Stop()
@@ -341,27 +306,22 @@ func TestQueryRetry(t *testing.T) {
 		}
 	}()
 
-	rt := &testRetryPolicy{numRetries: 10, t: t, attemptTimeout: time.Millisecond * 25}
-	queryCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*90)
-	defer cancel()
-	qry := db.Query("slow").RetryPolicy(rt).Observer(&testQueryObserver{}).WithContext(queryCtx)
+	rt := &SimpleRetryPolicy{NumRetries: 1}
+
+	qry := db.Query("kill").RetryPolicy(rt)
 	if err := qry.Exec(); err == nil {
 		t.Fatalf("expected error")
 	}
 
-	// wait for the last slow query to finish
-	// this prevents the test from flaking because of writing to a connection that's been closed
-	time.Sleep(100 * time.Millisecond)
-
-	numQueries := atomic.LoadUint64(&srv.nQueries)
-
-	// the 90ms timeout allows at most 4 retries
-	if numQueries > 4 {
-		t.Fatalf("Too many retries executed for query. Query executed %v times", numQueries)
+	requests := atomic.LoadInt64(&srv.nKillReq)
+	attempts := qry.Attempts()
+	if requests != int64(attempts) {
+		t.Fatalf("expected requests %v to match query attempts %v", requests, attempts)
 	}
-	// make sure query is retried to guard against regressions
-	if numQueries < 2 {
-		t.Fatalf("Not enough retries executed for query. Query executed %v times", numQueries)
+
+	// the query will only be attempted once, but is being retried
+	if requests != int64(rt.NumRetries) {
+		t.Fatalf("failed to retry the query %v time(s). Query executed %v times", rt.NumRetries, requests-1)
 	}
 }
 
@@ -815,7 +775,6 @@ type TestServer struct {
 	nreq             uint64
 	listen           net.Listener
 	nKillReq         int64
-	nQueries         uint64
 	compressor       Compressor
 
 	protocol   byte
@@ -931,7 +890,6 @@ func (srv *TestServer) process(f *framer) {
 		f.writeHeader(0, opSupported, head.stream)
 		f.writeShort(0)
 	case opQuery:
-		atomic.AddUint64(&srv.nQueries, 1)
 		query := f.readLongString()
 		first := query
 		if n := strings.Index(query, " "); n > 0 {

--- a/policies.go
+++ b/policies.go
@@ -5,7 +5,6 @@
 package gocql
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -131,7 +130,6 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
-	Context() context.Context
 }
 
 type RetryType uint16
@@ -153,15 +151,6 @@ const (
 type RetryPolicy interface {
 	Attempt(RetryableQuery) bool
 	GetRetryType(error) RetryType
-}
-
-// RetryPolicyWithAttemptTimeout is an optional interface retry policies can implement
-// in order to control the duration to use before a query attempt is considered
-// as a timeout and will potentially be retried.
-// It's not part of the RetryPolicy interface to remain backwards compatible.
-type RetryPolicyWithAttemptTimeout interface {
-	AttemptTimeout() time.Duration
-	RetryPolicy
 }
 
 // SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.

--- a/query_executor.go
+++ b/query_executor.go
@@ -48,7 +48,7 @@ func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryTy
 	if p.Attempt(rq) {
 		return p.GetRetryType(err), nil
 	}
-	return Rethrow, err
+	return p.GetRetryType(err), err
 }
 
 func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {

--- a/query_executor.go
+++ b/query_executor.go
@@ -1,13 +1,8 @@
 package gocql
 
 import (
-	"errors"
 	"time"
 )
-
-// ErrUnknownRetryType is returned if the retry policy returns a retry type
-// unknown to the query executor.
-var ErrUnknownRetryType = errors.New("unknown retry type returned by retry policy")
 
 type ExecutableQuery interface {
 	execute(conn *Conn) *Iter
@@ -33,75 +28,72 @@ func (q *queryExecutor) attemptQuery(qry ExecutableQuery, conn *Conn) *Iter {
 	return iter
 }
 
-// checkRetryPolicy is used by the query executor to determine how a failed query should be handled.
-// It consults the query context and the query's retry policy.
-func (q *queryExecutor) checkRetryPolicy(rq ExecutableQuery, err error) (RetryType, error) {
-	if ctx := rq.Context(); ctx != nil {
-		if ctx.Err() != nil {
-			return Rethrow, ctx.Err()
-		}
-	}
-	p := rq.retryPolicy()
-	if p == nil {
-		return Rethrow, err
-	}
-	if p.Attempt(rq) {
-		return p.GetRetryType(err), nil
-	}
-	return p.GetRetryType(err), err
-}
-
 func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
+	rt := qry.retryPolicy()
 	hostIter := q.policy.Pick(qry)
-	var iter *Iter
 
-outer:
+	var iter *Iter
 	for hostResponse := hostIter(); hostResponse != nil; hostResponse = hostIter() {
 		host := hostResponse.Info()
 		if host == nil || !host.IsUp() {
 			continue
 		}
-		hostPool, ok := q.pool.getPool(host)
+
+		pool, ok := q.pool.getPool(host)
 		if !ok {
 			continue
 		}
 
-		conn := hostPool.Pick()
+		conn := pool.Pick()
 		if conn == nil {
 			continue
 		}
-	inner:
-		for {
-			iter = q.attemptQuery(qry, conn)
-			// Update host
-			hostResponse.Mark(iter.err)
 
-			// note host the query was issued against
+		iter = q.attemptQuery(qry, conn)
+		// Update host
+		hostResponse.Mark(iter.err)
+
+		if rt == nil {
 			iter.host = host
+			break
+		}
 
-			// exit if the query was successful
-			if iter.err == nil {
-				return iter, nil
+		switch rt.GetRetryType(iter.err) {
+		case Retry:
+			for rt.Attempt(qry) {
+				iter = q.attemptQuery(qry, conn)
+				hostResponse.Mark(iter.err)
+				if iter.err == nil {
+					iter.host = host
+					return iter, nil
+				}
+				if rt.GetRetryType(iter.err) != Retry {
+					break
+				}
 			}
+		case Rethrow:
+			return nil, iter.err
+		case Ignore:
+			return iter, nil
+		case RetryNextHost:
+		default:
+		}
 
-			// consult retry policy on how to proceed
-			var retryType RetryType
-			retryType, iter.err = q.checkRetryPolicy(qry, iter.err)
-			switch retryType {
-			case Retry:
-				continue inner
-			case Rethrow:
-				return nil, iter.err
-			case Ignore:
-				return iter, nil
-			case RetryNextHost:
-				continue outer
-			default:
-				return nil, ErrUnknownRetryType
-			}
+		// Exit for loop if the query was successful
+		if iter.err == nil {
+			iter.host = host
+			return iter, nil
+		}
+
+		if !rt.Attempt(qry) {
+			// What do here? Should we just return an error here?
+			break
 		}
 	}
 
-	// if we reach this point, there is no host in the pool
-	return nil, ErrNoConnections
+	if iter == nil {
+		return nil, ErrNoConnections
+	}
+
+	return iter, nil
 }

--- a/session.go
+++ b/session.go
@@ -681,7 +681,6 @@ type Query struct {
 	disableSkipMetadata   bool
 	context               context.Context
 	idempotent            bool
-	attemptTimeoutTimer   *time.Timer
 
 	disableAutoPage bool
 }
@@ -802,11 +801,6 @@ func (q *Query) RoutingKey(routingKey []byte) *Query {
 func (q *Query) WithContext(ctx context.Context) *Query {
 	q.context = ctx
 	return q
-}
-
-// Context satisfies the ExecutableQuery interface.
-func (q *Query) Context() context.Context {
-	return q.context
 }
 
 func (q *Query) execute(conn *Conn) *Iter {
@@ -1489,11 +1483,6 @@ func (b *Batch) RetryPolicy(r RetryPolicy) *Batch {
 func (b *Batch) WithContext(ctx context.Context) *Batch {
 	b.context = ctx
 	return b
-}
-
-// Context satisfies the ExecutableQuery interface.
-func (b *Batch) Context() context.Context {
-	return b.context
 }
 
 // Size returns the number of batch statements to be executed by the batch operation.


### PR DESCRIPTION
This reverts #1151 (and #1164 by association because it builds on top of it) because we introduced a serious issue reported in #1161.

I'll open a new PR with better tests, do a more rigorous review and also use that version in our staging services first (/cc @ekle to keep him in the loop).