### PR TITLE
fix tuple unmarshaling

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1951,16 +1951,22 @@ func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
 		}
 
 		for i, elem := range tuple.Elems {
-			m := readInt(data)
-			data = data[4:]
+			var p []byte
+			if len(data) > 4 {
+				p, data = readBytes(data)
+			}
 
 			v := elem.New()
-			if err := Unmarshal(elem, data[:m], v); err != nil {
+			if err := Unmarshal(elem, p, v); err != nil {
 				return err
 			}
-			rv.Field(i).Set(reflect.ValueOf(v).Elem())
 
-			data = data[m:]
+			switch rv.Field(i).Kind() {
+			case reflect.Ptr:
+				rv.Field(i).Set(reflect.ValueOf(v))
+			default:
+				rv.Field(i).Set(reflect.ValueOf(v).Elem())
+			}
 		}
 
 		return nil
@@ -1975,16 +1981,22 @@ func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
 		}
 
 		for i, elem := range tuple.Elems {
-			m := readInt(data)
-			data = data[4:]
+			var p []byte
+			if len(data) > 4 {
+				p, data = readBytes(data)
+			}
 
 			v := elem.New()
-			if err := Unmarshal(elem, data[:m], v); err != nil {
+			if err := Unmarshal(elem, p, v); err != nil {
 				return err
 			}
-			rv.Index(i).Set(reflect.ValueOf(v).Elem())
 
-			data = data[m:]
+			switch rv.Index(i).Kind() {
+			case reflect.Ptr:
+				rv.Index(i).Set(reflect.ValueOf(v))
+			default:
+				rv.Index(i).Set(reflect.ValueOf(v).Elem())
+			}
 		}
 
 		return nil


### PR DESCRIPTION
There are two problems.

First, tuples with a null value are not handled properly which results in a
panic:

    panic: runtime error: slice bounds out of range [:-1]

    goroutine 1 [running]:
    github.com/gocql/gocql.unmarshalTuple(0x769880, 0xc0000e8cc0, 0xc0000ae83a, 0x10, 0x4a, 0xc000186540, 0xc000190480, 0xc000190480, 0x16)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:1950 +0x1276
    github.com/gocql/gocql.Unmarshal(0x769880, 0xc0000e8cc0, 0xc0000ae836, 0x10, 0x4a, 0xc000186540, 0xc000190480, 0xc0000e8cc0, 0xc0000ae832)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:167 +0xd56
    github.com/gocql/gocql.unmarshalMap(0x769800, 0xc0000e8d00, 0xc0000ae836, 0x10, 0x4e, 0x698740, 0xc000190450, 0x0, 0x677f11)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:1669 +0x8fb
    github.com/gocql/gocql.Unmarshal(0x769800, 0xc0000e8d00, 0xc0000ae828, 0x1e, 0x58, 0x698740, 0xc000190450, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:159 +0xcbf
    github.com/gocql/gocql.scanColumn(0xc0000ae828, 0x1e, 0x58, 0xc0000b0988, 0x6, 0xc0000b09a0, 0xc, 0xc0000b09b0, 0x4, 0x769800, ...)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1314 +0x274
    github.com/gocql/gocql.(*Iter).Scan(0xc0001963f0, 0xc000190460, 0x2, 0x2, 0x1)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1414 +0x2e5
    main.main()
            /home/vincent/tmp/gocql-tuple-map/main.go:90 +0x9cc

It panics when unmarshaling into a struct or into an array/slice.

Second, the unmarshaling code does not work with pointer fields in a
struct or pointer elements in an array/slice which results in a panic:

    panic: reflect.Set: value of type time.Time is not assignable to type *time.Time

    goroutine 1 [running]:
    reflect.Value.assignTo(0x6fa700, 0xc000282280, 0x199, 0x7026c8, 0xb, 0x6fc0e0, 0x0, 0x0, 0x6fc0e0, 0xc000282280)
            /usr/local/go/src/reflect/value.go:2403 +0x426
    reflect.Value.Set(0x6fc0e0, 0xc0002821b8, 0x196, 0x6fa700, 0xc000282280, 0x199)
            /usr/local/go/src/reflect/value.go:1532 +0xbd
    github.com/gocql/gocql.unmarshalTuple(0x7698c0, 0xc000384100, 0xc0003aa0b6, 0x10, 0x4a, 0xc00028c1c0, 0xc0002821a0, 0xc0002821a0, 0x16)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:1952 +0xf06
    github.com/gocql/gocql.Unmarshal(0x7698c0, 0xc000384100, 0xc0003aa0b6, 0x10, 0x4a, 0xc00028c1c0, 0xc0002821a0, 0xc000384100, 0xc0003aa0b2)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:166 +0xd56
    github.com/gocql/gocql.unmarshalMap(0x769840, 0xc000384140, 0xc0003aa0b6, 0x10, 0x4e, 0x698720, 0xc000282170, 0x0, 0x677e51)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:1668 +0x8fb
    github.com/gocql/gocql.Unmarshal(0x769840, 0xc000384140, 0xc0003aa0a8, 0x1e, 0x58, 0x698720, 0xc000282170, 0x0, 0x0)
            /home/vincent/dev/go/src/github.com/gocql/gocql/marshal.go:158 +0xcbf
    github.com/gocql/gocql.scanColumn(0xc0003aa0a8, 0x1e, 0x58, 0xc000382018, 0x6, 0xc000382030, 0xc, 0xc000382040, 0x4, 0x769840, ...)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1314 +0x274
    github.com/gocql/gocql.(*Iter).Scan(0xc00029a120, 0xc000282180, 0x2, 0x2, 0x1)
            /home/vincent/dev/go/src/github.com/gocql/gocql/session.go:1414 +0x2e5
    main.main()
            /home/vincent/tmp/gocql-tuple-map/main.go:90 +0x9cc

This commit fixes both problems.

You can reproduce the panics with the following code:
```
package main

import (
	"flag"
	"log"
	"time"

	"github.com/gocql/gocql"
)

func main() {
	var (
		flNilDate          = flag.Bool("nil-date", false, "use a nil date")
		flUnmarshalInArray = flag.Bool("unmarshal-in-array", false, "unmarshal in an array")
	)

	flag.Parse()

	const schema = `CREATE TABLE IF NOT EXISTS foobar.map_of_tuple (id uuid PRIMARY KEY, data map<smallint, frozen<tuple<timestamp, timestamp>>>)`

	cfg := gocql.NewCluster("localhost:9042")

	session, err := cfg.CreateSession()
	if err != nil {
		log.Fatal(err)
	}

	err = session.Query(schema).Exec()
	if err != nil {
		log.Fatal(err)
	}

	id, _ := gocql.RandomUUID()

	switch {
	case *flNilDate:
		now := time.Now().Add(-2000 * time.Hour)
		myTuple := struct {
			ID   time.Time
			Date *time.Time
		}{now, nil}

		err = session.Query(`update foobar.map_of_tuple set data[?] = (?, ?) where id = ?`, 20, myTuple.ID, myTuple.Date, id).Exec()
		if err != nil {
			log.Fatal(err)
		}

	default:
		before := time.Now().Add(-2000 * time.Hour)
		now := time.Now()

		myTuple := struct {
			ID   time.Time
			Date *time.Time
		}{before, &now}

		err = session.Query(`update foobar.map_of_tuple set data[?] = (?, ?) where id = ?`, 20, myTuple.ID, myTuple.Date, id).Exec()
		if err != nil {
			log.Fatal(err)
		}
	}

	//

	iter := session.Query(`select id, data from foobar.map_of_tuple where id = ?`, id).Iter()

	switch {
	case *flUnmarshalInArray:
		var row struct {
			id   gocql.UUID
			data map[int][2]*time.Time
		}

		iter.Scan(&row.id, &row.data)
		if err := iter.Close(); err != nil {
			log.Fatal(err)
		}

		log.Printf("id: %v data: %+v", id, row.data)

	default:
		var row struct {
			id   gocql.UUID
			data map[int]struct {
				ID   time.Time
				Date *time.Time
			}
		}

		iter.Scan(&row.id, &row.data)
		if err := iter.Close(); err != nil {
			log.Fatal(err)
		}

		log.Printf("id: %v data: %+v", id, row.data)
	}

}
```