### PR TITLE
Add a variant of WithTimestamp that accepts time.Time

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -41,10 +41,11 @@ func TestBatch_WithTimestamp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	micros := time.Now().UnixNano()/1e3 - 1000
+	timestamp := time.Now().Add(-1000 * time.Microsecond)
+	micros := timestamp.UnixNano() / 1e3
 
 	b := session.NewBatch(LoggedBatch)
-	b.WithTimestamp(micros)
+	b.WithTimestamp(timestamp)
 	b.Query("INSERT INTO batch_ts (id, val) VALUES (?, ?)", 1, "val")
 	if err := session.ExecuteBatch(b); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
With just timestamp int64 parameter, it's possible to mistake the unit
used for the timestamp, so we document that it's microseconds since UNIX
epoch.

Since Go users are likely to already have a time.Time value representing
the time instant used for the timestamp, I'm adding a method that
accepts a time.Time directly and takes care of the correct unit
conversion itself.