### PR TITLE
adding failing tests for tuple and map in getCassandraType

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -77,6 +77,46 @@ func TestGetCassandraType(t *testing.T) {
 				},
 			},
 		},
+		{
+			"frozen<tuple<frozen<tuple<int, int>>, int, frozen<tuple<int, int>>>>", TupleTypeInfo{
+				NativeType: NativeType{typ: TypeTuple},
+
+				Elems: []TypeInfo{
+					TupleTypeInfo{
+						NativeType: NativeType{typ: TypeTuple},
+
+						Elems: []TypeInfo{
+							NativeType{typ: TypeInt},
+							NativeType{typ: TypeInt},
+						},
+					},
+					NativeType{typ: TypeInt},
+					TupleTypeInfo{
+						NativeType: NativeType{typ: TypeTuple},
+
+						Elems: []TypeInfo{
+							NativeType{typ: TypeInt},
+							NativeType{typ: TypeInt},
+						},
+					},
+				},
+			},
+		},
+		{
+			"frozen<map<frozen<tuple<int, int>>, int>>", CollectionType{
+				NativeType: NativeType{typ: TypeMap},
+
+				Key: TupleTypeInfo{
+					NativeType: NativeType{typ: TypeTuple},
+
+					Elems: []TypeInfo{
+						NativeType{typ: TypeInt},
+						NativeType{typ: TypeInt},
+					},
+				},
+				Elem: NativeType{typ: TypeInt},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
relating to https://github.com/gocql/gocql/issues/1184
and the fix here https://github.com/gocql/gocql/pull/1185