### PR TITLE
Fix token aware host policy.

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -600,10 +600,11 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	if ht == nil {
 		host, _ := meta.tokenRing.GetHostForToken(token)
 		replicas = []*HostInfo{host}
-	} else if t.shuffleReplicas {
-		replicas = shuffleHosts(replicas)
 	} else {
 		replicas = ht.hosts
+		if t.shuffleReplicas {
+			replicas = shuffleHosts(replicas)
+		}
 	}
 
 	var (


### PR DESCRIPTION
With ShuffleReplicas enabled, we were shuffling an empty list of
replicas and not doing any token aware routing.