### PR TITLE
Conn.close calling Session ObserveDisconnect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/inf.v0 v0.9.1
 )
 

--- a/session.go
+++ b/session.go
@@ -2022,10 +2022,22 @@ type ObservedConnect struct {
 	Err error
 }
 
+type ObservedDisconnect struct {
+	// Host is the information about the host about to connect
+	Host *HostInfo
+
+	Start time.Time // time immediately before the connection is closed
+	End   time.Time // time immediately after the connection is closed
+
+	// Err is the connection closing error (if any)
+	Err error
+}
+
 // ConnectObserver is the interface implemented by connect observers / stat collectors.
 type ConnectObserver interface {
 	// ObserveConnect gets called when a new connection to cassandra is made.
 	ObserveConnect(ObservedConnect)
+	ObserveDisconnect(ObservedDisconnect)
 }
 
 type Error struct {

--- a/session_observers_test.go
+++ b/session_observers_test.go
@@ -1,0 +1,44 @@
+// +build all cassandra
+
+package gocql
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type CounterConnectObserver struct {
+	count int32
+}
+
+func (o *CounterConnectObserver) ObserveConnect(e ObservedConnect) {
+	atomic.AddInt32(&o.count, 1)
+}
+
+func (o *CounterConnectObserver) ObserveDisconnect(e ObservedDisconnect) {
+	atomic.AddInt32(&o.count, -1)
+}
+
+// Verify if all connection creation and closing
+// are observable
+func TestSessionObserveConnectAndDisconnect(t *testing.T) {
+	obs := CounterConnectObserver{}
+	cluster := createCluster()
+	cluster.ConnectObserver = &obs
+
+	// We expect to see some connections being opened...
+	if !assert.Equal(t, int32(0), obs.count, "Observed connections must start at zero.") {
+		return
+	}
+	session, _ := cluster.CreateSession()
+	if !assert.NotEqual(t, int32(0), atomic.LoadInt32(&obs.count), "No connections opening were observed.") {
+		return
+	}
+
+	// ...and being closed.
+	session.Close()
+	assert.Equal(t, int32(0), atomic.LoadInt32(&obs.count), fmt.Sprintf("[%d] connections still open.", obs.count))
+}


### PR DESCRIPTION
Implements https://github.com/gocql/gocql/issues/756 .

Possible problems:

1 - Implementations of "ConnectObserver" will not be valid anymore. See https://github.com/gocql/gocql/pull/1467/commits/fd6472f2981091234a8c3afc785ee74b404d515e#diff-f2fccfb96064097b73fbe8eeae3703eeR2037. To avoid this problem, one solution is to follow the issue suggestion and start using channels for notifications.

2 - Maybe not a realistic problem, but one can call "session.Close()" before the connection pools are full. Exactly what happens in the test. I chose the simple solution of waiting for the filling to finish before closing the Session. This explains the promotion of the fill WaitGroup to inside the "hostConnPool" struct and the "Wait()" in the "pool.Close()".

Example of the implementation.
```
func (o PrintConnectObserver) ObserveDisconnect(e gocql.ObservedDisconnect) {
    fmt.Println("ObserveDisconnect.Host: ", e.Host)
    fmt.Println("ObserveDisconnect.Start: ", e.Start)
    fmt.Println("ObserveDisconnect.End: ", e.End)
    fmt.Println("ObserveDisconnect.Err: ", e.Err)
}

cluster := gocql.NewCluster("172.18.0.3")
cluster.ConnectObserver = PrintConnectObserver{}

cluster.CreateSession()
session.Close() // <- generates the log below
```

Result:

```
ObserveDisconnect.Host:  [HostInfo hostname="172.18.0.3" connectAddress="172.18.0.3" peer="<nil>" rpc_address="<nil>" broadcast_address="<nil>" preferred_ip="<nil>" connect_addr="172.18.0.3" connect_addr_source="connect_address" port=9042 data_centre="" rack="" host_id="" version="v0.0.0" state=UP num_tokens=0]
ObserveDisconnect.Start:  2020-06-30 13:48:57.1785857 +0100 BST m=+0.022178701
ObserveDisconnect.End:  2020-06-30 13:48:57.1786369 +0100 BST m=+0.022229901
ObserveDisconnect.Err:  <nil>
````

Test:

```
go test -tags cassandra -run TestSessionObserveConnectAndDisconnect -v 
```