### PR TITLE
Allocation-Free Round Robin Policy (fixes #1401)

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -871,8 +871,6 @@ func roundRobbin(shift int, hosts ...[]*HostInfo) NextHost {
 
 			}
 		}
-
-		return nil
 	}
 }
 

--- a/policies.go
+++ b/policies.go
@@ -342,14 +342,6 @@ func (r *roundRobinHostPolicy) KeyspaceChanged(KeyspaceUpdateEvent) {}
 func (r *roundRobinHostPolicy) SetPartitioner(partitioner string)   {}
 func (r *roundRobinHostPolicy) Init(*Session)                       {}
 
-var (
-	randPool = sync.Pool{
-		New: func() interface{} {
-			return rand.New(randSource())
-		},
-	}
-)
-
 func (r *roundRobinHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&r.lastUsedHostIdx, 1)
 	return roundRobbin(int(nextStartOffset), r.hosts.get())

--- a/policies.go
+++ b/policies.go
@@ -6,8 +6,6 @@ package gocql
 
 import (
 	"context"
-	crand "crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -837,20 +835,6 @@ func (d *dcAwareRR) RemoveHost(host *HostInfo) {
 
 func (d *dcAwareRR) HostUp(host *HostInfo)   { d.AddHost(host) }
 func (d *dcAwareRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
-
-var randSeed int64
-
-func init() {
-	p := make([]byte, 8)
-	if _, err := crand.Read(p); err != nil {
-		panic(err)
-	}
-	randSeed = int64(binary.BigEndian.Uint64(p))
-}
-
-func randSource() rand.Source {
-	return rand.NewSource(atomic.AddInt64(&randSeed, 1))
-}
 
 func roundRobbin(hosts []*HostInfo, startOffset int) NextHost {
 	return func() SelectedHost {


### PR DESCRIPTION
Copy-free and allocation-free version of round robin.

Uses offset increased by atomic package to select next query destination.

Fixes memory allocation in #1401 downing it to zero.