### PR TITLE
Sort AUTHORS file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   - set -e
   - PATH=$PATH:$HOME/.local/bin bash integration.sh $CASS $AUTH
   - go vet .
+  - ./authors.py --check
 
 notifications:
   - email: false

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,112 +1,115 @@
 # This source file refers to The gocql Authors for copyright purposes.
+# Please keep the list sorted to avoid unnecessary merge conflicts.
+# You can sort this file with `python3 /authors.py` or add an author with
+# `python3 authors.py 'Your Name <yourmail@example.org>'`
 
+Adam Weiner <adamsweiner@gmail.com>
+Adrian Casajus <adriancasajus@gmail.com>
+Adriano Orioli <orioli.adriano@gmail.com>
+Adrien Bustany <adrien@bustany.org>
+Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
+Alex Zorin <git@zor.io>
+Alexander Inozemtsev <alexander.inozemtsev@gmail.com>
+Andrew de Andrade <andrew@deandrade.com.br>
+Andrey Smirnov <smirnov.andrey@gmail.com>
+Anthony Woods <awoods@raintank.io>
+Artem Chernyshev <artem.0xD2@gmail.com>
+Ashwin Purohit <purohit@gmail.com>
+Baptiste Fontaine <b@ptistefontaine.fr>
+Bartosz Burclaf <burclaf@gmail.com>
+Ben Frye <benfrye@gmail.com>
+Ben Hood <0x6e6562@gmail.com>
+Ben Krebsbach <ben.krebsbach@gmail.com>
+Blake Atkinson <me@blakeatkinson.com>
+Bo Blanton <bo.blanton@gmail.com>
+Caleb Doxsey <caleb@datadoghq.com>
+Chang Liu <changliu.it@gmail.com>
+Charles Law <charles.law@gmail.com>; <claw@conduce.com>
+Charlie Andrews <charlieandrews.cwa@gmail.com>
+Chris Bannister <c.bannister@gmail.com>
 Christoph Hack <christoph@tux21b.org>
+Claudiu Raveica <claudiu.raveica@gmail.com>
+Dan Forest <bonjour@dan.tf>
+Dan Kennedy <daniel@firstcs.co.uk>
+Dan Kinder <dkinder.is.me@gmail.com>
+Dan Simmons <dan@simmons.io>
+Daniel Cannon <daniel@danielcannon.co.uk>
+Dean Elbaz <elbaz.dean@gmail.com>
+Derrick Wippler <thrawn01@gmail.com>
+Dharmendra Parsaila <d4dharmu@gmail.com>
+Dmitriy Fedorenko <c0va23@gmail.com>
+Ference Fu <fym201@msn.com>
+Fred McCann <fred@sharpnoodles.com>
+Frederic Hemery <frederic.hemery@datadoghq.com>
+Ghais Issa <ghais.issa@gmail.com>
+Harpreet Sawhney <harpreet.sawhney@gmail.com>
+Ian Lozinski <ian.lozinski@gmail.com>
+Ingo Oeser <nightlyone@gmail.com>
+Jacob Greenleaf <jacob@jacobgreenleaf.com>
+Jacob Rhoden <jacob.rhoden@gmail.com>
+James Maloney <jamessagan@gmail.com>
+Jamie Cuthill <jamie.cuthill@gmail.com>
+Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
+Jeff Mitchell <jeffrey.mitchell@gmail.com>
+Jeremy Schlatter <jeremy.schlatter@gmail.com>
+Jesse Claven <jesse.claven@gmail.com>
+John Weldon <johnweldon4@gmail.com>
+Johnny Bergström <johnny@joonix.se>
 Jonathan Rudenberg <jonathan@titanous.com>
-Thorsten von Eicken <tve@rightscale.com>
+Josh Wright <jshwright@gmail.com>
+Julien Da Silva <julien.dasilva@gmail.com>
+Justin Corpron <jncorpron@gmail.com>
+Karl Matthias <karl@matthias.org>
+Kasper Middelboe Petersen <me@phant.dk>
+Konstantin Cherkasov <k.cherkasoff@gmail.com>
+Krishnanand Thommandra <devtkrishna@gmail.com>
+Leigh McCulloch <leigh@leighmcculloch.com>
+LOVOO <opensource@lovoo.com>
+Luke Hines <lukehines@protonmail.com>
+Luke Hines <lukehines@protonmail.com>
+Maciek Sakrejda <maciek@heroku.com>
+Marco Cadetg <cadetg@gmail.com>
+Marcus King <marcusking01@gmail.com>
+Mark M <m.mim95@gmail.com>
+Matt Heath <matt@mattheath.com>
 Matt Robenolt <mattr@disqus.com>
-Phillip Couto <phillip.couto@stemstudios.com>
+Matthias Kadenbach <matthias.kadenbach@gmail.com>
+Maxim Bublis <b@codemonkey.ru>
+Michael Highstead <highstead@gmail.com>
+Michał Matczuk <mmatczuk@gmail.com>
+Miguel Serrano <miguelvps@gmail.com>
+Mike Berman <evencode@gmail.com>
+Miles Delahunty <miles.delahunty@gmail.com>
+Muir Manders <muir@retailnext.net>
+Nathan Davies <nathanjamesdavies@gmail.com>
+Nathan Youngman <git@nathany.com>
+Nayef Ghattas <nayef.ghattas@datadoghq.com>
+Nick Dhupia<nick.dhupia@gmail.com>
+nikandfor <nikandfor@gmail.com>
 Niklas Korz <korz.niklask@gmail.com>
 Nimi Wariboko Jr <nimi@channelmeter.com>
-Ghais Issa <ghais.issa@gmail.com>
-Sasha Klizhentas <klizhentas@gmail.com>
-Konstantin Cherkasov <k.cherkasoff@gmail.com>
-Ben Hood <0x6e6562@gmail.com>
-Pete Hopkins <phopkins@gmail.com>
-Chris Bannister <c.bannister@gmail.com>
-Maxim Bublis <b@codemonkey.ru>
-Alex Zorin <git@zor.io>
-Kasper Middelboe Petersen <me@phant.dk>
-Harpreet Sawhney <harpreet.sawhney@gmail.com>
-Charlie Andrews <charlieandrews.cwa@gmail.com>
-Stanislavs Koikovs <stanislavs.koikovs@gmail.com>
-Dan Forest <bonjour@dan.tf>
-Miguel Serrano <miguelvps@gmail.com>
-Stefan Radomski <gibheer@zero-knowledge.org>
-Josh Wright <jshwright@gmail.com>
-Jacob Rhoden <jacob.rhoden@gmail.com>
-Ben Frye <benfrye@gmail.com>
-Fred McCann <fred@sharpnoodles.com>
-Dan Simmons <dan@simmons.io>
-Muir Manders <muir@retailnext.net>
-Sankar P <sankar.curiosity@gmail.com>
-Julien Da Silva <julien.dasilva@gmail.com>
-Dan Kennedy <daniel@firstcs.co.uk>
-Nick Dhupia<nick.dhupia@gmail.com>
-Yasuharu Goto <matope.ono@gmail.com>
-Jeremy Schlatter <jeremy.schlatter@gmail.com>
-Matthias Kadenbach <matthias.kadenbach@gmail.com>
-Dean Elbaz <elbaz.dean@gmail.com>
-Mike Berman <evencode@gmail.com>
-Dmitriy Fedorenko <c0va23@gmail.com>
-Zach Marcantel <zmarcantel@gmail.com>
-James Maloney <jamessagan@gmail.com>
-Ashwin Purohit <purohit@gmail.com>
-Dan Kinder <dkinder.is.me@gmail.com>
 Oliver Beattie <oliver@obeattie.com>
-Justin Corpron <jncorpron@gmail.com>
-Miles Delahunty <miles.delahunty@gmail.com>
-Zach Badgett <zach.badgett@gmail.com>
-Maciek Sakrejda <maciek@heroku.com>
-Jeff Mitchell <jeffrey.mitchell@gmail.com>
-Baptiste Fontaine <b@ptistefontaine.fr>
-Matt Heath <matt@mattheath.com>
-Jamie Cuthill <jamie.cuthill@gmail.com>
-Adrian Casajus <adriancasajus@gmail.com>
-John Weldon <johnweldon4@gmail.com>
-Adrien Bustany <adrien@bustany.org>
-Andrey Smirnov <smirnov.andrey@gmail.com>
-Adam Weiner <adamsweiner@gmail.com>
-Daniel Cannon <daniel@danielcannon.co.uk>
-Johnny Bergström <johnny@joonix.se>
-Adriano Orioli <orioli.adriano@gmail.com>
-Claudiu Raveica <claudiu.raveica@gmail.com>
-Artem Chernyshev <artem.0xD2@gmail.com>
-Ference Fu <fym201@msn.com>
-LOVOO <opensource@lovoo.com>
-nikandfor <nikandfor@gmail.com>
-Anthony Woods <awoods@raintank.io>
-Alexander Inozemtsev <alexander.inozemtsev@gmail.com>
-Rob McColl <rob@robmccoll.com>; <rmccoll@ionicsecurity.com>
-Viktor Tönköl <viktor.toenkoel@motionlogic.de>
-Ian Lozinski <ian.lozinski@gmail.com>
-Michael Highstead <highstead@gmail.com>
-Sarah Brown <esbie.is@gmail.com>
-Caleb Doxsey <caleb@datadoghq.com>
-Frederic Hemery <frederic.hemery@datadoghq.com>
 Pekka Enberg <penberg@scylladb.com>
-Mark M <m.mim95@gmail.com>
-Bartosz Burclaf <burclaf@gmail.com>
-Marcus King <marcusking01@gmail.com>
-Andrew de Andrade <andrew@deandrade.com.br>
-Robert Nix <robert@nicerobot.org>
-Nathan Youngman <git@nathany.com>
-Charles Law <charles.law@gmail.com>; <claw@conduce.com>
-Nathan Davies <nathanjamesdavies@gmail.com>
-Bo Blanton <bo.blanton@gmail.com>
-Vincent Rischmann <me@vrischmann.me>
-Jesse Claven <jesse.claven@gmail.com>
-Derrick Wippler <thrawn01@gmail.com>
-Leigh McCulloch <leigh@leighmcculloch.com>
-Ron Kuris <swcafe@gmail.com>
+Pete Hopkins <phopkins@gmail.com>
+Phillip Couto <phillip.couto@stemstudios.com>
 Raphael Gavache <raphael.gavache@gmail.com>
-Yasser Abdolmaleki <yasser@yasser.ca>
-Krishnanand Thommandra <devtkrishna@gmail.com>
-Blake Atkinson <me@blakeatkinson.com>
-Dharmendra Parsaila <d4dharmu@gmail.com>
-Nayef Ghattas <nayef.ghattas@datadoghq.com>
-Michał Matczuk <mmatczuk@gmail.com>
-Ben Krebsbach <ben.krebsbach@gmail.com>
-Vivian Mathews <vivian.mathews.3@gmail.com>
+Rob McColl <rob@robmccoll.com>; <rmccoll@ionicsecurity.com>
+Robert Nix <robert@nicerobot.org>
+Ron Kuris <swcafe@gmail.com>
+Sankar P <sankar.curiosity@gmail.com>
+Sarah Brown <esbie.is@gmail.com>
 Sascha Steinbiss <satta@debian.org>
+Sasha Klizhentas <klizhentas@gmail.com>
 Seth Rosenblum <seth.t.rosenblum@gmail.com>
-Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
-Luke Hines <lukehines@protonmail.com>
-Zhixin Wen <john.wenzhixin@hotmail.com>
-Chang Liu <changliu.it@gmail.com>
-Ingo Oeser <nightlyone@gmail.com>
-Luke Hines <lukehines@protonmail.com>
-Jacob Greenleaf <jacob@jacobgreenleaf.com>
-Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
-Marco Cadetg <cadetg@gmail.com>
-Karl Matthias <karl@matthias.org>
+Stanislavs Koikovs <stanislavs.koikovs@gmail.com>
+Stefan Radomski <gibheer@zero-knowledge.org>
 Thomas Meson <zllak@hycik.org>
+Thorsten von Eicken <tve@rightscale.com>
+Viktor Tönköl <viktor.toenkoel@motionlogic.de>
+Vincent Rischmann <me@vrischmann.me>
+Vivian Mathews <vivian.mathews.3@gmail.com>
+Yasser Abdolmaleki <yasser@yasser.ca>
+Yasuharu Goto <matope.ono@gmail.com>
+Zach Badgett <zach.badgett@gmail.com>
+Zach Marcantel <zmarcantel@gmail.com>
+Zhixin Wen <john.wenzhixin@hotmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Maciek Sakrejda <maciek@heroku.com>
 Marco Cadetg <cadetg@gmail.com>
 Marcus King <marcusking01@gmail.com>
 Mark M <m.mim95@gmail.com>
+Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
 Matt Heath <matt@mattheath.com>
 Matt Robenolt <mattr@disqus.com>
 Matthias Kadenbach <matthias.kadenbach@gmail.com>

--- a/authors.py
+++ b/authors.py
@@ -2,10 +2,12 @@
 # Helper script for managing AUTHORS file
 import os
 import argparse
+import io
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument('author', nargs='?')
+parser.add_argument('--check', action='store_true', help='Return 0 if no changes are required')
 
 args = parser.parse_args()
 
@@ -22,10 +24,23 @@ with open('AUTHORS', 'r', encoding='UTF-8') as f:
 if args.author:
     authors.append(args.author + '\n')
 
-with open('AUTHORS.tmp', 'w', encoding='UTF-8') as f:
+
+def write_authors(f):
     for line in preamble:
         f.write(line)
     for author in sorted(authors, key=str.casefold):
         f.write(author)
 
-os.rename('AUTHORS.tmp', 'AUTHORS')
+if args.check:
+    with open('AUTHORS', 'rb') as f:
+        original = f.read()
+    f = io.StringIO()
+    write_authors(f)
+    new = f.getvalue().encode('UTF-8')
+    if original != new:
+        print("Changes to AUTHORS file required")
+        raise SystemExit(1)
+else:
+    with open('AUTHORS.tmp', 'w', encoding='UTF-8') as f:
+        write_authors(f)
+    os.rename('AUTHORS.tmp', 'AUTHORS')

--- a/authors.py
+++ b/authors.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Helper script for managing AUTHORS file
+import os
+import argparse
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('author', nargs='?')
+
+args = parser.parse_args()
+
+preamble = []
+authors = []
+
+with open('AUTHORS', 'r', encoding='UTF-8') as f:
+    for line in f:
+        if line.startswith('#') or line.strip() == '':
+            preamble.append(line)
+            continue
+        authors.append(line)
+
+if args.author:
+    authors.append(args.author + '\n')
+
+with open('AUTHORS.tmp', 'w', encoding='UTF-8') as f:
+    for line in preamble:
+        f.write(line)
+    for author in sorted(authors, key=str.casefold):
+        f.write(author)
+
+os.rename('AUTHORS.tmp', 'AUTHORS')


### PR DESCRIPTION
Adding new entries at the end creates unnecessary merge conflicts,
which could be mostly avoided if the list of authors was sorted.

Added a helper script to manage the file so that there is a single
canonical order.