### PR TITLE
Don't fetch aggregates/UDFs on version 2.1

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -89,6 +89,10 @@ func (c cassVersion) Before(major, minor, patch int) bool {
 	return false
 }
 
+func (c cassVersion) AtLeast(major, minor, patch int) bool {
+	return !c.Before(major, minor, patch)
+}
+
 func (c cassVersion) String() string {
 	return fmt.Sprintf("v%d.%d.%d", c.Major, c.Minor, c.Patch)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -913,7 +913,7 @@ func getViewsMetadata(session *Session, keyspaceName string) ([]ViewMetadata, er
 }
 
 func getFunctionsMetadata(session *Session, keyspaceName string) ([]FunctionMetadata, error) {
-	if session.cfg.ProtoVersion == protoVersion1 {
+	if session.cfg.ProtoVersion == protoVersion1 || !session.hasAggregatesAndFunctions {
 		return nil, nil
 	}
 	var tableName string
@@ -968,7 +968,7 @@ func getFunctionsMetadata(session *Session, keyspaceName string) ([]FunctionMeta
 }
 
 func getAggregatesMetadata(session *Session, keyspaceName string) ([]AggregateMetadata, error) {
-	if session.cfg.ProtoVersion == protoVersion1 {
+	if session.cfg.ProtoVersion == protoVersion1 || !session.hasAggregatesAndFunctions {
 		return nil, nil
 	}
 	var tableName string

--- a/session.go
+++ b/session.go
@@ -62,8 +62,9 @@ type Session struct {
 	schemaEvents *eventDebouncer
 
 	// ring metadata
-	hosts           []HostInfo
-	useSystemSchema bool
+	hosts                     []HostInfo
+	useSystemSchema           bool
+	hasAggregatesAndFunctions bool
 
 	cfg ClusterConfig
 
@@ -240,8 +241,9 @@ func (s *Session) init() error {
 		newer, _ := checkSystemSchema(s.control)
 		s.useSystemSchema = newer
 	} else {
-		host := s.ring.rrHost()
-		s.useSystemSchema = host.Version().Major >= 3
+		version := s.ring.rrHost().Version()
+		s.useSystemSchema = version.AtLeast(3, 0, 0)
+		s.hasAggregatesAndFunctions = version.AtLeast(2, 2, 0)
 	}
 
 	if s.pool.Size() == 0 {


### PR DESCRIPTION
The system.schema_aggregates and system.schema_functions tables don't
exists in 2.1 (these were added in 2.2).

I added a version.AtLeast() function that inverts
version.Before(). Normally you are checking for a minimum version, so
this avoids additional negatives and makes things more readable.