### PR TITLE
session: bulk add hosts to TokenAwarePolicy on init

### DIFF
--- a/session.go
+++ b/session.go
@@ -221,9 +221,28 @@ func (s *Session) init() error {
 		hostMap[host.ConnectAddress().String()] = host
 	}
 
+	hosts = hosts[:0]
 	for _, host := range hostMap {
 		host = s.ring.addOrUpdate(host)
-		s.addNewNode(host)
+		if s.cfg.filterHost(host) {
+			continue
+		}
+
+		host.setState(NodeUp)
+		s.pool.addHost(host)
+
+		hosts = append(hosts, host)
+	}
+
+	type bulkAddHosts interface {
+		AddHosts([]*HostInfo)
+	}
+	if v, ok := s.policy.(bulkAddHosts); ok {
+		v.AddHosts(hosts)
+	} else {
+		for _, host := range hosts {
+			s.policy.AddHost(host)
+		}
 	}
 
 	// TODO(zariel): we probably dont need this any more as we verify that we


### PR DESCRIPTION
Adding a new host to the TokenAwarePolicy requires recomputing the
replica map, previously we would add each host one at a time which
requires regenerating the replica map for each host and discarding the
old one. Fix this to only calcaulte it once during init after adding all
the hosts in a bulk operation.