### PR TITLE
Test with latest go1.1{1,2} versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ env:
       AUTH=false
 
 go:
-  - "1.11"
-  - "1.12"
+  - 1.11.x
+  - 1.12.x
 
 install:
   - ./install_test_deps.sh $TRAVIS_REPO_SLUG


### PR DESCRIPTION
Go support policy is the latest minor release of the latest two major versions.

In travis, specifying "1.11" pins the test to the original go1.11 release.