### PR TITLE
Test with Go 1.13 and 1.12 in CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
       AUTH=false
 
 go:
-  - 1.11.x
   - 1.12.x
+  - 1.13.x
 
 install:
   - ./install_test_deps.sh $TRAVIS_REPO_SLUG

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.11 | yes | yes | yes
 1.12 | yes | yes | yes
+1.13 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1434,6 +1434,7 @@ func TestQueryInfo(t *testing.T) {
 func TestPrepare_PreparedCacheEviction(t *testing.T) {
 	const maxPrepared = 4
 
+	clusterHosts := getClusterHosts()
 	host := clusterHosts[0]
 	cluster := createCluster()
 	cluster.MaxPreparedStmts = maxPrepared
@@ -2739,6 +2740,7 @@ func TestDiscoverViaProxy(t *testing.T) {
 	// that is infact a proxy it discovers the rest of the ring behind the proxy
 	// and does not store the proxies address as a host in its connection pool.
 	// See https://github.com/gocql/gocql/issues/481
+	clusterHosts := getClusterHosts()
 	proxy, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("unable to create proxy listener: %v", err)

--- a/common_test.go
+++ b/common_test.go
@@ -26,15 +26,16 @@ var (
 	flagTimeout      = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
 
 	flagCassVersion cassVersion
-	clusterHosts    []string
 )
 
 func init() {
 	flag.Var(&flagCassVersion, "gocql.cversion", "the cassandra version being tested against")
 
-	flag.Parse()
-	clusterHosts = strings.Split(*flagCluster, ",")
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
+func getClusterHosts() []string {
+	return strings.Split(*flagCluster, ",")
 }
 
 func addSslOptions(cluster *ClusterConfig) *ClusterConfig {
@@ -72,6 +73,7 @@ func createTable(s *Session, table string) error {
 }
 
 func createCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
+	clusterHosts := getClusterHosts()
 	cluster := NewCluster(clusterHosts...)
 	cluster.ProtoVersion = *flagProto
 	cluster.CQLVersion = *flagCQL

--- a/integration_test.go
+++ b/integration_test.go
@@ -37,6 +37,7 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestGetHosts(t *testing.T) {
+	clusterHosts := getClusterHosts()
 	cluster := createCluster()
 	session := createSessionFromCluster(cluster, t)
 
@@ -49,6 +50,7 @@ func TestGetHosts(t *testing.T) {
 
 //TestRingDiscovery makes sure that you can autodiscover other cluster members when you seed a cluster config with just one node
 func TestRingDiscovery(t *testing.T) {
+	clusterHosts := getClusterHosts()
 	cluster := createCluster()
 	cluster.Hosts = clusterHosts[:1]
 


### PR DESCRIPTION
```
Fix tests in Go 1.13

The flag.Parse() in common-test.go init() causes errors to be raised
since package testing no longer registers it's flags in its own init(),
but instead provides testing.Init().

One option to fix this is to call testing.Init() just before calling
flag.Parse(). However, testing.Init() is not available in older Go
releases so we'd need to create separate versions of init() based on
build tags.

Instead, we can remove the call to flag.Parse() altogether as it was
only used to set clusterHosts variable and we defer parsing of
clusterHosts to a time when tests are executed. This version of code
runs both on Go 1.12 and Go 1.13.
```

```
Test with Go 1.13 and 1.12 in CI

As per the README: In general, the gocql team will focus on supporting
the current and previous versions of Go.
```