### PR TITLE
Adding ecaudit plugin to connection whitelist.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,6 +29,7 @@ var (
 		"com.instaclustr.cassandra.auth.SharedSecretAuthenticator",
 		"com.datastax.bdp.cassandra.auth.DseAuthenticator",
 		"io.aiven.cassandra.auth.AivenAuthenticator",
+		"com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator",
 	}
 )
 


### PR DESCRIPTION
This is a seemingly trivial change to a plugin whitelist. It uses a drop-in replacement to cassandra username/password auth to create an audit log for compliance purposes.

Edit: To address issue #1320 