### PR TITLE
Add Support For Secure Connection Bundle 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fuzz-corpus
 fuzz-work
 gocql.test
 .idea
+.history

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Features
   * Support for UDTs via a custom marshaller or struct tags
 * Support for Cassandra 3.0+ [binary protocol version 4](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec)
 * An API to access the schema metadata of a given keyspace
+* Connection support for secure connect bundle
 
 Performance
 -----------

--- a/cluster.go
+++ b/cluster.go
@@ -223,7 +223,8 @@ func (cfg *ClusterConfig) filterHost(host *HostInfo) bool {
 }
 
 var (
-	ErrNoHosts              = errors.New("no hosts provided")
-	ErrNoConnectionsStarted = errors.New("no connections were made when creating the session")
-	ErrHostQueryFailed      = errors.New("unable to populate Hosts")
+	ErrNoHosts                            = errors.New("no hosts provided")
+	ErrNoConnectionsStarted               = errors.New("no connections were made when creating the session")
+	ErrHostQueryFailed                    = errors.New("unable to populate Hosts")
+	ErrDisableInitialHostLookupNotAllowed = errors.New("DisableInitialHostLookup true not allowed with a Secure Connection Bundle")
 )

--- a/cluster.go
+++ b/cluster.go
@@ -63,9 +63,9 @@ type ClusterConfig struct {
 	MaxRoutingKeyInfo           int                                      // Sets the maximum cache size for query info about statements for each session (default: 1000)
 	PageSize                    int                                      // Default page size to use for created sessions (default: 5000)
 	SerialConsistency           SerialConsistency                        // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
-	SslOpts                     *SslOptions
-	SecureConnectBundleFilename string // Sets the Secure Connect Bundle
-	DefaultTimestamp            bool   // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
+	SslOpts                     *SslOptions                              // SSlOpts to use for this cluster. Ignored if SecureConnectBundleFilename is set.
+	SecureConnectBundleFilename string                                   // Sets the Secure Connect Bundle
+	DefaultTimestamp            bool                                     // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
@@ -186,6 +186,13 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
 	}
+	return cfg
+}
+
+// Create a Cluster for using Secure Connect Bundle.
+func NewClusterSecureConnectBundle(connectBundleFilename string) *ClusterConfig {
+	cfg := NewCluster()
+	cfg.SecureConnectBundleFilename = connectBundleFilename
 	return cfg
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -200,7 +200,8 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 // and port, If no AddressTranslator or if an error occurs, the given address and
 // port will be returned.
 func (cfg *ClusterConfig) translateAddressPort(addr net.IP, port int) (net.IP, int) {
-	if cfg.AddressTranslator == nil || len(addr) == 0 {
+	// Do not do translations on secure connect bundle. It is handled automatically by sni processing.
+	if cfg.SecureConnectBundleFilename != "" || cfg.AddressTranslator == nil || len(addr) == 0 {
 		return addr, port
 	}
 	newAddr, newPort := cfg.AddressTranslator.Translate(addr, port)

--- a/cluster.go
+++ b/cluster.go
@@ -45,26 +45,27 @@ type ClusterConfig struct {
 	// If it is 0 or unset (the default) then the driver will attempt to discover the
 	// highest supported protocol for the cluster. In clusters with nodes of different
 	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
-	ProtoVersion       int
-	Timeout            time.Duration                            // connection timeout (default: 600ms)
-	ConnectTimeout     time.Duration                            // initial connection timeout, used during initial dial to server (default: 600ms)
-	Port               int                                      // port (default: 9042)
-	Keyspace           string                                   // initial keyspace (optional)
-	NumConns           int                                      // number of connections per host (default: 2)
-	Consistency        Consistency                              // default consistency level (default: Quorum)
-	Compressor         Compressor                               // compression algorithm (default: nil)
-	Authenticator      Authenticator                            // authenticator (default: nil)
-	AuthProvider       func(h *HostInfo) (Authenticator, error) // an authenticator factory. Can be used to create alternative authenticators (default: nil)
-	RetryPolicy        RetryPolicy                              // Default retry policy to use for queries (default: 0)
-	ConvictionPolicy   ConvictionPolicy                         // Decide whether to mark host as down based on the error and host info (default: SimpleConvictionPolicy)
-	ReconnectionPolicy ReconnectionPolicy                       // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
-	SocketKeepalive    time.Duration                            // The keepalive period to use, enabled if > 0 (default: 0)
-	MaxPreparedStmts   int                                      // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
-	MaxRoutingKeyInfo  int                                      // Sets the maximum cache size for query info about statements for each session (default: 1000)
-	PageSize           int                                      // Default page size to use for created sessions (default: 5000)
-	SerialConsistency  SerialConsistency                        // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
-	SslOpts            *SslOptions
-	DefaultTimestamp   bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
+	ProtoVersion                int
+	Timeout                     time.Duration                            // connection timeout (default: 600ms)
+	ConnectTimeout              time.Duration                            // initial connection timeout, used during initial dial to server (default: 600ms)
+	Port                        int                                      // port (default: 9042)
+	Keyspace                    string                                   // initial keyspace (optional)
+	NumConns                    int                                      // number of connections per host (default: 2)
+	Consistency                 Consistency                              // default consistency level (default: Quorum)
+	Compressor                  Compressor                               // compression algorithm (default: nil)
+	Authenticator               Authenticator                            // authenticator (default: nil)
+	AuthProvider                func(h *HostInfo) (Authenticator, error) // an authenticator factory. Can be used to create alternative authenticators (default: nil)
+	RetryPolicy                 RetryPolicy                              // Default retry policy to use for queries (default: 0)
+	ConvictionPolicy            ConvictionPolicy                         // Decide whether to mark host as down based on the error and host info (default: SimpleConvictionPolicy)
+	ReconnectionPolicy          ReconnectionPolicy                       // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
+	SocketKeepalive             time.Duration                            // The keepalive period to use, enabled if > 0 (default: 0)
+	MaxPreparedStmts            int                                      // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
+	MaxRoutingKeyInfo           int                                      // Sets the maximum cache size for query info about statements for each session (default: 1000)
+	PageSize                    int                                      // Default page size to use for created sessions (default: 5000)
+	SerialConsistency           SerialConsistency                        // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
+	SslOpts                     *SslOptions
+	SecureConnectBundleFilename string // Sets the Secure Connect Bundle
+	DefaultTimestamp            bool   // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig

--- a/conn.go
+++ b/conn.go
@@ -203,10 +203,12 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 	port := host.port
 
 	// TODO(zariel): remove these
-	if !validIpAddr(ip) {
-		panic(fmt.Sprintf("host missing connect ip address: %v", ip))
-	} else if port == 0 {
-		panic(fmt.Sprintf("host missing port: %v", port))
+	if cfg.sniConfig == nil {
+		if !validIpAddr(ip) {
+			panic(fmt.Sprintf("host missing connect ip address: %v", ip))
+		} else if port == 0 {
+			panic(fmt.Sprintf("host missing port: %v", port))
+		}
 	}
 
 	dialer := cfg.Dialer

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -82,15 +82,11 @@ func connConfig(cfg *ClusterConfig, sniConfig *SNIConfig) (*ConnConfig, error) {
 	)
 
 	// TODO(zariel): move tls config setup into session init.
-	cfgSslOpts := cfg.SslOpts
 	if sniConfig != nil {
 		// These will completely replace any incoming ssl opts because the secure connection bundle overrides these.
-		t := sniConfig.SSLOpts
-		t.EnableHostVerification = false // Do not do host verification. The sniServerName will not match certificate. We've already cert. when we got the metadata.
-		cfgSslOpts = &t
-	}
-	if cfgSslOpts != nil {
-		tlsConfig, err = setupTLSConfig(cfgSslOpts)
+		tlsConfig = sniConfig.tlsConfig
+	} else if cfg.SslOpts != nil {
+		tlsConfig, err = setupTLSConfig(cfg.SslOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/control.go
+++ b/control.go
@@ -274,7 +274,8 @@ func (c *controlConn) setupConn(conn *Conn) error {
 
 	// TODO(zariel): do we need to fetch host info everytime
 	// the control conn connects? Surely we have it cached?
-	// (rlk) - not necessarily on the first time for this host.
+	// (rlk) - actually may be needed on the first time for this host since the info may not be filled in yet.
+	// Maybe a test to see if local info filled in?
 	host, err := conn.localHostInfo(context.TODO())
 	if err != nil {
 		return err

--- a/control.go
+++ b/control.go
@@ -274,6 +274,7 @@ func (c *controlConn) setupConn(conn *Conn) error {
 
 	// TODO(zariel): do we need to fetch host info everytime
 	// the control conn connects? Surely we have it cached?
+	// (rlk) - not necessarily on the first time for this host.
 	host, err := conn.localHostInfo(context.TODO())
 	if err != nil {
 		return err

--- a/filters.go
+++ b/filters.go
@@ -40,7 +40,7 @@ func DataCentreHostFilter(dataCentre string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(hosts, 9042)
+	hostInfos, err := addrsToHosts(hosts, 9042, nil)
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/host_source.go
+++ b/host_source.go
@@ -464,6 +464,11 @@ func checkSystemSchema(control *controlConn) (bool, error) {
 func (s *Session) hostInfoFromMap(row map[string]interface{}, host *HostInfo) (*HostInfo, error) {
 	const assertErrorMsg = "Assertion failed for %s"
 	var ok bool
+	if s.connCfg.sniConfig != nil {
+		// connectAddress field should never be set on incoming for a host when sni turned on.
+		// instead it will be computed from the row info as rpc, etc. and set correctly here,
+		host.connectAddress = nil
+	}
 
 	// Default to our connected port if the cluster doesn't have port information
 	for key, value := range row {

--- a/session.go
+++ b/session.go
@@ -144,6 +144,13 @@ func addrsToHosts(addrs []string, defaultPort int, sniConfig *SNIConfig) ([]*Hos
 
 // NewSession wraps an existing Node.
 func NewSession(cfg ClusterConfig) (*Session, error) {
+
+	// Not able to support DisableInitialHostLookup and secure bundle because the generated hosts are not resolvable
+	// They hosts can only be resolved by getting the host lookup data.
+	if cfg.DisableInitialHostLookup && cfg.SecureConnectBundleFilename != "" {
+		return nil, ErrDisableInitialHostLookupNotAllowed
+	}
+
 	// Check that hosts in the ClusterConfig is not empty. If SecureConnectBudndle hosts are not expected
 	if len(cfg.Hosts) < 1 && cfg.SecureConnectBundleFilename == "" {
 		return nil, ErrNoHosts

--- a/session.go
+++ b/session.go
@@ -170,12 +170,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		//    b) 'key' file
 		//    c) 'ca.crt' file
 
-		// create tmp directory with secureBundle filename as root to put files into
-		tmp, err := os.Getwd()
-		dir, err := ioutil.TempDir(tmp, cfg.SecureConnectBundleFilename)
-		if err != nil {
-			return nil, err
-		}
+		dir, err := ioutil.TempDir("", "securezip")
 		if err != nil {
 			return nil, err
 		}

--- a/session.go
+++ b/session.go
@@ -155,8 +155,37 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	s.connectObserver = cfg.ConnectObserver
 	s.frameObserver = cfg.FrameHeaderObserver
 
+	var sniConfig *SNIConfig
+
+	if cfg.SecureConnectBundleFilename != "" {
+		// TODO Gil:
+		// 1. Unzip the secure bundle.
+		// 2. Put in temp directory (the following MUST BE FILES for this to work.
+		//    a) 'cert' file
+		//    b) 'key' file
+		//    c) 'ca.crt' file
+		// 3. Create a SNIConfig{} object into sniConfig, and set.
+		//    sniConfig.SSLOpts to
+		//      SslOptions{
+		//        CertPath: "cert",
+		//        KeyPath: "key",
+		//        CaPath:" "ca.crt"
+		//        EnableHostVerification: true,
+		//    }
+		// 4. Load the 'config.json' file as json into a map[string]interface{}
+		// 5. Create url: "https://<config.json["host"]:config.json["port"]>/metadata
+		// 6. tlsConfig, err := setupTLSConfig(&sniConfig.SSLOpts)
+		//    if err != nil {
+		//      return nil, err
+		//    }
+		// 7. Call the url and use the tlsConfig when making call. This is required to validate the certificates.
+		// 8. Gather the "data" need the sniProxyHost to be put into sniConfig.SNIProxyAddress (host:port) returned from the metadata.
+		// 9. Gather other data, not sure what yet.
+		//
+	}
+
 	//Check the TLS Config before trying to connect to anything external
-	connCfg, err := connConfig(&s.cfg)
+	connCfg, err := connConfig(&s.cfg, sniConfig)
 	if err != nil {
 		//TODO: Return a typed error
 		return nil, fmt.Errorf("gocql: unable to create session: %v", err)

--- a/session.go
+++ b/session.go
@@ -369,8 +369,9 @@ func (s *Session) init() error {
 					filteredHosts = append(filteredHosts, host)
 				}
 			}
-			hosts = append(hosts, filteredHosts...)
 			var newFinalHosts []*HostInfo
+			for _, host := range hosts {
+				found := false
 				for _, filteredHost := range filteredHosts {
 					if host.HostID() == filteredHost.HostID() {
 						found = true

--- a/session.go
+++ b/session.go
@@ -171,11 +171,15 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		//    c) 'ca.crt' file
 
 		// create tmp directory with secureBundle filename as root to put files into
-		dir, err := ioutil.TempDir("", cfg.SecureConnectBundleFilename)
+		tmp, err := os.Getwd()
+		dir, err := ioutil.TempDir(tmp, cfg.SecureConnectBundleFilename)
 		if err != nil {
 			return nil, err
 		}
-		defer os.RemoveAll(dir) // the files are only needed until we create the tlsConfig, at that point they have been read in and processed, so not needed any longer and can be deleted at end of method.
+		if err != nil {
+			return nil, err
+		}
+		// defer os.RemoveAll(dir) // the files are only needed until we create the tlsConfig, at that point they have been read in and processed, so not needed any longer and can be deleted at end of method.
 
 		// add each file from bundle to the directory
 		for _, f := range r.File {
@@ -237,7 +241,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		tlsConfig, err := setupTLSConfig(&SslOptions{
 			CertPath:               path.Join(dir, "cert"),
 			KeyPath:                path.Join(dir, "key"),
-			CaPath:                 path.Join(dir, "ca.crts"),
+			CaPath:                 path.Join(dir, "ca.crt"),
 			EnableHostVerification: true,
 		})
 		if err != nil {

--- a/session.go
+++ b/session.go
@@ -370,6 +370,18 @@ func (s *Session) init() error {
 				}
 			}
 			hosts = append(hosts, filteredHosts...)
+			var newFinalHosts []*HostInfo
+				for _, filteredHost := range filteredHosts {
+					if host.HostID() == filteredHost.HostID() {
+						found = true
+						newFinalHosts = append(newFinalHosts, filteredHost)
+					}
+				}
+				if !found {
+					newFinalHosts = append(newFinalHosts, host)
+				}
+			}
+			hosts = newFinalHosts
 		}
 	}
 

--- a/session.go
+++ b/session.go
@@ -157,6 +157,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 
 	var sniConfig *SNIConfig
 
+	ihosts := cfg.Hosts
 	if cfg.SecureConnectBundleFilename != "" {
 		// TODO Gil:
 		// 1. Unzip the secure bundle.
@@ -181,7 +182,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		// 7. Call the url and use the tlsConfig when making call. This is required to validate the certificates.
 		// 8. Gather the "data" need the sniProxyHost to be put into sniConfig.SNIProxyAddress (host:port) returned from the metadata.
 		// 9. Gather other data, not sure what yet.
-		//
+		// 10. set contact_hosts into a string array into ihosts, replacing incoming
 	}
 
 	//Check the TLS Config before trying to connect to anything external
@@ -192,7 +193,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	}
 	s.connCfg = connCfg
 
-	if err := s.init(); err != nil {
+	if err := s.init(ihosts); err != nil {
 		s.Close()
 		if err == ErrNoConnectionsStarted {
 			//This error used to be generated inside NewSession & returned directly
@@ -207,8 +208,8 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	return s, nil
 }
 
-func (s *Session) init() error {
-	hosts, err := addrsToHosts(s.cfg.Hosts, s.cfg.Port)
+func (s *Session) init(ihosts []string) error {
+	hosts, err := addrsToHosts(ihosts, s.cfg.Port)
 	if err != nil {
 		return err
 	}

--- a/session.go
+++ b/session.go
@@ -179,7 +179,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		if err != nil {
 			return nil, err
 		}
-		// defer os.RemoveAll(dir) // the files are only needed until we create the tlsConfig, at that point they have been read in and processed, so not needed any longer and can be deleted at end of method.
+		defer os.RemoveAll(dir) // the files are only needed until we create the tlsConfig, at that point they have been read in and processed, so not needed any longer and can be deleted at end of method.
 
 		// add each file from bundle to the directory
 		for _, f := range r.File {

--- a/session.go
+++ b/session.go
@@ -371,20 +371,27 @@ func (s *Session) init() error {
 					filteredHosts = append(filteredHosts, host)
 				}
 			}
-			var newFinalHosts []*HostInfo
-			for _, host := range hosts {
-				found := false
-				for _, filteredHost := range filteredHosts {
-					if host.HostID() == filteredHost.HostID() {
-						found = true
-						newFinalHosts = append(newFinalHosts, filteredHost)
+			if s.sniConfig == nil {
+				hosts = append(hosts, filteredHosts...)
+			} else {
+				// with secure connection we need to replace the old that match by host id with new host into final host list,
+				// otherwise we would get duplicates. The new host is complete with needed hostinfo.
+				// Filter out original with same hostid and replace with new one. All that weren't matched will remain in list.
+				var newFinalHosts []*HostInfo
+				for _, host := range hosts {
+					found := false
+					for _, filteredHost := range filteredHosts {
+						if host.HostID() == filteredHost.HostID() {
+							found = true
+							newFinalHosts = append(newFinalHosts, filteredHost)
+						}
+					}
+					if !found {
+						newFinalHosts = append(newFinalHosts, host)
 					}
 				}
-				if !found {
-					newFinalHosts = append(newFinalHosts, host)
-				}
+				hosts = newFinalHosts
 			}
-			hosts = newFinalHosts
 		}
 	}
 


### PR DESCRIPTION
There is no existing gocql driver support for connecting to Cassandra Databases via Secure Connection Bundle, which our team at IBM required. IBM Cassandra is switching to Secure Connection Bundles and this will be needed for anyone using this golang driver to connect to them. We've been using this gocql driver now for a long time to connect to our previous Cassandra instance, and made the updates required to add connectivity support for Cassandra databases which use the Secure Connection Bundle.