### PR TITLE
Randomising initial offset as per comments in #1401

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -329,7 +329,9 @@ type NextHost func() SelectedHost
 // RoundRobinHostPolicy is a round-robin load balancing policy, where each host
 // is tried sequentially for each query.
 func RoundRobinHostPolicy() HostSelectionPolicy {
-	return &roundRobinHostPolicy{}
+	return &roundRobinHostPolicy{
+		lastUsedHostIdx: rand.Uint64(),
+	}
 }
 
 type roundRobinHostPolicy struct {


### PR DESCRIPTION
As @nightlyone mentioned, zero-offset may be suboptimal in hypothetical scenario of multiple clients coming into server at a same time.

While this might be very unlikely scenario, the fix is easy and makes no harm. 

Let's pick initial offset randomly (only first time).