### PR TITLE
Add Aiven authenticator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -108,3 +108,4 @@ Luke Hines <lukehines@protonmail.com>
 Jacob Greenleaf <jacob@jacobgreenleaf.com>
 Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
 Marco Cadetg <cadetg@gmail.com>
+Karl Matthias <karl@matthias.org>

--- a/conn.go
+++ b/conn.go
@@ -28,6 +28,7 @@ var (
 		"org.apache.cassandra.auth.PasswordAuthenticator",
 		"com.instaclustr.cassandra.auth.SharedSecretAuthenticator",
 		"com.datastax.bdp.cassandra.auth.DseAuthenticator",
+		"io.aiven.cassandra.auth.AivenAuthenticator",
 	}
 )
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -35,6 +35,7 @@ func TestApprove(t *testing.T) {
 		approve("org.apache.cassandra.auth.PasswordAuthenticator"):          true,
 		approve("com.instaclustr.cassandra.auth.SharedSecretAuthenticator"): true,
 		approve("com.datastax.bdp.cassandra.auth.DseAuthenticator"):         true,
+		approve("io.aiven.cassandra.auth.AivenAuthenticator"):               true,
 		approve("com.apache.cassandra.auth.FakeAuthenticator"):              false,
 	}
 	for k, v := range tests {


### PR DESCRIPTION
Hosted Cassandra provider [Aiven](http://aiven.io) uses their own authenticator and it causes `gocql` to fail to connect. This just adds it to the approve list with the others.