### PR TITLE
prepared statements: reduce contentions

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1484,38 +1484,30 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 		t.Fatalf("insert into prepcachetest failed, error '%v'", err)
 	}
 
-	session.stmtsLRU.mu.Lock()
-	defer session.stmtsLRU.mu.Unlock()
-
-	//Make sure the cache size is maintained
-	if session.stmtsLRU.lru.Len() != session.stmtsLRU.lru.MaxEntries {
-		t.Fatalf("expected cache size of %v, got %v", session.stmtsLRU.lru.MaxEntries, session.stmtsLRU.lru.Len())
-	}
-
 	// Walk through all the configured hosts and test cache retention and eviction
 	for _, host := range session.cfg.Hosts {
-		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
-		if ok {
+		v := session.stmtsLRU.get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 0"))
+		if v == nil {
 			t.Errorf("expected first select to be purged but was in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
-		if !ok {
+		v = session.stmtsLRU.get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "SELECT id,mod FROM prepcachetest WHERE id = 1"))
+		if v == nil {
 			t.Errorf("exepected second select to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
-		if !ok {
+		v = session.stmtsLRU.get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "INSERT INTO prepcachetest (id,mod) VALUES (?, ?)"))
+		if v == nil {
 			t.Errorf("expected insert to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
-		if !ok {
+		v = session.stmtsLRU.get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "UPDATE prepcachetest SET mod = ? WHERE id = ?"))
+		if v == nil {
 			t.Errorf("expected update to be in cached for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
-		if !ok {
+		v = session.stmtsLRU.get(session.stmtsLRU.keyFor(host+":9042", session.cfg.Keyspace, "DELETE FROM prepcachetest WHERE id = ?"))
+		if v == nil {
 			t.Errorf("expected delete to be cached for host=%q", host)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/gocql/gocql
 require (
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+	github.com/minio/highwayhash v1.0.0
 	gopkg.in/inf.v0 v0.9.1
 )

--- a/go.modverify
+++ b/go.modverify
@@ -1,3 +1,0 @@
-github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
-github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
-gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/minio/highwayhash v1.0.0 h1:iMSDhgUILCr0TNm8LWlSjF8N0ZIj2qbO8WHp6Q/J2BA=
+github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564 h1:o6ENHFwwr1TZ9CUPQcfo1HGvLP1OPsPOTB7xCIOPNmU=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
+gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,64 +1,121 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/lru"
+	"encoding/hex"
 	"sync"
+
+	"github.com/gocql/gocql/internal/lru"
+	"github.com/minio/highwayhash"
 )
 
-const defaultMaxPreparedStmts = 1000
+const (
+	defaultMaxPreparedStmts = 1000
+	shardCount              = 256
+)
 
 // preparedLRU is the prepared statement cache
 type preparedLRU struct {
-	mu  sync.Mutex
-	lru *lru.Cache
+	shards [shardCount]*shard
+	key    []byte
+}
+
+type shard struct {
+	items *lru.Cache
+	lock  *sync.RWMutex
+}
+
+// newPreparedLRU creates and initializes a * preparedLRU instance.
+func newPreparedLRU(size int) *preparedLRU {
+	key, err := hex.DecodeString("000102030405060708090A0B0C0D0E0FF0E0D0C0B0A090807060504030201000")
+	if err != nil {
+		panic(err)
+	}
+	c := &preparedLRU{
+		key: key,
+	}
+	for i := 0; i < shardCount; i++ {
+		c.shards[i] = &shard{
+			items: lru.New(size),
+			lock:  new(sync.RWMutex),
+		}
+	}
+	return c
 }
 
 // Max adjusts the maximum size of the cache and cleans up the oldest records if
 // the new max is lower than the previous value. Not concurrency safe.
 func (p *preparedLRU) max(max int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	for p.lru.Len() > max {
-		p.lru.RemoveOldest()
+	for _, shard := range p.shards {
+		shard.lock.Lock()
+		for shard.items.Len() > max {
+			shard.items.RemoveOldest()
+		}
+		shard.items.MaxEntries = max
+		shard.lock.Unlock()
 	}
-	p.lru.MaxEntries = max
 }
 
 func (p *preparedLRU) clear() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	for p.lru.Len() > 0 {
-		p.lru.RemoveOldest()
+	for _, shard := range p.shards {
+		shard.lock.Lock()
+		if shard.items.Len() > 0 {
+			shard.items.RemoveOldest()
+		}
+		shard.lock.Unlock()
 	}
 }
 
 func (p *preparedLRU) add(key string, val *inflightPrepare) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.lru.Add(key, val)
+	shard := p.shard(key)
+	shard.lock.Lock()
+	shard.items.Add(key, val)
+	shard.lock.Unlock()
 }
 
 func (p *preparedLRU) remove(key string) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.lru.Remove(key)
+	shard := p.shard(key)
+	shard.lock.Lock()
+	ok := shard.items.Remove(key)
+	shard.lock.Unlock()
+	return ok
 }
 
 func (p *preparedLRU) execIfMissing(key string, fn func(lru *lru.Cache) *inflightPrepare) (*inflightPrepare, bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	shard := p.shard(key)
+	shard.lock.Lock()
+	defer shard.lock.Unlock()
 
-	val, ok := p.lru.Get(key)
+	val, ok := shard.items.Get(key)
 	if ok {
 		return val.(*inflightPrepare), true
 	}
 
-	return fn(p.lru), false
+	return fn(shard.items), false
 }
 
 func (p *preparedLRU) keyFor(addr, keyspace, statement string) string {
 	// TODO: maybe use []byte for keys?
 	return addr + keyspace + statement
+}
+
+func (c *preparedLRU) get(key string) *inflightPrepare {
+	shard := c.shard(key)
+	shard.lock.Lock()
+	defer shard.lock.Unlock()
+	if inflight, ok := shard.items.Get(key); ok {
+		return inflight.(*inflightPrepare)
+	}
+	return nil
+}
+
+func (c *preparedLRU) set(key string, val *inflightPrepare) {
+	shard := c.shard(key)
+	shard.lock.Lock()
+	shard.items.Add(key, val)
+	shard.lock.Unlock()
+}
+
+func (c *preparedLRU) shard(key string) (shard *shard) {
+	shardKey := highwayhash.Sum64([]byte(key), c.key) % shardCount
+	return c.shards[shardKey]
 }

--- a/session.go
+++ b/session.go
@@ -118,7 +118,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		prefetch:        0.25,
 		cfg:             cfg,
 		pageSize:        cfg.PageSize,
-		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts)},
+		stmtsLRU:        newPreparedLRU(cfg.MaxPreparedStmts),
 		quit:            make(chan struct{}),
 		connectObserver: cfg.ConnectObserver,
 	}


### PR DESCRIPTION
A sharded layer on top of the existing LRU cache dispatches the keys across 256 buckets.
The hashing used is Highwayhash which should provide accurate dispersion and sufficient speed.

This is a work in progress. It needs some cleanup and an analysis as to the hash key generation.

Fixes: #1291 