### PR TITLE
prepared statements: reduce contentions, alt 2

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql/internal/lru"
 	"github.com/gocql/gocql/internal/streams"
 )
 
@@ -954,10 +953,9 @@ type inflightPrepare struct {
 
 func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer) (*preparedStatment, error) {
 	stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
-	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
+	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func() *inflightPrepare {
 		flight := new(inflightPrepare)
 		flight.wg.Add(1)
-		lru.Add(stmtCacheKey, flight)
 		return flight
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/gocql/gocql
 
 require (
+	github.com/cornelk/hashmap v1.0.0
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	gopkg.in/inf.v0 v0.9.1

--- a/go.modverify
+++ b/go.modverify
@@ -1,3 +1,0 @@
-github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
-github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
-gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cornelk/hashmap v1.0.0 h1:jNHWycAM10SO5Ig76HppMQ69jnbqaziRpqVTNvAxdJQ=
+github.com/cornelk/hashmap v1.0.0/go.mod h1:8wbysTUDnwJGrPZ1Iwsou3m+An6sldFrJItjRhfegCw=
+github.com/dchest/siphash v1.1.0 h1:1Rs9eTUlZLPBEvV+2sTaM8O0NWn0ppbgqS7p11aWawI=
+github.com/dchest/siphash v1.1.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
+github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
+gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/session.go
+++ b/session.go
@@ -18,6 +18,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/cornelk/hashmap"
 	"github.com/gocql/gocql/internal/lru"
 )
 
@@ -118,7 +119,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		prefetch:        0.25,
 		cfg:             cfg,
 		pageSize:        cfg.PageSize,
-		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts)},
+		stmtsLRU:        &preparedLRU{cache: hashmap.New(uintptr(cfg.MaxPreparedStmts))},
 		quit:            make(chan struct{}),
 		connectObserver: cfg.ConnectObserver,
 	}


### PR DESCRIPTION
A lockfree hashmap is used in place of the current LRU cache. If this tradeoff is worth it
it gives a great boon to scalability.