### PR TITLE
Helpers function goType supports TypeTime

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -26,7 +26,7 @@ func goType(t TypeInfo) reflect.Type {
 		return reflect.TypeOf(*new(string))
 	case TypeBigInt, TypeCounter:
 		return reflect.TypeOf(*new(int64))
-	case TypeTimestamp:
+	case TypeTimestamp, TypeTime:
 		return reflect.TypeOf(*new(time.Time))
 	case TypeBlob:
 		return reflect.TypeOf(*new([]byte))


### PR DESCRIPTION
TypeTime is handled like TypeTimestamp elsewhere but was missing in the
helpers function goType.

The panic that led to finding this:

```
panic: reflect: New(nil)

goroutine 105 [running]:
reflect.New(0x0, 0x0, 0x0, 0x0, 0x811f40)
	/usr/lib/go/src/reflect/value.go:2287 +0xc3
github.com/gocql/gocql.NativeType.New(0xc00023b504, 0x12, 0x0, 0x0, 0x811f40, 0xc000288380)
	/home/henrik/go/pkg/mod/github.com/scylladb/gocql@v1.0.1/marshal.go:2132 +0x92
github.com/gocql/gocql.(*Iter).RowData(0xc0000f5200, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc00006e000, 0xc00023b850)
	/home/henrik/go/pkg/mod/github.com/scylladb/gocql@v1.0.1/helpers.go:300 +0x66b
github.com/gocql/gocql.(*Iter).MapScan(0xc0000f5200, 0xc0002860c0, 0x0)
	/home/henrik/go/pkg/mod/github.com/scylladb/gocql@v1.0.1/helpers.go:397 +0x4a
github.com/scylladb/gemini.loadSet(0xc0000f5200, 0x831570, 0xc0000f5200, 0xc00027a120)
	/home/henrik/dev/gemini/session.go:143 +0x62
github.com/scylladb/gemini.(*Session).Check(0xc000099f00, 0x819bce, 0x6, 0xc000098e80, 0x1, 0x1, 0xc0000b8900, 0x3, 0x4, 0xc0000c8d00, ...)
	/home/henrik/dev/gemini/session.go:71 +0x161
main.validationJob(0xc000090ba0, 0x819bce, 0x6, 0xc000098e80, 0x1, 0x1, 0xc0000b8900, 0x3, 0x4, 0xc0000c8d00, ...)
	/home/henrik/dev/gemini/cmd/gemini/root.go:232 +0x134
main.Job(0x8a52a0, 0xc000022c80, 0xc000018500, 0xc000090ba0, 0x819bce, 0x6, 0xc000098e80, 0x1, 0x1, 0xc0000b8900, ...)
	/home/henrik/dev/gemini/cmd/gemini/root.go:264 +0x33e
created by main.runJob
	/home/henrik/dev/gemini/cmd/gemini/root.go:163 +0x1ed
```

Maybe the error lies elsewhere but this should go in regardless I believe.