### PR TITLE
policy: tokenAwareHostPolicy host selection bug fix

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -442,7 +442,7 @@ func (t *tokenAwareHostPolicy) updateKeyspaceMetadata(keyspace string) {
 	if err == nil {
 		strat := getStrategy(ks)
 		if strat != nil {
-			tr := t.tokenRing.Load().(*tokenRing)
+			tr, _ := t.tokenRing.Load().(*tokenRing)
 			if tr != nil {
 				newMeta.replicas[keyspace] = strat.replicaMap(t.hosts.get(), tr.tokens)
 			}

--- a/session.go
+++ b/session.go
@@ -248,6 +248,12 @@ func (s *Session) init() error {
 		return ErrNoConnectionsStarted
 	}
 
+	// Invoke KeyspaceChanged to let the policy cache the session keyspace
+	// parameters. This is used by tokenAwareHostPolicy to discover replicas.
+	if !s.cfg.disableControlConn && s.cfg.Keyspace != "" {
+		s.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: s.cfg.Keyspace})
+	}
+
 	return nil
 }
 

--- a/token.go
+++ b/token.go
@@ -192,18 +192,17 @@ func (t *tokenRing) String() string {
 	return string(buf.Bytes())
 }
 
-func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) *HostInfo {
+func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, endToken token) {
 	if t == nil {
-		return nil
+		return nil, nil
 	}
 
-	token := t.partitioner.Hash(partitionKey)
-	return t.GetHostForToken(token)
+	return t.GetHostForToken(t.partitioner.Hash(partitionKey))
 }
 
-func (t *tokenRing) GetHostForToken(token token) *HostInfo {
+func (t *tokenRing) GetHostForToken(token token) (host *HostInfo, endToken token) {
 	if t == nil || len(t.tokens) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// find the primary replica
@@ -216,5 +215,6 @@ func (t *tokenRing) GetHostForToken(token token) *HostInfo {
 		ringIndex = 0
 	}
 
-	return t.tokens[ringIndex].host
+	v := t.tokens[ringIndex]
+	return v.host, v.token
 }

--- a/token_test.go
+++ b/token_test.go
@@ -156,43 +156,43 @@ func TestTokenRing_Int(t *testing.T) {
 
 	sort.Sort(ring)
 
-	if ring.GetHostForToken(intToken(0)) != host0 {
+	if host, endToken := ring.GetHostForToken(intToken(0)); host != host0 || endToken != intToken(0) {
 		t.Error("Expected host 0 for token 0")
 	}
-	if ring.GetHostForToken(intToken(1)) != host25 {
+	if host, endToken := ring.GetHostForToken(intToken(1)); host != host25 || endToken != intToken(25) {
 		t.Error("Expected host 25 for token 1")
 	}
-	if ring.GetHostForToken(intToken(24)) != host25 {
+	if host, endToken := ring.GetHostForToken(intToken(24)); host != host25 || endToken != intToken(25) {
 		t.Error("Expected host 25 for token 24")
 	}
-	if ring.GetHostForToken(intToken(25)) != host25 {
+	if host, endToken := ring.GetHostForToken(intToken(25)); host != host25 || endToken != intToken(25) {
 		t.Error("Expected host 25 for token 25")
 	}
-	if ring.GetHostForToken(intToken(26)) != host50 {
+	if host, endToken := ring.GetHostForToken(intToken(26)); host != host50 || endToken != intToken(50) {
 		t.Error("Expected host 50 for token 26")
 	}
-	if ring.GetHostForToken(intToken(49)) != host50 {
+	if host, endToken := ring.GetHostForToken(intToken(49)); host != host50 || endToken != intToken(50) {
 		t.Error("Expected host 50 for token 49")
 	}
-	if ring.GetHostForToken(intToken(50)) != host50 {
+	if host, endToken := ring.GetHostForToken(intToken(50)); host != host50 || endToken != intToken(50) {
 		t.Error("Expected host 50 for token 50")
 	}
-	if ring.GetHostForToken(intToken(51)) != host75 {
+	if host, endToken := ring.GetHostForToken(intToken(51)); host != host75 || endToken != intToken(75) {
 		t.Error("Expected host 75 for token 51")
 	}
-	if ring.GetHostForToken(intToken(74)) != host75 {
+	if host, endToken := ring.GetHostForToken(intToken(74)); host != host75 || endToken != intToken(75) {
 		t.Error("Expected host 75 for token 74")
 	}
-	if ring.GetHostForToken(intToken(75)) != host75 {
+	if host, endToken := ring.GetHostForToken(intToken(75)); host != host75 || endToken != intToken(75) {
 		t.Error("Expected host 75 for token 75")
 	}
-	if ring.GetHostForToken(intToken(76)) != host0 {
+	if host, endToken := ring.GetHostForToken(intToken(76)); host != host0 || endToken != intToken(0) {
 		t.Error("Expected host 0 for token 76")
 	}
-	if ring.GetHostForToken(intToken(99)) != host0 {
+	if host, endToken := ring.GetHostForToken(intToken(99)); host != host0 || endToken != intToken(0) {
 		t.Error("Expected host 0 for token 99")
 	}
-	if ring.GetHostForToken(intToken(100)) != host0 {
+	if host, endToken := ring.GetHostForToken(intToken(100)); host != host0 || endToken != intToken(0) {
 		t.Error("Expected host 0 for token 100")
 	}
 }
@@ -201,10 +201,10 @@ func TestTokenRing_Int(t *testing.T) {
 func TestTokenRing_Nil(t *testing.T) {
 	var ring *tokenRing = nil
 
-	if ring.GetHostForToken(nil) != nil {
+	if host, endToken := ring.GetHostForToken(nil); host != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
-	if ring.GetHostForPartitionKey(nil) != nil {
+	if host, endToken := ring.GetHostForPartitionKey(nil); host != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
 }
@@ -242,19 +242,19 @@ func TestTokenRing_Murmur3(t *testing.T) {
 	p := murmur3Partitioner{}
 
 	for _, host := range hosts {
-		actual := ring.GetHostForToken(p.ParseString(host.tokens[0]))
+		actual, _ := ring.GetHostForToken(p.ParseString(host.tokens[0]))
 		if !actual.ConnectAddress().Equal(host.ConnectAddress()) {
 			t.Errorf("Expected address %v for token %q, but was %v", host.ConnectAddress(),
 				host.tokens[0], actual.ConnectAddress())
 		}
 	}
 
-	actual := ring.GetHostForToken(p.ParseString("12"))
+	actual, _ := ring.GetHostForToken(p.ParseString("12"))
 	if !actual.ConnectAddress().Equal(hosts[1].ConnectAddress()) {
 		t.Errorf("Expected address 1 for token \"12\", but was %s", actual.ConnectAddress())
 	}
 
-	actual = ring.GetHostForToken(p.ParseString("24324545443332"))
+	actual, _ = ring.GetHostForToken(p.ParseString("24324545443332"))
 	if !actual.ConnectAddress().Equal(hosts[0].ConnectAddress()) {
 		t.Errorf("Expected address 0 for token \"24324545443332\", but was %s", actual.ConnectAddress())
 	}
@@ -274,19 +274,19 @@ func TestTokenRing_Ordered(t *testing.T) {
 
 	var actual *HostInfo
 	for _, host := range hosts {
-		actual = ring.GetHostForToken(p.ParseString(host.tokens[0]))
+		actual, _ := ring.GetHostForToken(p.ParseString(host.tokens[0]))
 		if !actual.ConnectAddress().Equal(host.ConnectAddress()) {
 			t.Errorf("Expected address %v for token %q, but was %v", host.ConnectAddress(),
 				host.tokens[0], actual.ConnectAddress())
 		}
 	}
 
-	actual = ring.GetHostForToken(p.ParseString("12"))
+	actual, _ = ring.GetHostForToken(p.ParseString("12"))
 	if !actual.peer.Equal(hosts[1].peer) {
 		t.Errorf("Expected address 1 for token \"12\", but was %s", actual.ConnectAddress())
 	}
 
-	actual = ring.GetHostForToken(p.ParseString("24324545443332"))
+	actual, _ = ring.GetHostForToken(p.ParseString("24324545443332"))
 	if !actual.ConnectAddress().Equal(hosts[1].ConnectAddress()) {
 		t.Errorf("Expected address 1 for token \"24324545443332\", but was %s", actual.ConnectAddress())
 	}
@@ -305,19 +305,19 @@ func TestTokenRing_Random(t *testing.T) {
 
 	var actual *HostInfo
 	for _, host := range hosts {
-		actual = ring.GetHostForToken(p.ParseString(host.tokens[0]))
+		actual, _ := ring.GetHostForToken(p.ParseString(host.tokens[0]))
 		if !actual.ConnectAddress().Equal(host.ConnectAddress()) {
 			t.Errorf("Expected address %v for token %q, but was %v", host.ConnectAddress(),
 				host.tokens[0], actual.ConnectAddress())
 		}
 	}
 
-	actual = ring.GetHostForToken(p.ParseString("12"))
+	actual, _ = ring.GetHostForToken(p.ParseString("12"))
 	if !actual.peer.Equal(hosts[1].peer) {
 		t.Errorf("Expected address 1 for token \"12\", but was %s", actual.ConnectAddress())
 	}
 
-	actual = ring.GetHostForToken(p.ParseString("24324545443332"))
+	actual, _ = ring.GetHostForToken(p.ParseString("24324545443332"))
 	if !actual.ConnectAddress().Equal(hosts[0].ConnectAddress()) {
 		t.Errorf("Expected address 1 for token \"24324545443332\", but was %s", actual.ConnectAddress())
 	}

--- a/topology.go
+++ b/topology.go
@@ -47,6 +47,8 @@ func getStrategy(ks *KeyspaceMetadata) placementStrategy {
 			dcs[dc] = getReplicationFactorFromOpts(ks.Name+":dc="+dc, rf)
 		}
 		return &networkTopology{dcs: dcs}
+	case strings.Contains(ks.StrategyClass, "LocalStrategy"):
+		return nil
 	default:
 		// TODO: handle unknown replicas and just return the primary host for a token
 		panic(fmt.Sprintf("unsupported strategy class: %v", ks.StrategyClass))


### PR DESCRIPTION
Bug:

`tokenAwareHostPolicy` always selects a primary replica of a token.
When using `tokenAwareHostPolicy` backed by `dcAwareRR`, for tokens
with primary replica in a different DC, this results in selecting
a RANDOM host in a given DC.

This is caused by two issues in `tokenAwareHostPolicy::getReplicas` func.

* `tokenAwareHostPolicy::meta` is always nil unless a keyspace changed
  event it received
* even when metadata is available it uses the calculated token value of
  a partition key to find replicas, however, the replicas are stored
  in a map where the key is the primary replica token aka the `end_token`
  (nodetool describering)

Solution:

This commit extends `tokenRing::GetHostForPartitionKey` to return
the endToken that is later used in the `Pick` function, and forces
a call to `KeyspaceChanged` when session is initialised.

Extra changes:
In addition to that commit d497a99 adds support for handling host add and host remove events. Otherwise those events were ignored and resulted in wrong token to replica mapping.

Signed-off-by: Michał Matczuk <michal@scylladb.com>