### PR TITLE
query executor: better handling of errors for host selection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,3 +109,4 @@ Jacob Greenleaf <jacob@jacobgreenleaf.com>
 Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
 Marco Cadetg <cadetg@gmail.com>
 Karl Matthias <karl@matthias.org>
+Thomas Meson <zllak@hycik.org>


### PR DESCRIPTION
We cannot mark the host as failed in case of logical errors, whether it is from
gocql itself or from the context package.
Ideally, ErrNotFound should not be the only error to be handled, all errors defined in `session.go` should be used.