### PR TITLE
allow tokenAware policy to handle keyspace with skipped dcs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,4 @@ Thomas Meson <zllak@hycik.org>
 Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
 Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
+Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>

--- a/topology_test.go
+++ b/topology_test.go
@@ -90,76 +90,86 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 	}
 	sort.Sort(&tokenRing{tokens: tokens})
 
-	strat := &networkTopology{
-		dcs: map[string]int{
-			"dc1": 1,
-			"dc2": 2,
-			"dc3": 3,
+	strats := []*networkTopology{
+		&networkTopology{
+			dcs: map[string]int{
+				"dc1": 1,
+				"dc2": 2,
+				"dc3": 3,
+			},
+		},
+		&networkTopology{
+			dcs: map[string]int{
+				"dc2": 2,
+				"dc3": 3,
+			},
 		},
 	}
 
-	var expReplicas int
-	for _, rf := range strat.dcs {
-		expReplicas += rf
-	}
-
-	tokenReplicas := strat.replicaMap(&tokenRing{hosts: hosts, tokens: tokens})
-	if len(tokenReplicas) != len(tokens) {
-		t.Fatalf("expected replica map to have %d items but has %d", len(tokens), len(tokenReplicas))
-	}
-	if !sort.IsSorted(tokenReplicas) {
-		t.Fatal("replica map was not sorted by token")
-	}
-
-	for token, replicas := range tokenReplicas {
-		if len(replicas.hosts) != expReplicas {
-			t.Fatalf("expected to have %d replicas got %d for token=%v", expReplicas, len(replicas.hosts), token)
+	for _, strat := range strats {
+		var expReplicas int
+		for _, rf := range strat.dcs {
+			expReplicas += rf
 		}
-	}
 
-	for dc, rf := range strat.dcs {
-		dcTokens := dcRing[dc]
-		for i, th := range dcTokens {
-			token := th.token
-			allReplicas := tokenReplicas.replicasFor(token)
-			if allReplicas.token != token {
-				t.Fatalf("token %v not in replica map", token)
+		tokenReplicas := strat.replicaMap(&tokenRing{hosts: hosts, tokens: tokens})
+		if needTokens := hostsPerDC * len(strat.dcs); len(tokenReplicas) != needTokens {
+			t.Fatalf("expected replica map to have %d items but has %d", needTokens, len(tokenReplicas))
+		}
+		if !sort.IsSorted(tokenReplicas) {
+			t.Fatal("replica map was not sorted by token")
+		}
+
+		for token, replicas := range tokenReplicas {
+			if len(replicas.hosts) != expReplicas {
+				t.Fatalf("expected to have %d replicas got %d for token=%v", expReplicas, len(replicas.hosts), token)
 			}
+		}
 
-			var replicas []*HostInfo
-			for _, replica := range allReplicas.hosts {
-				if replica.dataCenter == dc {
-					replicas = append(replicas, replica)
+		for dc, rf := range strat.dcs {
+			dcTokens := dcRing[dc]
+			for i, th := range dcTokens {
+				token := th.token
+				allReplicas := tokenReplicas.replicasFor(token)
+				if allReplicas.token != token {
+					t.Fatalf("token %v not in replica map", token)
 				}
-			}
 
-			if len(replicas) != rf {
-				t.Fatalf("expected %d replicas in dc %q got %d", rf, dc, len(replicas))
-			}
+				var replicas []*HostInfo
+				for _, replica := range allReplicas.hosts {
+					if replica.dataCenter == dc {
+						replicas = append(replicas, replica)
+					}
+				}
 
-			var lastRack string
-			for j, replica := range replicas {
-				// expected is in the next rack
-				var exp *HostInfo
-				if lastRack == "" {
-					// primary, first replica
-					exp = dcTokens[(i+j)%len(dcTokens)].host
-				} else {
-					for k := 0; k < len(dcTokens); k++ {
-						// walk around the ring from i + j to find the next host the
-						// next rack
-						p := (i + j + k) % len(dcTokens)
-						h := dcTokens[p].host
-						if h.rack != lastRack {
-							exp = h
-							break
+				if len(replicas) != rf {
+					t.Fatalf("expected %d replicas in dc %q got %d", rf, dc, len(replicas))
+				}
+
+				var lastRack string
+				for j, replica := range replicas {
+					// expected is in the next rack
+					var exp *HostInfo
+					if lastRack == "" {
+						// primary, first replica
+						exp = dcTokens[(i+j)%len(dcTokens)].host
+					} else {
+						for k := 0; k < len(dcTokens); k++ {
+							// walk around the ring from i + j to find the next host the
+							// next rack
+							p := (i + j + k) % len(dcTokens)
+							h := dcTokens[p].host
+							if h.rack != lastRack {
+								exp = h
+								break
+							}
+						}
+						if exp.rack == lastRack {
+							panic("no more racks")
 						}
 					}
-					if exp.rack == lastRack {
-						panic("no more racks")
-					}
+					lastRack = replica.rack
 				}
-				lastRack = replica.rack
 			}
 		}
 	}


### PR DESCRIPTION
Keyspace could define replication that doesn't cover all datacenters.
More over: such case certainly happens when new data is added to cluster.

This commit fixes handling of this situation in networkTopology replicaMap
by skipping tokens from excess datacenters.

fixes #1349