### PR TITLE
Allow to Cancel() query at any time

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -130,7 +130,6 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
-	Cancel()
 }
 
 type RetryType uint16

--- a/policies.go
+++ b/policies.go
@@ -130,6 +130,7 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
+	Cancel()
 }
 
 type RetryType uint16

--- a/query_executor.go
+++ b/query_executor.go
@@ -10,6 +10,7 @@ type ExecutableQuery interface {
 	retryPolicy() RetryPolicy
 	GetRoutingKey() ([]byte, error)
 	Keyspace() string
+	Cancel()
 	RetryableQuery
 }
 

--- a/session.go
+++ b/session.go
@@ -831,9 +831,7 @@ func (q *Query) RoutingKey(routingKey []byte) *Query {
 // timeout when waiting for responses from Cassandra. Additionally it adds
 // the cancel function so that it can be called whenever necessary.
 func (q *Query) WithContext(ctx context.Context) *Query {
-	context, cancel := context.WithCancel(ctx)
-	q.context = context
-	q.cancelQuery = cancel
+	q.context, q.cancelQuery = context.WithCancel(ctx)
 	return q
 }
 
@@ -1546,9 +1544,7 @@ func (b *Batch) RetryPolicy(r RetryPolicy) *Batch {
 // timeout when waiting for responses from Cassandra. Additionally it adds
 // the cancel function so that it can be called whenever necessary.
 func (b *Batch) WithContext(ctx context.Context) *Batch {
-	context, cancel := context.WithCancel(ctx)
-	b.context = context
-	b.cancelBatch = cancel
+	b.context, b.cancelBatch = context.WithCancel(ctx)
 	return b
 }
 

--- a/session.go
+++ b/session.go
@@ -683,6 +683,7 @@ type Query struct {
 	defaultTimestampValue int64
 	disableSkipMetadata   bool
 	context               context.Context
+	cancelQuery           func()
 	idempotent            bool
 	metrics               map[string]*queryMetrics
 
@@ -703,6 +704,10 @@ func (q *Query) defaultsFromSession() {
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
 	q.metrics = make(map[string]*queryMetrics)
+
+	// Initiate an empty context with a cancel call
+	q.WithContext(context.Background())
+
 	s.mu.RUnlock()
 }
 
@@ -823,10 +828,17 @@ func (q *Query) RoutingKey(routingKey []byte) *Query {
 }
 
 // WithContext will set the context to use during a query, it will be used to
-// timeout when waiting for responses from Cassandra.
+// timeout when waiting for responses from Cassandra. Additionally it adds
+// the cancel function so that it can be called whenever necessary.
 func (q *Query) WithContext(ctx context.Context) *Query {
-	q.context = ctx
+	context, cancel := context.WithCancel(ctx)
+	q.context = context
+	q.cancelQuery = cancel
 	return q
+}
+
+func (q *Query) Cancel() {
+	q.cancelQuery()
 }
 
 func (q *Query) execute(conn *Conn) *Iter {
@@ -1418,6 +1430,7 @@ type Batch struct {
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	context               context.Context
+	cancelBatch           func()
 	keyspace              string
 	metrics               map[string]*queryMetrics
 }
@@ -1442,6 +1455,10 @@ func (s *Session) NewBatch(typ BatchType) *Batch {
 		keyspace:         s.cfg.Keyspace,
 		metrics:          make(map[string]*queryMetrics),
 	}
+
+	// Initiate an empty context with a cancel call
+	batch.WithContext(context.Background())
+
 	s.mu.RUnlock()
 	return batch
 }
@@ -1526,10 +1543,17 @@ func (b *Batch) RetryPolicy(r RetryPolicy) *Batch {
 }
 
 // WithContext will set the context to use during a query, it will be used to
-// timeout when waiting for responses from Cassandra.
+// timeout when waiting for responses from Cassandra. Additionally it adds
+// the cancel function so that it can be called whenever necessary.
 func (b *Batch) WithContext(ctx context.Context) *Batch {
-	b.context = ctx
+	context, cancel := context.WithCancel(ctx)
+	b.context = context
+	b.cancelBatch = cancel
 	return b
+}
+
+func (b *Batch) Cancel() {
+	b.cancelBatch()
 }
 
 // Size returns the number of batch statements to be executed by the batch operation.


### PR DESCRIPTION
Solving #1173

* Add a Cancel() call to the ExecutableQuery interface
* Add cancelQuery and cancelBatch fields
* Initiate Query/Batch context/cancel functions
* Implement Cancel() call by calling the cancelQuery/cancelBatch
functions
* Add TestCancel to verify that the query is being cancelled by the
cancel call before it's finished.