### PR TITLE
policies: tokenAwareHostPolicy use token ranges from "local" hosts only

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -467,7 +467,9 @@ func (t *tokenAwareHostPolicy) SetPartitioner(partitioner string) {
 }
 
 func (t *tokenAwareHostPolicy) AddHost(host *HostInfo) {
-	t.hosts.add(host)
+	if t.fallback.IsLocal(host) {
+		t.hosts.add(host)
+	}
 	t.fallback.AddHost(host)
 
 	t.mu.RLock()


### PR DESCRIPTION
This adds `t.fallback.IsLocal()` check to tokenAwareHostPolicy::AddHost.
Otherwise the tokenRing uses token ranges from all DCs merging them to one.
This results in wrong host selection in Pick method, primaryEndpoint
may be assigned to a host in a remote DCs. If using DCAwareRoundRobinPolicy
the host is rejected and we are falling back to a random host in a local DC.

Signed-off-by: Michał Matczuk <michal@scylladb.com>