### PR TITLE
Add AwaitSchemaAgreement to Session

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -4,6 +4,7 @@ package gocql
 
 // This file groups integration tests where Cassandra has to be set up with some special integration variables
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -169,6 +170,15 @@ func TestCustomPayloadValues(t *testing.T) {
 		if !reflect.DeepEqual(customPayload, rCustomPayload) {
 			t.Fatal("The received custom payload should match the sent")
 		}
+	}
+}
+
+func TestSessionAwaitSchemaAgreement(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := session.AwaitSchemaAgreement(context.Background()); err != nil {
+		t.Fatalf("expected session.AwaitSchemaAgreement to not return an error but got '%v'", err)
 	}
 }
 


### PR DESCRIPTION
This adds `AwaitSchemaAgreement` to the `*gocql.Session` object by using the control connection and the already existing `awaitSchemaAgreement` functionality on the Connection object.

See https://github.com/scylladb/gocqlx/issues/106 and https://github.com/gocql/gocql/issues/1301 for details.