### PR TITLE
Add go1.13 to the testing matrix / formatting updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 branches:
   only:
-  - master
+    - master
 
 env:
   global:
@@ -33,6 +33,7 @@ env:
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 
 install:
   - ./install_test_deps.sh $TRAVIS_REPO_SLUG
@@ -46,4 +47,4 @@ script:
   - go vet .
 
 notifications:
-  - email: false
+  email: false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
 1.11 | yes | yes | yes
 1.12 | yes | yes | yes
+1.13 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 

--- a/common_test.go
+++ b/common_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -32,7 +33,9 @@ var (
 func init() {
 	flag.Var(&flagCassVersion, "gocql.cversion", "the cassandra version being tested against")
 
-	flag.Parse()
+	if !strings.HasPrefix(runtime.Version(), "go1.13") {
+		flag.Parse()
+	}
 	clusterHosts = strings.Split(*flagCluster, ",")
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )
+
+go 1.13


### PR DESCRIPTION
This adds go1.13.x to the testing matrix.

This also adds small formatting fixes to the .travis.yml file (yay
linters).

I suggest dropping official go1.11 support once go1.13.1 is out.