### PR TITLE
[Code Optimization], huge parameters need to passed as pointer 

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -325,12 +325,14 @@ type testQueryObserver struct {
 	verbose bool
 }
 
-func (o *testQueryObserver) ObserveQuery(ctx context.Context, q ObservedQuery) {
-	host := q.Host.ConnectAddress().String()
-	o.metrics[host] = q.Metrics
-	if o.verbose {
-		Logger.Printf("Observed query %q. Returned %v rows, took %v on host %q with %v attempts and total latency %v. Error: %q\n",
-			q.Statement, q.Rows, q.End.Sub(q.Start), host, q.Metrics.Attempts, q.Metrics.TotalLatency, q.Err)
+func (o *testQueryObserver) ObserveQuery(ctx context.Context, q *ObservedQuery) {
+	if q !=  nil {
+		host := q.Host.ConnectAddress().String()
+		o.metrics[host] = q.Metrics
+		if o.verbose {
+			Logger.Printf("Observed query %q. Returned %v rows, took %v on host %q with %v attempts and total latency %v. Error: %q\n",
+				q.Statement, q.Rows, q.End.Sub(q.Start), host, q.Metrics.Attempts, q.Metrics.TotalLatency, q.Err)
+		}
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -999,7 +999,7 @@ func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 	attempt, metricsForHost := q.metrics.attempt(1, latency, host, q.observer != nil)
 
 	if q.observer != nil {
-		q.observer.ObserveQuery(q.Context(), ObservedQuery{
+		q.observer.ObserveQuery(q.Context(), &ObservedQuery{
 			Keyspace:  keyspace,
 			Statement: q.stmt,
 			Start:     start,
@@ -1989,7 +1989,7 @@ type QueryObserver interface {
 	// ObserveQuery gets called on every query to cassandra, including all queries in an iterator when paging is enabled.
 	// It doesn't get called if there is no query because the session is closed or there are no connections available.
 	// The error reported only shows query errors, i.e. if a SELECT is valid but finds no matches it will be nil.
-	ObserveQuery(context.Context, ObservedQuery)
+	ObserveQuery(context.Context, *ObservedQuery)
 }
 
 type ObservedBatch struct {

--- a/session_test.go
+++ b/session_test.go
@@ -91,9 +91,9 @@ func TestSessionAPI(t *testing.T) {
 	}
 }
 
-type funcQueryObserver func(context.Context, ObservedQuery)
+type funcQueryObserver func(context.Context, *ObservedQuery)
 
-func (f funcQueryObserver) ObserveQuery(ctx context.Context, o ObservedQuery) {
+func (f funcQueryObserver) ObserveQuery(ctx context.Context, o *ObservedQuery) {
 	f(ctx, o)
 }
 


### PR DESCRIPTION
Structs which are huge/heavy should be passed as pointers, in-order to avoid copying a large value to local parameters in the function.

ObservedQuery struct in the method of QueryObserver interface, is a heavy struct.