### PR TITLE
Add support for Amazon MCS 

### DIFF
--- a/token.go
+++ b/token.go
@@ -152,6 +152,8 @@ func newTokenRing(partitioner string, hosts []*HostInfo) (*tokenRing, error) {
 		tokenRing.partitioner = orderedPartitioner{}
 	} else if strings.HasSuffix(partitioner, "RandomPartitioner") {
 		tokenRing.partitioner = randomPartitioner{}
+	} else if strings.HasSuffix(partitioner, "DefaultPartitioner") {
+		tokenRing.partitioner = orderedPartitioner{}
 	} else {
 		return nil, fmt.Errorf("Unsupported partitioner '%s'", partitioner)
 	}


### PR DESCRIPTION
Full partitioner name: com.amazonaws.cassandra.DefaultPartitioner