### PR TITLE
Prevent infinite loop

### DIFF
--- a/query_executor.go
+++ b/query_executor.go
@@ -107,16 +107,19 @@ func (q *queryExecutor) run(qry ExecutableQuery, specWG *sync.WaitGroup, results
 	for selectedHost != nil {
 		host := selectedHost.Info()
 		if host == nil || !host.IsUp() {
+			selectedHost = hostIter()
 			continue
 		}
 
 		pool, ok := q.pool.getPool(host)
 		if !ok {
+			selectedHost = hostIter()
 			continue
 		}
 
 		conn := pool.Pick()
 		if conn == nil {
+			selectedHost = hostIter()
 			continue
 		}
 


### PR DESCRIPTION
Fix for https://github.com/gocql/gocql/issues/1218

The loop was changed in commit aa46e85d0a7f8496b2fe83e9b551a63a550604d2 such that it no longer called `hostIter()` to advance, causing an infinite loop if any of the first 3 continue cases were hit.