### PR TITLE
handle tinyint fields in getCassandraBaseType

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -91,6 +91,8 @@ func getCassandraBaseType(name string) Type {
 		return TypeFloat
 	case "int":
 		return TypeInt
+	case "tinyint":
+		return TypeTinyInt
 	case "timestamp":
 		return TypeTimestamp
 	case "uuid":


### PR DESCRIPTION
I have a generic tool that discovers the fields of a table using the [KeyspaceMetadata](http://localhost:6060/pkg/github.com/gocql/gocql/#Session.KeyspaceMetadata) method.

On a Cassandra 3.11 cluster I have a table with a tinyint field and the returned metadata is wrong:

    &{Keyspace:live_selection Table:install_campaign_sent Name:partition ComponentIndex:3 Kind:partition_key Validator:int Type:int ClusteringOrder:none Order:false Index:{Name: Type: Options:map[]}}
    &{Keyspace:live_selection Table:install_campaign_sent Name:platform ComponentIndex:1 Kind:partition_key Validator:tinyint Type:custom() ClusteringOrder:none Order:false Index:{Name: Type: Options:map[]}}

which means that I can't probably handle this type because `ColumnMetadata.Type.Type()` is wrong.

Fortunately the fix is trivial. I have verified it works with my tool.