### PR TITLE
SQL Scan implementation for UUID type

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -270,3 +270,43 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 	*u, err = ParseUUID(string(text))
 	return
 }
+
+// This satisfies the sql.Scanner interface.
+func (uuid *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case nil:
+		return nil
+
+	case string:
+		// if an empty UUID comes from a table, we return a null UUID
+		if src == "" {
+			return nil
+		}
+
+		// see Parse for required string format
+		u, err := ParseUUID(src)
+		if err != nil {
+			return fmt.Errorf("Scan: %v", err)
+		}
+
+		*uuid = u
+
+	case []byte:
+		// if an empty UUID comes from a table, we return a null UUID
+		if len(src) == 0 {
+			return nil
+		}
+
+		// assumes a simple slice of bytes if 16 bytes
+		// otherwise attempts to parse
+		if len(src) != 16 {
+			return uuid.Scan(string(src))
+		}
+		copy((*uuid)[:], src)
+
+	default:
+		return fmt.Errorf("Scan: unable to scan type %T into UUID", src)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This type now satisfies the SQL Scanner.

To use UUIDs in SQL, use the binary(16) for the designated column.
`n,_ := gocql.RandomUUID()`
`Exec(n.Bytes())`
`Scan(&n)`
