### PR TITLE
TLS Host Verification failing with missing ServerName

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
 Jorge Bay <jorgebg@apache.org>
+Suhail Patel <me@suhailpatel.com>

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -57,6 +57,7 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 	}
 
 	sslOpts.InsecureSkipVerify = !sslOpts.EnableHostVerification
+	sslOpts.ServerName = sslOpts.HostServerName
 
 	// return clone to avoid race
 	return sslOpts.Config.Clone(), nil


### PR DESCRIPTION
Using `EnableHostVerification` in `gocql.SslOptions` does not work at all and fails with the following error
```
2020/09/27 22:06:05 gocql: unable to create session: unable to discover protocol version: tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```

This is because the `tls.Config.ServerName` is not being set (which is a pre-requisite of having `tls.Config.InsecureSkipVerify` be false and having host verification). 

This regression was introduced in #1368 where we changed from `tls.DialWithDialer` (which [under the hood](https://github.com/golang/go/blob/4b09c8ad6fb9d30b9c3417b5364809ff0006749d/src/crypto/tls/tls.go#L157-L164) sets the `tls.Config.ServerName` if one is not set) to wrapping the existing connection using `tls.Client`.

I've erred on the side of fixing for backwards compatibility by introducing the `HostServerName` field but falling back to `host.hostname` if one isn't present. 