### PR TITLE
Don't dial control connection twice

### DIFF
--- a/control.go
+++ b/control.go
@@ -172,8 +172,7 @@ func (c *controlConn) shuffleDial(endpoints []*HostInfo) (*Conn, error) {
 	var err error
 	for _, host := range shuffled {
 		var conn *Conn
-		c.session.dial(host, &cfg, c)
-		conn, err = c.session.connect(host, c)
+		conn, err = c.session.dial(host, &cfg, c)
 		if err == nil {
 			return conn, nil
 		}


### PR DESCRIPTION
The dial was added in 9a2217868665d0540eaf7de957d71de90274d10b to
disable write coalescing for the control connection, but the
return value from dial was not used. It was probably intended
to change the connect to dial.