### PR TITLE
Add information about Host to FrameHeaderObserver

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -604,6 +604,7 @@ func (c *Conn) recv() error {
 			Length:  int32(head.length),
 			Start:   headStartTime,
 			End:     headEndTime,
+			Host:    c.host,
 		})
 	}
 

--- a/frame.go
+++ b/frame.go
@@ -361,6 +361,9 @@ type ObservedFrameHeader struct {
 	Start time.Time
 	// EndHeader is the time we finished reading the frame header off the network connection.
 	End time.Time
+
+	// Host is Host of the connection the frame header was read from.
+	Host *HostInfo
 }
 
 func (f ObservedFrameHeader) String() string {


### PR DESCRIPTION
FrameHeaderObserver is the only observer that does not report
host currently, so add it there as well since Host is useful
if you want to tag the metrics by host/rack/dc/cluster.