### PR TITLE
Make sure all connections are observed

### DIFF
--- a/session.go
+++ b/session.go
@@ -656,21 +656,6 @@ func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) 
 	return applied, iter, iter.err
 }
 
-func (s *Session) connect(host *HostInfo, errorHandler ConnErrorHandler) (*Conn, error) {
-	if s.connectObserver != nil {
-		obs := ObservedConnect{
-			Host:  host,
-			Start: time.Now(),
-		}
-		conn, err := s.dial(host, s.connCfg, errorHandler)
-		obs.End = time.Now()
-		obs.Err = err
-		s.connectObserver.ObserveConnect(obs)
-		return conn, err
-	}
-	return s.dial(host, s.connCfg, errorHandler)
-}
-
 type hostMetrics struct {
 	Attempts     int
 	TotalLatency int64


### PR DESCRIPTION
Currently, control connections used for example to discover protocol
version are not observable using connection observer. This change
aims to make sure all connections created by the driver are seen
by the connection observer.

The `dialWithoutObserver` name is intentionally longer than `dial`
so that one must explicitly acknowledge the connection will not be
observed when using the function.