### PR TITLE
make session immuatable

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -124,17 +124,6 @@ func TestTracing(t *testing.T) {
 		t.Fatal("select: failed to obtain any tracing")
 	}
 
-	// also works from session tracer
-	session.SetTrace(trace)
-	trace.mu.Lock()
-	buf.Reset()
-	trace.mu.Unlock()
-	if err := session.Query(`SELECT id FROM trace WHERE id = ?`, 42).Scan(&value); err != nil {
-		t.Fatal("select:", err)
-	}
-	if buf.Len() == 0 {
-		t.Fatal("select: failed to obtain any tracing")
-	}
 }
 
 func TestObserve(t *testing.T) {

--- a/cluster.go
+++ b/cluster.go
@@ -144,6 +144,17 @@ type ClusterConfig struct {
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
 
+	// If set the tracer will be used for all queries. Alternativly it can be set of on a
+	// per query basis.
+	// default: nil
+	Tracer Tracer
+
+	// NextPagePrefetch sets the default threshold for pre-fetching new pages. If
+	// there are only p*pageSize rows remaining, the next page will be requested
+	// automatically. This value can also be changed on a per-query basis and
+	// the default value is 0.25.
+	NextPagePrefetch float64
+
 	// internal config for testing
 	disableControlConn bool
 }
@@ -175,6 +186,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
+		NextPagePrefetch:       0.25,
 	}
 	return cfg
 }


### PR DESCRIPTION
This removes the ability to change the consistency, tracer, page
prefetch and page size after the session has been created globally.
Instead they can continue to be change on a per query level. This allows
us to remove the RWMutex in query creation.

fixes #357 