### PR TITLE
marshal: prevent calling IsNil on non nullable types

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1478,13 +1478,14 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 	}
 
 	rv := reflect.ValueOf(value)
-	if rv.IsNil() {
-		return nil, nil
-	}
 
 	t := rv.Type()
 	if t.Kind() != reflect.Map {
 		return nil, marshalErrorf("can not marshal %T into %s", value, info)
+	}
+
+	if rv.IsNil() {
+		return nil, nil
 	}
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
I just encountered a bug with `marshalMap` due to a mistake on my part.

Here's a sample which reproduces the bug:

    package main
    
    import (
    	"log"
    
    	"github.com/gocql/gocql"
    )
    
    func main() {
    	cfg := gocql.NewCluster("localhost:9042")
    
    	session, err := cfg.CreateSession()
    	if err != nil {
    		log.Fatal(err)
    	}
    
    	err = session.Query("CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;").Exec()
    	if err != nil {
    		log.Fatal(err)
    	}
    
    	err = session.Query("CREATE TABLE IF NOT EXISTS ks.foobar (id text primary key, data map<text, text>)").Exec()
    	if err != nil {
    		log.Fatal(err)
    	}
    
    	const stmt = "INSERT INTO ks.foobar(id, data) VALUES (?, ?)"
    
    	err = session.Query(stmt, "foobar", "mystring").Exec()
    	if err != nil {
    		log.Fatal(err)
    	}
    }

I get a panic:

    panic: reflect: call of reflect.Value.IsNil on string Value
    
    goroutine 1 [running]:
    reflect.Value.IsNil(...)
            /usr/lib/golang/src/reflect/value.go:1048
    github.com/gocql/gocql.marshalMap(0x6f8b20, 0xc000156800, 0x658ac0, 0x6f5610, 0x0, 0x0, 0x8, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:1481 +0xaae
    github.com/gocql/gocql.Marshal(0x6f8b20, 0xc000156800, 0x658ac0, 0x6f5610, 0xc00018e250, 0x6, 0x8, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:90 +0xeb4
    github.com/gocql/gocql.marshalQueryValue(0x6f8b20, 0xc000156800, 0x658ac0, 0x6f5610, 0xc0001266f0, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/conn.go:965 +0xb1
    github.com/gocql/gocql.(*Conn).executeQuery(0xc0001b0200, 0x6f8820, 0xc00001a0f0, 0xc0001b6120, 0xeebcee)
            /home/vincent/dev/go/src/github.com/gocql/gocql/conn.go:1037 +0x3ff
    github.com/gocql/gocql.(*Query).execute(0xc0001b6120, 0x6f8820, 0xc00001a0f0, 0xc0001b0200, 0xc000000008)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:895 +0x49
    github.com/gocql/gocql.(*queryExecutor).attemptQuery(0xc00000cf20, 0x6f8820, 0xc00001a0f0, 0x6fa2e0, 0xc0001b6120, 0xc0001b0200, 0xc000164240)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:29 +0x87
    github.com/gocql/gocql.(*queryExecutor).do(0xc00000cf20, 0x6f8820, 0xc00001a0f0, 0x6fa2e0, 0xc0001b6120, 0x40ce3f)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:112 +0x1d9
    github.com/gocql/gocql.(*queryExecutor).executeQuery(0xc00000cf20, 0x6fa2e0, 0xc0001b6120, 0x0, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/query_executor.go:60 +0xdd
    github.com/gocql/gocql.(*Session).executeQuery(0xc000124380, 0xc0001b6120, 0x61f200)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:399 +0xba
    github.com/gocql/gocql.(*Query).Iter(0xc0001b6120, 0xc0001b6120)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1110 +0xac
    github.com/gocql/gocql.(*Query).Exec(0xc0001b6120, 0x6bc2bc, 0x2d)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1093 +0x2b
    main.main()
            /home/vincent/tmp/gocql-repro/main.go:29 +0x41c
    exit status 2

`IsNil` can't be called on a string. With the fix I get this:

    2019/01/22 21:35:38 can not marshal string into map(varchar, varchar)

I'm not sure if I broke something else however