### PR TITLE
marshal: use passed in byte slice if available.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -232,12 +232,13 @@ func unmarshalVarchar(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	case *[]byte:
 		if data != nil {
-			*v = copyBytes(data)
+			*v = append((*v)[:0], data...)
 		} else {
 			*v = nil
 		}
 		return nil
 	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1401,3 +1401,16 @@ func TestMarshalDate(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkUnmarshalVarchar(b *testing.B) {
+	b.ReportAllocs()
+	src := make([]byte, 1024)
+	dst := make([]byte, len(src))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := unmarshalVarchar(NativeType{}, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
We don't aloways need to allocate a new slice to unmarshal into when the
passed in one is available.

```
name                old time/op    new time/op    delta
UnmarshalVarchar-4     280ns ± 3%      75ns ± 4%  -73.23%  (p=0.000 n=18+19)

name                old alloc/op   new alloc/op   delta
UnmarshalVarchar-4    1.06kB ± 0%    0.03kB ± 0%  -96.97%  (p=0.000 n=20+20)

name                old allocs/op  new allocs/op  delta
UnmarshalVarchar-4      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=20+20)
```