### PR TITLE
session: NewBatch needs a valid speculation execution policy

### DIFF
--- a/session.go
+++ b/session.go
@@ -1487,7 +1487,11 @@ type Batch struct {
 //
 // Deprecated: use session.NewBatch instead
 func NewBatch(typ BatchType) *Batch {
-	return &Batch{Type: typ, metrics: &queryMetrics{m: make(map[string]*hostMetrics)}}
+	return &Batch{
+		Type:    typ,
+		metrics: &queryMetrics{m: make(map[string]*hostMetrics)},
+		spec:    &NonSpeculativeExecution{},
+	}
 }
 
 // NewBatch creates a new batch operation using defaults defined in the cluster


### PR DESCRIPTION
The old gocql.NewBatch function creates a bad Batch object
that can fail with a nil pointer dereference when executing
an empty batch.

Because the batch is empty, IsIdempotent returns true and then
queryExecutor.executeQuery fails when calling sp.Delay() because
no spec has been set on the Batch by NewBatch.

Here is a simple test case to trigger the panic:

    package main
    
    import (
            "log"
    
            "github.com/gocql/gocql"
    )
    
    func main() {
            cfg := gocql.NewCluster("localhost:9042")
            cfg.Consistency = gocql.All
    
            session, err := cfg.CreateSession()
            if err != nil {
                    log.Fatal(err)
            }
    
            batch := gocql.NewBatch(gocql.LoggedBatch)
            // batch := session.NewBatch(gocql.LoggedBatch)
    
            log.Printf("idempotent: %v", batch.IsIdempotent())
    
            if err := session.ExecuteBatch(batch); err != nil {
                    log.Fatal(err)
            }
    }

Result:

    2018/10/18 20:23:14 idempotent: true
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x624691]
    
    goroutine 81 [running]:
    github.com/gocql/gocql.(*queryExecutor).executeQuery.func1(0xc0002102a0, 0xc000222720, 0x0, 0x0, 0xc00000cea0, 0x6f8b80, 0xc000248000, 0xc00021e720)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:71 +0x71
    created by github.com/gocql/gocql.(*queryExecutor).executeQuery
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:61 +0x210
    exit status 2