### PR TITLE
change CustomDialer type *net.Dialer to func(context.Context, string, string) (net.Conn, error)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,4 @@ Thomas Meson <zllak@hycik.org>
 Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
 Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
+Yusuke Kato <i.can.feel.gravity@gmail.com>

--- a/cluster.go
+++ b/cluster.go
@@ -5,6 +5,7 @@
 package gocql
 
 import (
+	"context"
 	"errors"
 	"net"
 	"time"
@@ -146,7 +147,7 @@ type ClusterConfig struct {
 
 	// Dialer will be used to establish all connections created for this Cluster.
 	// If not provided, a default dialer configured with ConnectTimeout will be used.
-	Dialer *net.Dialer
+	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 
 	// internal config for testing
 	disableControlConn bool


### PR DESCRIPTION
Hi, thanks for providing a great library

I want to make some changes to #1376 
@rinx did a great job at #1376 and likes his idea, but there's a problem with dialer customization.
In #1376 Dialer type is *net.Dialer, but net.Dialer is struct we can not customize dialer we can just configure only net.Dialer's field configuration,
I wish I could use `func(context.Context, string, string) (net.Conn, error)` type for Dialer instead of net.Dialer, but how about?

FYI:
in [go-redis](https://github.com/go-redis/redis) they also provide the [custom dialer functionality](https://github.com/go-redis/redis/blob/master/cluster.go#L56)
and the use `func(context.Context, string, string) (net.Conn, error)` type for configuration