### PR TITLE
conn: implement write coalescing

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -136,6 +136,13 @@ type ClusterConfig struct {
 	// Default idempotence for queries
 	DefaultIdempotence bool
 
+	// The time to wait for frames before flushing the frames connection to Cassandra.
+	// Can help reduce syscall overhead by making less calls to write. Set to 0 to
+	// disable.
+	//
+	// (default: 200 microseconds)
+	WriteCoalesceWaitTime time.Duration
+
 	// internal config for testing
 	disableControlConn bool
 }
@@ -166,6 +173,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ReconnectInterval:      60 * time.Second,
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
+		WriteCoalesceWaitTime:  200 * time.Microsecond,
 	}
 	return cfg
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -778,6 +778,10 @@ func TestWriteCoalescing(t *testing.T) {
 	}()
 	wg.Wait()
 
+	if buf.Len() != 0 {
+		t.Fatalf("expected buffer to be empty have: %v", buf.String())
+	}
+
 	w.flush()
 	if got := buf.String(); got != "onetwo" {
 		t.Fatalf("expected to get %q got %q", "onetwo", got)

--- a/conn_test.go
+++ b/conn_test.go
@@ -311,7 +311,7 @@ func TestCancel(t *testing.T) {
 	}()
 
 	// The query will timeout after about 1 seconds, so cancel it after a short pause
-	time.AfterFunc(20 * time.Millisecond, qry.Cancel)
+	time.AfterFunc(20*time.Millisecond, qry.Cancel)
 	wg.Wait()
 }
 
@@ -748,6 +748,39 @@ func TestContext_Timeout(t *testing.T) {
 	err = db.Query("timeout").WithContext(ctx).Exec()
 	if err != context.Canceled {
 		t.Fatalf("expected to get context cancel error: %v got %v", context.Canceled, err)
+	}
+}
+
+func TestWriteCoalescing(t *testing.T) {
+	var buf bytes.Buffer
+	w := &writeCoalescer{
+		w: &buf,
+	}
+	w.cond = sync.NewCond(&w.mu)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		if _, err := w.write([]byte("one")); err != nil {
+			t.Error(err)
+		}
+	}()
+	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		if _, err := w.write([]byte("two")); err != nil {
+			t.Error(err)
+		}
+	}()
+	wg.Wait()
+
+	w.flush()
+	if got := buf.String(); got != "onetwo" {
+		t.Fatalf("expected to get %q got %q", "onetwo", got)
 	}
 }
 


### PR DESCRIPTION
Add an option to switch on write coalescing outgoing requests using
net.Buffers. This can be switched off via cluster config and the
interval to buffer for can be adjusted.

fixes #458
fixes #383