### PR TITLE
executor: mark a host with an error if we're given a host that is not up

### DIFF
--- a/query_executor.go
+++ b/query_executor.go
@@ -2,6 +2,7 @@ package gocql
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -92,7 +93,13 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery) *Iter {
 	var iter *Iter
 	for selectedHost != nil {
 		host := selectedHost.Info()
-		if host == nil || !host.IsUp() {
+		if host == nil {
+			selectedHost = hostIter()
+			continue
+		}
+
+		if !host.IsUp() {
+			selectedHost.Mark(errors.New("executor: host is not up"))
 			selectedHost = hostIter()
 			continue
 		}


### PR DESCRIPTION
Depending on the policy, it may keep picking the same node constantly until marked so it's worth marking nodes that are not up so SelectedHost interface implementations are aware of this fact.

I also wonder if we should mark the host if we could not fetch the pool or pick a connection. These seem like more internal gocql attributes which we might not want to penalise the host choice for?