### PR TITLE
Demonstrate unmarshalling with []byte fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ func main() {
 
 	/* Search for a specific set of records whose 'timeline' column matches
 	 * the value 'me'. The secondary index that we created earlier will be
-	 * used for optimizing the search */
+	 * used for optimizing the search. */
 	if err := session.Query(`SELECT id, text FROM tweet WHERE timeline = ? LIMIT 1`,
 		"me").Consistency(gocql.One).Scan(&id, &text); err != nil {
 		log.Fatal(err)
@@ -159,7 +159,7 @@ func main() {
 	 * Note: Unmarshalling into []byte re-uses the existing slice rather than copying it,
 	 * as a performance optimization: https://github.com/gocql/gocql/pull/1167
 	 * So when iterating, you must reset the value each time. This example demonstrates
-	 * unmarshalling into a struct that contains a []byte field.
+	 * unmarshalling into a struct that contains a []byte field. */
 	Tweet type struct{
 		timeline []byte
 		id gocql.UUID


### PR DESCRIPTION
In https://github.com/gocql/gocql/pull/1167 the unmarshalling behavior
for `[]byte` was changed to re-use the existing slice if it is non-nil.

However, this results in extremely confusing behavior when unmarshalling 
into a struct because it causes those fields (and only those fields) to be all
mutated to the value of the final row.

Reverting this change would result in less confusing behavior, but also a
significant performance regression for folks trying to leverage this. 
So instead add an example to the `README` demonstrating the issue 
and the fix of re-setting the struct field value between iterations.

Fix https://github.com/gocql/gocql/issues/1348

H/T to @Tommy42 for reporting the issue and 
@continuum-oleksandr-mosur for tracking down the root cause.