### PR TITLE
Don't send connectAddress when looping over peers

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -650,7 +650,7 @@ func (r *ringDescriber) getHostInfo(ip net.IP, port int) (*HostInfo, error) {
 		}
 
 		for _, row := range rows {
-			h, err := r.session.hostInfoFromMap(row, &HostInfo{connectAddress: ip, port: port})
+			h, err := r.session.hostInfoFromMap(row, &HostInfo{port: port})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This ends up associating the wrong connectAddress with each peer since we
don't overwrite connectAddress inside hostInfoFromMap.

Fixes #1361