### PR TITLE
conn: Non blocking Done

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -895,9 +895,9 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 		timeoutCh = call.timer.C
 	}
 
-	var ctxDone <-chan struct{}
-	if ctx != nil {
-		ctxDone = ctx.Done()
+	if ctx == nil {
+		// Done channel is nil for top level context.
+		ctx = context.Background()
 	}
 
 	select {
@@ -917,7 +917,7 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 		close(call.timeout)
 		c.handleTimeout()
 		return nil, ErrTimeoutNoResponse
-	case <-ctxDone:
+	case <-ctx.Done():
 		close(call.timeout)
 		return nil, ctx.Err()
 	case <-c.quit:

--- a/go.modverify
+++ b/go.modverify
@@ -1,3 +1,0 @@
-github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
-github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
-gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=


### PR DESCRIPTION
Instead of having blocking call to Done (it uses Mutex under the hood)
we move Done() to select and initiate a new context in case the context
passed is nil.
This should lower the contention caused by calls to ctx.Done().


There is an option to either use `TODO` or `Background` context I wasn't sure which one to choose. I created this PR because I noticed `*(cancelCtx).Done` few times in contention profiles when context is being passed to underlying Queries.

Related to: https://github.com/gocql/gocql/issues/1291