### PR TITLE
Increasing local test stability

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -59,7 +59,7 @@ func createTable(s *Session, table string) error {
 		return err
 	}
 
-	if err := s.Query(table).RetryPolicy(nil).Exec(); err != nil {
+	if err := s.Query(table).RetryPolicy(&SimpleRetryPolicy{}).Exec(); err != nil {
 		log.Printf("error creating table table=%q err=%v\n", table, err)
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )
+
+go 1.13


### PR DESCRIPTION
I get a lot of timeouts when running integration tests and simply setting a retry policy for the createTable() testing method seems to make it much more reliable.