### PR TITLE
policy: roundrobbin should try all up hosts

### DIFF
--- a/topology.go
+++ b/topology.go
@@ -26,9 +26,20 @@ func (h tokenRingReplicas) replicasFor(t token) *hostTokens {
 	p := sort.Search(len(h), func(i int) bool {
 		return !h[i].token.Less(t)
 	})
+
+	// TODO: simplify this
+	if p < len(h) && h[p].token == t {
+		return &h[p]
+	}
+
+	p--
+
 	if p >= len(h) {
 		// rollover
 		p = 0
+	} else if p < 0 {
+		// rollunder
+		p = len(h) - 1
 	}
 
 	return &h[p]
@@ -100,7 +111,6 @@ func (s *simpleStrategy) replicaMap(tokenRing *tokenRing) tokenRingReplicas {
 		seen := make(map[*HostInfo]bool)
 
 		for j := 0; j < len(tokens) && len(replicas) < s.rf; j++ {
-			// TODO: need to ensure we dont add the same hosts twice
 			h := tokens[(i+j)%len(tokens)]
 			if !seen[h.host] {
 				replicas = append(replicas, h.host)


### PR DESCRIPTION
Instead of keep a global position to iterate around a ring of hosts just
shuffle all the hosts and return hosts which are up.

Fix finding the correct token in the token ring for host selection.

Simplify the tests so that they only test things they are inteded to
test, let other tests verify that DCAwareRR works for example.