### PR TITLE
Add ExponentialReconnectionPolicy.MaxInterval

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -953,10 +953,15 @@ func (c *ConstantReconnectionPolicy) GetMaxRetries() int {
 type ExponentialReconnectionPolicy struct {
 	MaxRetries      int
 	InitialInterval time.Duration
+	MaxInterval     time.Duration
 }
 
 func (e *ExponentialReconnectionPolicy) GetInterval(currentRetry int) time.Duration {
-	return getExponentialTime(e.InitialInterval, math.MaxInt16*time.Second, currentRetry)
+	max := e.MaxInterval
+	if max < e.InitialInterval {
+		max = math.MaxInt16 * time.Second
+	}
+	return getExponentialTime(e.InitialInterval, max, currentRetry)
 }
 
 func (e *ExponentialReconnectionPolicy) GetMaxRetries() int {


### PR DESCRIPTION
since the default of around every 9 hours is a bit too high for most use cases.

e.g. you actually want to give the ops team up to 24 hours to recover a
node, but want to confirm normal operations quickly after they are done.