### PR TITLE
Round robin fixes

### DIFF
--- a/policies_test.go
+++ b/policies_test.go
@@ -397,7 +397,7 @@ func TestHostPolicy_DCAwareRR(t *testing.T) {
 		p.AddHost(host)
 	}
 
-	// interleaved iteration should always increment the host
+	// interleaved iteration should always increment the host, try order ABBA
 	iterA := p.Pick(nil)
 	if actual := iterA(); actual.Info() != hosts[0] {
 		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
@@ -412,6 +412,23 @@ func TestHostPolicy_DCAwareRR(t *testing.T) {
 	if actual := iterA(); actual.Info() != hosts[1] {
 		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
 	}
+	// now the remote nodes should be returned, try order ABAB
+	if actual := iterA(); actual.Info() != hosts[2] {
+		t.Errorf("Expected hosts[2] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterB(); actual.Info() != hosts[3] {
+		t.Errorf("Expected hosts[3] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterA(); actual.Info() != hosts[3] {
+		t.Errorf("Expected hosts[3] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterB(); actual.Info() != hosts[2] {
+		t.Errorf("Expected hosts[2] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterA(); actual != nil {
+		t.Errorf("Expected nil but was hosts[%s]", actual.Info().HostID())
+	}
+
 	iterC := p.Pick(nil)
 	if actual := iterC(); actual.Info() != hosts[0] {
 		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
@@ -420,6 +437,11 @@ func TestHostPolicy_DCAwareRR(t *testing.T) {
 	if actual := iterC(); actual.Info() != hosts[1] {
 		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
 	}
+	if actual := iterC(); actual.Info() != hosts[3] {
+		t.Errorf("Expected hosts[3] but was hosts[%s]", actual.Info().HostID())
+	}
+
+	// test with no local hosts
 	p.RemoveHost(hosts[1])
 	iterD := p.Pick(nil)
 	if actual := iterD(); actual.Info() != hosts[2] {
@@ -429,4 +451,19 @@ func TestHostPolicy_DCAwareRR(t *testing.T) {
 		t.Errorf("Expected hosts[3] but was hosts[%s]", actual.Info().HostID())
 	}
 
+	// test with no remote hosts
+	p.AddHost(hosts[0])
+	p.AddHost(hosts[1])
+	p.RemoveHost(hosts[2])
+	p.RemoveHost(hosts[3])
+	iterE := p.Pick(nil)
+	if actual := iterE(); actual.Info() != hosts[1] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterE(); actual.Info() != hosts[0] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterE(); actual != nil {
+		t.Errorf("Expected nil but was hosts[%s]", actual.Info().HostID())
+	}
 }

--- a/policies_test.go
+++ b/policies_test.go
@@ -26,7 +26,9 @@ func TestHostPolicy_RoundRobin(t *testing.T) {
 		policy.AddHost(host)
 	}
 
-	// interleaved iteration should always increment the host
+	// interleaved iteration should always increment the host, first test
+	// (order ABBA).  In both this order and the one below, we have two calls
+	// to A and two calls to B, and A and B should both return both hosts.
 	iterA := policy.Pick(nil)
 	if actual := iterA(); actual.Info() != hosts[0] {
 		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
@@ -40,6 +42,26 @@ func TestHostPolicy_RoundRobin(t *testing.T) {
 	}
 	if actual := iterA(); actual.Info() != hosts[1] {
 		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterA(); actual != nil {
+		t.Errorf("Expected nil but was hosts[%s]", actual.Info().HostID())
+	}
+
+	// interleaved iteration should always increment the host, second test
+	// (order ABAB).
+	iterA2 := policy.Pick(nil)
+	if actual := iterA2(); actual.Info() != hosts[0] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
+	}
+	iterB2 := policy.Pick(nil)
+	if actual := iterB2(); actual.Info() != hosts[1] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterA2(); actual.Info() != hosts[1] {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actual.Info().HostID())
+	}
+	if actual := iterB2(); actual.Info() != hosts[0] {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actual.Info().HostID())
 	}
 
 	iterC := policy.Pick(nil)


### PR DESCRIPTION
There were some nasty issues with the round-robin host policies!

The round-robin host policy wasn't actually returning all the nodes to each iterator, you'd get queries where it would try some nodes twice, some not at all, because the iterators were using a shared index.

The DC-aware round-robin policy was similarly broken, and wouldn't even return any remote nodes: as long as there were any local nodes, it would never query a remote node, so if you were in a cluster where the local nodes went down the driver wouldn't fall back to anything else!

I've closely copied the strategy used by the Datastax Java driver, so I think these fixes are right.

Added tests (which fail without the code changes). See individual commit messages for further details.