### PR TITLE
Adding ecaudit.auth.AuditAuthenticator to connection whitelist.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -31,6 +31,7 @@ var (
 		"io.aiven.cassandra.auth.AivenAuthenticator",
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator",
 		"com.amazon.helenus.auth.HelenusAuthenticator",
+		"com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator",
 	}
 )
 


### PR DESCRIPTION
To address issue https://github.com/gocql/gocql/issues/1440.
This is a trivial change to add a new authenticator of an existing plugin - ecaudit to the whitelist.