### PR TITLE
Update supported Go versions to 1.11 and 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
       AUTH=false
 
 go:
-  - "1.10"
   - "1.11"
+  - "1.12"
 
 install:
   - ./install_test_deps.sh $TRAVIS_REPO_SLUG

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.10 | yes | yes | yes
 1.11 | yes | yes | yes
+1.12 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
As the README states, the current and previous version of Go is
supported, so tests should be run accordingly.

Also note that this commit removes Go 1.10, the last version
that does not support Go modules.

Thanks @dahankzter for the suggestion.