### PR TITLE
Fix ExponentialReconnectionPolicy not incrementing correctly

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -945,7 +945,7 @@ type ExponentialReconnectionPolicy struct {
 }
 
 func (e *ExponentialReconnectionPolicy) GetInterval(currentRetry int) time.Duration {
-	return getExponentialTime(e.InitialInterval, math.MaxInt16*time.Second, e.GetMaxRetries())
+	return getExponentialTime(e.InitialInterval, math.MaxInt16*time.Second, currentRetry)
 }
 
 func (e *ExponentialReconnectionPolicy) GetMaxRetries() int {


### PR DESCRIPTION
`ExponentialReconnectionPolicy` doesn't honor the number of retries made, since it uses the wrong argument for the attempt count.

Test code:
```
package main

import (
	"fmt"
	"github.com/gocql/gocql"
)

func main() {
	policy := gocql.ExponentialReconnectionPolicy{
		MaxRetries: 10,
	}

	for index := 0; index < 10; index++ {
		fmt.Println(policy.GetInterval(index))
	}
}
```

Before changes:
```
51.210466028s
51.244050908s
51.216456005s
51.193771418s
51.192463749s
51.218682307s
51.156563701s
51.165651925s
51.159696951s
51.180091186s
```

After changes:
```
60.466028ms
144.050908ms
216.456005ms
393.771418ms
792.463749ms
1.618682307s
3.156563701s
6.365651925s
12.759696951s
25.580091186s
```