### PR TITLE
Add eof checks to unmarshalList/Map

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1559,6 +1559,9 @@ func unmarshalList(info TypeInfo, data []byte, value interface{}) error {
 				return err
 			}
 			data = data[p:]
+			if len(data) < m {
+				return unmarshalErrorf("unmarshal list: unexpected eof")
+			}
 			if err := Unmarshal(listInfo.Elem, data[:m], rv.Index(i).Addr().Interface()); err != nil {
 				return err
 			}
@@ -1653,6 +1656,9 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 			return err
 		}
 		data = data[p:]
+		if len(data) < m {
+			return unmarshalErrorf("unmarshal map: unexpected eof")
+		}
 		key := reflect.New(t.Key())
 		if err := Unmarshal(mapInfo.Key, data[:m], key.Interface()); err != nil {
 			return err
@@ -1664,6 +1670,9 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 			return err
 		}
 		data = data[p:]
+		if len(data) < m {
+			return unmarshalErrorf("unmarshal map: unexpected eof")
+		}
 		val := reflect.New(t.Elem())
 		if err := Unmarshal(mapInfo.Elem, data[:m], val.Interface()); err != nil {
 			return err

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -729,6 +729,19 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
+			NativeType: NativeType{proto: 3, typ: TypeList},
+			Elem:       NativeType{proto: 3, typ: TypeInt},
+		},
+		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
+		func() *[]int {
+			l := []int{1, 2}
+			return &l
+		}(),
+		nil,
+		nil,
+	},
+	{
+		CollectionType{
 			NativeType: NativeType{proto: 2, typ: TypeList},
 			Elem:       NativeType{proto: 2, typ: TypeInt},
 		},
@@ -1209,6 +1222,38 @@ var unmarshalTests = []struct {
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x00"),
 		AliasUint32(0),
 		UnmarshalError("unmarshal int: value 4294967296 out of range for gocql.AliasUint32"),
+	},
+	{
+		CollectionType{
+			NativeType: NativeType{proto: 3, typ: TypeList},
+			Elem:       NativeType{proto: 3, typ: TypeInt},
+		},
+		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00"), // truncated data
+		func() *[]int {
+			l := []int{1, 2}
+			return &l
+		}(),
+		UnmarshalError("unmarshal list: unexpected eof"),
+	},
+	{
+		CollectionType{
+			NativeType: NativeType{proto: 2, typ: TypeMap},
+			Key:        NativeType{proto: 2, typ: TypeVarchar},
+			Elem:       NativeType{proto: 2, typ: TypeInt},
+		},
+		[]byte("\x00\x01\x00\x03fo"),
+		map[string]int{"foo": 1},
+		UnmarshalError("unmarshal map: unexpected eof"),
+	},
+	{
+		CollectionType{
+			NativeType: NativeType{proto: 2, typ: TypeMap},
+			Key:        NativeType{proto: 2, typ: TypeVarchar},
+			Elem:       NativeType{proto: 2, typ: TypeInt},
+		},
+		[]byte("\x00\x01\x00\x03foo\x00\x04\x00\x00"),
+		map[string]int{"foo": 1},
+		UnmarshalError("unmarshal map: unexpected eof"),
 	},
 }
 


### PR DESCRIPTION
There were missing checks for length which could lead to panic when the
server sends malformed data. This commits adds the missing checks.