### PR TITLE
Parse smallint data type in metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,3 +114,4 @@ Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
 Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
+Jorge Bay <jorgebg@apache.org>

--- a/helpers.go
+++ b/helpers.go
@@ -85,10 +85,14 @@ func getCassandraBaseType(name string) Type {
 		return TypeBoolean
 	case "counter":
 		return TypeCounter
+	case "date":
+		return TypeDate
 	case "decimal":
 		return TypeDecimal
 	case "double":
 		return TypeDouble
+	case "duration":
+		return TypeDuration
 	case "float":
 		return TypeFloat
 	case "int":

--- a/helpers.go
+++ b/helpers.go
@@ -93,6 +93,8 @@ func getCassandraBaseType(name string) Type {
 		return TypeFloat
 	case "int":
 		return TypeInt
+	case "smallint":
+		return TypeSmallInt
 	case "tinyint":
 		return TypeTinyInt
 	case "time":

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -185,6 +185,20 @@ func TestGetCassandraType(t *testing.T) {
 		},
 		{"smallint", NativeType{typ: TypeSmallInt}},
 		{"tinyint", NativeType{typ: TypeTinyInt}},
+		{"duration", NativeType{typ: TypeDuration}},
+		{"date", NativeType{typ: TypeDate}},
+		{
+			"list<date>", CollectionType{
+				NativeType: NativeType{typ: TypeList},
+				Elem:       NativeType{typ: TypeDate},
+			},
+		},
+		{
+			"set<duration>", CollectionType{
+				NativeType: NativeType{typ: TypeSet},
+				Elem:       NativeType{typ: TypeDuration},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -171,6 +171,20 @@ func TestGetCassandraType(t *testing.T) {
 				Elem: NativeType{typ: TypeInt},
 			},
 		},
+		{
+			"set<smallint>", CollectionType{
+				NativeType: NativeType{typ: TypeSet},
+				Elem:       NativeType{typ: TypeSmallInt},
+			},
+		},
+		{
+			"list<tinyint>", CollectionType{
+				NativeType: NativeType{typ: TypeList},
+				Elem:       NativeType{typ: TypeTinyInt},
+			},
+		},
+		{"smallint", NativeType{typ: TypeSmallInt}},
+		{"tinyint", NativeType{typ: TypeTinyInt}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #1430 .

Small fix and added some more coverage for `tinyint` as well.