### PR TITLE
conn: add skip prepare for control queries

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1086,7 +1086,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		info  *preparedStatment
 	)
 
-	if qry.shouldPrepare() {
+	if !qry.skipPrepare && qry.shouldPrepare() {
 		// Prepare all DML queries. Other queries can not be prepared.
 		var err error
 		info, err = c.prepareStatement(ctx, qry.stmt, qry.trace)
@@ -1361,6 +1361,8 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 func (c *Conn) query(ctx context.Context, statement string, values ...interface{}) (iter *Iter) {
 	q := c.session.Query(statement, values...).Consistency(One)
 	q.trace = nil
+	q.skipPrepare = true
+	q.disableSkipMetadata = true
 	return c.executeQuery(ctx, q)
 }
 

--- a/session.go
+++ b/session.go
@@ -809,6 +809,10 @@ type Query struct {
 
 	// getKeyspace is field so that it can be overriden in tests
 	getKeyspace func() string
+
+	// used by control conn queries to prevent triggering a write to systems
+	// tables in AWS MCS see
+	skipPrepare bool
 }
 
 func (q *Query) defaultsFromSession() {


### PR DESCRIPTION
Control queries only ever do reads on system tables but AWS MCS treats a
prepare as write which it blocks on system tables. We can avoid doing
prepares on selects as long as we get the result metadata.

fixes #1389