### PR TITLE
connection: Replaced sync.Pool with a channel

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -144,6 +144,14 @@ type ClusterConfig struct {
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
 
+	// The size of the internal stream request pool.
+	// Set it to something matching your expected concurrency.
+	// Setting it to a too low value will result in increased allocations but
+	// it will not block your application.
+	//
+	// (default: runtime.NumCPU()*1024)
+	StreamPoolSize int
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/session.go
+++ b/session.go
@@ -72,6 +72,8 @@ type Session struct {
 
 	closeMu  sync.RWMutex
 	isClosed bool
+
+	streamPool *callReqPool
 }
 
 var queryPool = &sync.Pool{
@@ -121,6 +123,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts)},
 		quit:            make(chan struct{}),
 		connectObserver: cfg.ConnectObserver,
+		streamPool:      newCallReqPool(cfg.StreamPoolSize),
 	}
 
 	s.schemaDescriber = newSchemaDescriber(s)


### PR DESCRIPTION
The internal sync.Pool lock was subject to contention.
This patch replaces the sync.Pool with a pool based on
a simple channel. The pool size can be configured by
the user through ClusterConfig::StreamPoolSize.

Fixes: #1287 