### PR TITLE
marshalling: treat cql time type as time.Duration

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -26,6 +26,8 @@ func goType(t TypeInfo) reflect.Type {
 		return reflect.TypeOf(*new(string))
 	case TypeBigInt, TypeCounter:
 		return reflect.TypeOf(*new(int64))
+	case TypeTime:
+		return reflect.TypeOf(*new(time.Duration))
 	case TypeTimestamp:
 		return reflect.TypeOf(*new(time.Time))
 	case TypeBlob:
@@ -93,6 +95,8 @@ func getCassandraBaseType(name string) Type {
 		return TypeInt
 	case "tinyint":
 		return TypeTinyInt
+	case "time":
+		return TypeTime
 	case "timestamp":
 		return TypeTimestamp
 	case "uuid":
@@ -231,6 +235,8 @@ func getApacheCassandraType(class string) Type {
 		return TypeSmallInt
 	case "ByteType":
 		return TypeTinyInt
+	case "TimeType":
+		return TypeTime
 	case "DateType", "TimestampType":
 		return TypeTimestamp
 	case "UUIDType", "LexicalUUIDType":


### PR DESCRIPTION
After discussions it was proposed to treat time as Go time.Duration.
This makes it consistent with what time is in the spec despite it's name.

The discussion took place in https://github.com/gocql/gocql/pull/1283 which was about a panic from incorrectly handling of the cql type time.

The cassandra spec (https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v5.spec#L986) clearly frames this type as a "duration" although the name hints at a "time". It was agreed that using a `time.Duration` instead makes much sense and any cognitive mismatch was negligible. 