### PR TITLE
Remove tokenRing.GetHostForPartitionKey

### DIFF
--- a/token.go
+++ b/token.go
@@ -195,14 +195,6 @@ func (t *tokenRing) String() string {
 	return string(buf.Bytes())
 }
 
-func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, endToken token) {
-	if t == nil {
-		return nil, nil
-	}
-
-	return t.GetHostForToken(t.partitioner.Hash(partitionKey))
-}
-
 func (t *tokenRing) GetHostForToken(token token) (host *HostInfo, endToken token) {
 	if t == nil || len(t.tokens) == 0 {
 		return nil, nil

--- a/token_test.go
+++ b/token_test.go
@@ -204,9 +204,6 @@ func TestTokenRing_Nil(t *testing.T) {
 	if host, endToken := ring.GetHostForToken(nil); host != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
-	if host, endToken := ring.GetHostForPartitionKey(nil); host != nil || endToken != nil {
-		t.Error("Expected nil for nil token ring")
-	}
 }
 
 // Test of the recognition of the partitioner class


### PR DESCRIPTION
This function is not used anymore.