### PR TITLE
Connection Dial should be to connect address not hostname

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -213,7 +213,8 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		dialer = d
 	}
 
-	conn, err := dialer.DialContext(ctx, "tcp", host.HostnameAndPort())
+	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -415,13 +415,6 @@ func (h *HostInfo) IsUp() bool {
 	return h != nil && h.State() == NodeUp
 }
 
-func (h *HostInfo) HostnameAndPort() string {
-	if h.hostname == "" {
-		h.hostname = h.ConnectAddress().String()
-	}
-	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
-}
-
 func (h *HostInfo) String() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()


### PR DESCRIPTION
Throughout gocql, this connection is mapped to the ConnectAddress which translates to an IP. It is expected that a connection created this far down the stack should be specific to the IP that was requested rather than any hostname (if one is set).

In some cases (mainly [when creating control connections](https://github.com/gocql/gocql/blob/393f0c961220893ab75e4627f1487608014502a7/control.go#L145)), the hostname is populated in the HostInfo struct with the user supplied hosts. If these map to a DNS name with multiple entries, the connection will be established to any of those IPs rather than specifically to the IP we want to connect to.