### PR TITLE
Fix goroutine stall on write to broken socket

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,4 @@ Thomas Meson <zllak@hycik.org>
 Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
 Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
+Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>

--- a/conn.go
+++ b/conn.go
@@ -745,6 +745,7 @@ type writeCoalescer struct {
 	cond    *sync.Cond
 	buffers net.Buffers
 	timeout time.Duration
+	flushes uint64
 
 	// result of the write
 	err error
@@ -767,6 +768,7 @@ func (w *writeCoalescer) flushLocked() {
 	if w.err != nil {
 		w.buffers = nil
 	}
+	w.flushes++
 	w.cond.Broadcast()
 }
 
@@ -801,7 +803,7 @@ func (w *writeCoalescer) Write(p []byte) (int, error) {
 	}
 
 	w.buffers = append(w.buffers, p)
-	for len(w.buffers) != 0 {
+	for flushes := w.flushes; w.flushes == flushes; {
 		w.cond.Wait()
 	}
 


### PR DESCRIPTION
imho, combination of
```go
	_, w.err = w.buffers.WriteTo(w.c)
	if w.err != nil {
		w.buffers = nil
	}
	w.cond.Broadcast()
```
and
```go
	for len(w.buffers) != 0 {
		w.cond.Wait()
	}
```
certainly have to lead to goroutine stall-ness on any write error.

Attempt to fix it by changing condition on "flush count".

If I'm mistaken, then excuse me for disturbing.