### PR TITLE
ensure framer is not nil before accessing customPayload

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
 Jorge Bay <jorgebg@apache.org>
+Adam Burk <amburk@gmail.com>

--- a/session.go
+++ b/session.go
@@ -1463,7 +1463,10 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 // custom QueryHandlers running in your C* cluster.
 // See https://datastax.github.io/java-driver/manual/custom_payloads/
 func (iter *Iter) GetCustomPayload() map[string][]byte {
-	return iter.framer.customPayload
+	if iter.framer != nil {
+		return iter.framer.customPayload
+	}
+	return nil
 }
 
 // Warnings returns any warnings generated if given in the response from Cassandra.


### PR DESCRIPTION
iter.GetCustomPayload() causes a nil panic if an error occurs on the cassandra query as iter.framer is nil. This PR adds a nil check of the framer before accessing customPayload and returns nil in the case where the framer is nil. This is similar to how Warnings() function works.
