### PR TITLE
CreateSession use statement consistency

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1232,7 +1232,7 @@ func (c *Conn) AvailableStreams() int {
 
 func (c *Conn) UseKeyspace(keyspace string) error {
 	q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
-	q.params.consistency = Any
+	q.params.consistency = c.session.cons
 
 	framer, err := c.exec(c.ctx, q, nil)
 	if err != nil {


### PR DESCRIPTION
The CreateSession with consistency and keyspace supplied will trigger a `use keyspace` query.
However, this query does not use the consistency supplied, instead it uses `Consistency.Any`.

This cause issue when using it with AWS MCS where only `Consistency.LocalOne` or `Consistency.LocalQuorum` is accepted for read statement