### PR TITLE
Also test latest 2.1 branch of cassandra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
   global:
     - GOMAXPROCS=2
   matrix:
+    - CASS=2.1.21
+      AUTH=true
     - CASS=2.2.13
       AUTH=true
     - CASS=2.2.13


### PR DESCRIPTION
The 2.1 release branch is [still supported until 4.0 comes out](http://cassandra.apache.org/download/#older-supported-releases), so continue to test against it to ensure compatibility with community supported releases of cassandra.