### PR TITLE
fix usage of deprecated gocql.NewBatch function.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -107,3 +107,4 @@ Ingo Oeser <nightlyone@gmail.com>
 Luke Hines <lukehines@protonmail.com>
 Jacob Greenleaf <jacob@jacobgreenleaf.com>
 Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
+Marco Cadetg <cadetg@gmail.com>

--- a/session.go
+++ b/session.go
@@ -1443,9 +1443,9 @@ type Batch struct {
 
 // NewBatch creates a new batch operation without defaults from the cluster
 //
-// Depreicated: use session.NewBatch instead
+// Deprecated: use session.NewBatch instead
 func NewBatch(typ BatchType) *Batch {
-	return &Batch{Type: typ}
+	return &Batch{Type: typ, metrics: make(map[string]*queryMetrics)}
 }
 
 // NewBatch creates a new batch operation using defaults defined in the cluster


### PR DESCRIPTION
Fix the gocql.NewBatch function which is broken due to recent changes and its deprecation. Without this change using the gocql.NewBatch function results in runtime panic like below:

```
2018/09/23 11:08:15 http: panic serving 127.0.0.1:49606: assignment to entry in nil map
goroutine 15 [running]:
net/http.(*conn).serve.func1(0xc000098fa0)
        /usr/local/go/src/net/http/server.go:1746 +0x17c
panic(0xb2c720, 0xc74960)
        /usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/gocql/gocql.(*Batch).getHostMetrics(0xc000284240, 0xc0001509a0, 0xc000208ee8)
        /home/marco/godev/gocql/session.go:1478 +0x1ef
github.com/gocql/gocql.(*Batch).attempt(0xc000284240, 0xc000126630, 0xc, 0xbee1f3dffb43c922, 0x221356d3, 0x106cac0, 0xbee1f3dffa8f68ee, 0x215ef6b2, 0x106cac0, 0xc0001e2240, ...)
        /home/marco/godev/gocql/session.go:1605 +0x61
github.com/gocql/gocql.(*queryExecutor).attemptQuery(0xc00013dd40, 0xc7d9e0, 0xc000284240, 0xc0001b2700, 0x4a2ec5)
        /home/marco/godev/gocql/query_executor.go:27 +0x1ce
github.com/gocql/gocql.(*queryExecutor).executeQuery(0xc00013dd40, 0xc7d9e0, 0xc000284240, 0xc000132800, 0x0, 0xc000073c00)
        /home/marco/godev/gocql/query_executor.go:53 +0x1dd
github.com/gocql/gocql.(*Session).executeBatch(0xc000073500, 0xc000284240, 0xb060e0)
        /home/marco/godev/gocql/session.go:590 +0x2b2
github.com/gocql/gocql.(*Session).ExecuteBatch(0xc000073500, 0xc000284240, 0xafd3e0, 0xc000121590)
        /home/marco/godev/gocql/session.go:601 +0x43
```