### PR TITLE
conn: unconditionally retry query execution on errUnprepared

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1192,11 +1192,8 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		return iter
 	case *RequestErrUnprepared:
 		stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, qry.stmt)
-		if c.session.stmtsLRU.remove(stmtCacheKey) {
-			return c.executeQuery(ctx, qry)
-		}
-
-		return &Iter{err: x, framer: framer}
+		c.session.stmtsLRU.remove(stmtCacheKey)
+		return c.executeQuery(ctx, qry)
 	case error:
 		return &Iter{err: x, framer: framer}
 	default:
@@ -1338,12 +1335,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 			key := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
 			c.session.stmtsLRU.remove(key)
 		}
-
-		if found {
-			return c.executeBatch(ctx, batch)
-		} else {
-			return &Iter{err: x, framer: framer}
-		}
+		return c.executeBatch(ctx, batch)
 	case *resultRowsFrame:
 		iter := &Iter{
 			meta:    x.meta,


### PR DESCRIPTION
The error handling for retrying or erroring out upon failure to find a server side prepared statement now simply attempts to prepare and execute again.

Fixes: #1252 