### PR TITLE
conn: avoid spinning in write coalesce with no work

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -754,8 +754,9 @@ func TestContext_Timeout(t *testing.T) {
 func TestWriteCoalescing(t *testing.T) {
 	var buf bytes.Buffer
 	w := &writeCoalescer{
-		w:    &buf,
-		cond: sync.NewCond(&sync.Mutex{}),
+		w:     &buf,
+		cond:  sync.NewCond(&sync.Mutex{}),
+		fcond: sync.NewCond(&sync.Mutex{}),
 	}
 
 	go func() {


### PR DESCRIPTION
Spinning in the write coalescer when there is no work causes high CPU
load for no reason. Use a second cond to start the flush loop once per
coalesce.