### PR TITLE
Support Go 1.14 and 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ env:
       AUTH=false
 
 go:
-  - 1.13.x
   - 1.14.x
+  - 1.15.x
 
 install:
   - ./install_test_deps.sh $TRAVIS_REPO_SLUG

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.13 | yes | yes | yes
 1.14 | yes | yes | yes
+1.15 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
We support two latest versions of Go.