### PR TITLE
prepared statements: reduce contentions, alt 3

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1484,9 +1484,6 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 		t.Fatalf("insert into prepcachetest failed, error '%v'", err)
 	}
 
-	session.stmtsLRU.mu.Lock()
-	defer session.stmtsLRU.mu.Unlock()
-
 	//Make sure the cache size is maintained
 	if session.stmtsLRU.lru.Len() != session.stmtsLRU.lru.MaxEntries {
 		t.Fatalf("expected cache size of %v, got %v", session.stmtsLRU.lru.MaxEntries, session.stmtsLRU.lru.Len())

--- a/cluster.go
+++ b/cluster.go
@@ -146,6 +146,11 @@ type ClusterConfig struct {
 
 	// internal config for testing
 	disableControlConn bool
+
+	// The time window that the prepared statement cache uses to avoid updating it's LRU list.
+	// For more info see: https://www.openmymind.net/High-Concurrency-LRU-Caching/
+	// Setting this to zero effectively disables this feature.
+	PreparedStmtWindow time.Duration
 }
 
 // NewCluster generates a new config for the default cluster implementation.
@@ -167,6 +172,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		NumConns:               2,
 		Consistency:            Quorum,
 		MaxPreparedStmts:       defaultMaxPreparedStmts,
+		PreparedStmtWindow:     defaultPreparedStmtsWindow,
 		MaxRoutingKeyInfo:      1000,
 		PageSize:               5000,
 		DefaultTimestamp:       true,

--- a/conn.go
+++ b/conn.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql/internal/lru"
 	"github.com/gocql/gocql/internal/streams"
 )
 
@@ -953,10 +952,9 @@ type inflightPrepare struct {
 
 func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer) (*preparedStatment, error) {
 	stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
-	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
+	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func() *inflightPrepare {
 		flight := new(inflightPrepare)
 		flight.wg.Add(1)
-		lru.Add(stmtCacheKey, flight)
 		return flight
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )
+
+go 1.13

--- a/internal/lru/lru.go
+++ b/internal/lru/lru.go
@@ -18,9 +18,13 @@ limitations under the License.
 // Package lru implements an LRU cache.
 package lru
 
-import "container/list"
+import (
+	"container/list"
+	"sync"
+	"time"
+)
 
-// Cache is an LRU cache. It is not safe for concurrent access.
+// Cache is an LRU cache. It is safe for concurrent access.
 //
 // This cache has been forked from github.com/golang/groupcache/lru, but
 // specialized with string keys to avoid the allocations caused by wrapping them
@@ -34,64 +38,130 @@ type Cache struct {
 	// executed when an entry is purged from the cache.
 	OnEvicted func(key string, value interface{})
 
-	ll    *list.List
-	cache map[string]*list.Element
+	window time.Duration
+	ll     *list.List
+	cache  map[string]*list.Element
+	mu     sync.RWMutex
 }
 
 type entry struct {
-	key   string
-	value interface{}
+	key       string
+	value     interface{}
+	timestamp time.Time
 }
 
 // New creates a new Cache.
 // If maxEntries is zero, the cache has no limit and it's assumed
 // that eviction is done by the caller.
-func New(maxEntries int) *Cache {
+// If window is zero the "windowed updates" of the LRU list will be disabled.
+// For further information on this technique see: https://www.openmymind.net/High-Concurrency-LRU-Caching/
+func New(maxEntries int, window time.Duration) *Cache {
 	return &Cache{
 		MaxEntries: maxEntries,
 		ll:         list.New(),
 		cache:      make(map[string]*list.Element),
+		window:     window,
 	}
 }
 
 // Add adds a value to the cache.
-func (c *Cache) Add(key string, value interface{}) {
-	if c.cache == nil {
-		c.cache = make(map[string]*list.Element)
-		c.ll = list.New()
-	}
-	if ee, ok := c.cache[key]; ok {
-		c.ll.MoveToFront(ee)
-		ee.Value.(*entry).value = value
+func (c *Cache) Add(key string, val interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ele, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ele)
+		ele.Value.(*entry).value = val
 		return
 	}
-	ele := c.ll.PushFront(&entry{key, value})
+	c.addLocked(key, val)
+}
+
+func (c *Cache) addLocked(key string, val interface{}) {
+	timestamp := time.Now()
+	ent := &entry{key, val, timestamp}
+	ele := c.ll.PushFront(ent)
 	c.cache[key] = ele
 	if c.MaxEntries != 0 && c.ll.Len() > c.MaxEntries {
-		c.RemoveOldest()
+		c.removeOldestLocked()
 	}
 }
 
 // Get looks up a key's value from the cache.
 func (c *Cache) Get(key string) (value interface{}, ok bool) {
-	if c.cache == nil {
-		return
+	timestamp := time.Now()
+
+	if c.window == 0 {
+		return c.getWithLock(key, timestamp)
 	}
-	if ele, hit := c.cache[key]; hit {
+
+	c.mu.RLock()
+	if ele, ok := c.cache[key]; ok {
+		ent := ele.Value.(*entry)
+		if timestamp.After(ent.timestamp.Add(c.window)) {
+			c.mu.RUnlock()
+			// We dropped the lock so we need to perform the lookup again.
+			return c.getWithLock(key, timestamp)
+		} else {
+			v := ent.value
+			c.mu.RUnlock()
+			return v, true
+		}
+	}
+	c.mu.RUnlock()
+	return
+}
+
+func (c *Cache) getWithLock(key string, timestamp time.Time) (interface{}, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ele, ok := c.cache[key]; ok {
+		ent := ele.Value.(*entry)
+		ent.timestamp = timestamp
 		c.ll.MoveToFront(ele)
+		return ent.value, true
+	} else {
+		return nil, false
+	}
+}
+
+// GetOrInsert either retrieves the current entry for the key or inserts the
+// provided value for the key.
+// It returns true if the value was loaded and false if the provided value
+// was stored.
+func (c *Cache) GetOrInsert(key string, val interface{}) (interface{}, bool) {
+	// Optimistically try a Get first
+	value, ok := c.Get(key)
+	if ok {
+		return value, ok
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// We need to check again
+	if ele, ok := c.cache[key]; ok {
 		return ele.Value.(*entry).value, true
 	}
-	return
+
+	c.addLocked(key, val)
+	return val, false
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	l := c.ll.Len()
+	c.mu.RUnlock()
+	return l
 }
 
 // Remove removes the provided key from the cache.
 func (c *Cache) Remove(key string) bool {
-	if c.cache == nil {
-		return false
-	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if ele, hit := c.cache[key]; hit {
-		c.removeElement(ele)
+		c.removeElementLocked(ele)
 		return true
 	}
 
@@ -100,28 +170,23 @@ func (c *Cache) Remove(key string) bool {
 
 // RemoveOldest removes the oldest item from the cache.
 func (c *Cache) RemoveOldest() {
-	if c.cache == nil {
-		return
-	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.removeOldestLocked()
+}
+
+func (c *Cache) removeOldestLocked() {
 	ele := c.ll.Back()
 	if ele != nil {
-		c.removeElement(ele)
+		c.removeElementLocked(ele)
 	}
 }
 
-func (c *Cache) removeElement(e *list.Element) {
+func (c *Cache) removeElementLocked(e *list.Element) {
 	c.ll.Remove(e)
 	kv := e.Value.(*entry)
 	delete(c.cache, kv.key)
 	if c.OnEvicted != nil {
 		c.OnEvicted(kv.key, kv.value)
 	}
-}
-
-// Len returns the number of items in the cache.
-func (c *Cache) Len() int {
-	if c.cache == nil {
-		return 0
-	}
-	return c.ll.Len()
 }

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,24 +1,24 @@
 package gocql
 
 import (
+	"time"
+
 	"github.com/gocql/gocql/internal/lru"
-	"sync"
 )
 
-const defaultMaxPreparedStmts = 1000
+const (
+	defaultMaxPreparedStmts    = 1000
+	defaultPreparedStmtsWindow = time.Second
+)
 
 // preparedLRU is the prepared statement cache
 type preparedLRU struct {
-	mu  sync.Mutex
 	lru *lru.Cache
 }
 
 // Max adjusts the maximum size of the cache and cleans up the oldest records if
 // the new max is lower than the previous value. Not concurrency safe.
 func (p *preparedLRU) max(max int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	for p.lru.Len() > max {
 		p.lru.RemoveOldest()
 	}
@@ -26,36 +26,27 @@ func (p *preparedLRU) max(max int) {
 }
 
 func (p *preparedLRU) clear() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	for p.lru.Len() > 0 {
 		p.lru.RemoveOldest()
 	}
 }
 
 func (p *preparedLRU) add(key string, val *inflightPrepare) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.lru.Add(key, val)
 }
 
 func (p *preparedLRU) remove(key string) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	return p.lru.Remove(key)
 }
 
-func (p *preparedLRU) execIfMissing(key string, fn func(lru *lru.Cache) *inflightPrepare) (*inflightPrepare, bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
+func (p *preparedLRU) execIfMissing(key string, fn func() *inflightPrepare) (*inflightPrepare, bool) {
 	val, ok := p.lru.Get(key)
 	if ok {
 		return val.(*inflightPrepare), true
 	}
 
-	return fn(p.lru), false
+	val, ok = p.lru.GetOrInsert(key, fn())
+	return val.(*inflightPrepare), ok
 }
 
 func (p *preparedLRU) keyFor(addr, keyspace, statement string) string {

--- a/session.go
+++ b/session.go
@@ -118,7 +118,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		prefetch:        0.25,
 		cfg:             cfg,
 		pageSize:        cfg.PageSize,
-		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts)},
+		stmtsLRU:        &preparedLRU{lru: lru.New(cfg.MaxPreparedStmts, cfg.PreparedStmtWindow)},
 		quit:            make(chan struct{}),
 		connectObserver: cfg.ConnectObserver,
 	}
@@ -128,7 +128,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	s.nodeEvents = newEventDebouncer("NodeEvents", s.handleNodeEvent)
 	s.schemaEvents = newEventDebouncer("SchemaEvents", s.handleSchemaEvent)
 
-	s.routingKeyInfoCache.lru = lru.New(cfg.MaxRoutingKeyInfo)
+	s.routingKeyInfoCache.lru = lru.New(cfg.MaxRoutingKeyInfo, time.Second)
 
 	s.hostSource = &ringDescriber{session: s}
 


### PR DESCRIPTION
A simple readlock in the fast path of prepared statements cache.
Protected by an additional read to ensure atomic creation of inflights.

Simplest possible fix. Solution thanks to @penberg and @rkuska and this has very good contention characteristics. It is also infinitely smaller in scope than the previous alternatives.

Fixes: #1291 