### PR TITLE
Avoid creating extra goroutines on nextIter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
 Jorge Bay <jorgebg@apache.org>
+Dmitriy Kozlov <hummerd@mail.ru>

--- a/session.go
+++ b/session.go
@@ -1423,7 +1423,7 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 	}
 
 	if iter.next != nil && iter.pos >= iter.next.pos {
-		go iter.next.fetch()
+		iter.next.fetchAsync()
 	}
 
 	// currently only support scanning into an expand tuple, such that its the same
@@ -1518,10 +1518,17 @@ func (iter *Iter) NumRows() int {
 }
 
 type nextIter struct {
-	qry  *Query
-	pos  int
-	once sync.Once
-	next *Iter
+	qry   *Query
+	pos   int
+	oncea sync.Once
+	once  sync.Once
+	next  *Iter
+}
+
+func (n *nextIter) fetchAsync() {
+	n.oncea.Do(func() {
+		go n.fetch()
+	})
 }
 
 func (n *nextIter) fetch() *Iter {


### PR DESCRIPTION
We have some problems with code `go iter.next.fetch()` from `iter.Scan`. Under heavy load it creates too many goroutines.
```
func (iter *Iter) Scan(dest ...interface{}) bool {
...
	if iter.next != nil && iter.pos >= iter.next.pos {
		go iter.next.fetch()
	}
```
In our performance test ~800 reading routines created 1 842 734 (!) almost 2M fetching routines. It is too heavy load for runtime :)
```
814 @ ...
#	0x6ba9c8	github.com/gocql/gocql.(*Conn).exec+0x448
#	0x6bbae8	github.com/gocql/gocql.(*Conn).executeQuery+0x568
#	0x70f128	github.com/gocql/gocql.(*Query).execute+0x48
#	0x708163	github.com/gocql/gocql.(*queryExecutor).attemptQuery+0x83
#	0x708c46	github.com/gocql/gocql.(*queryExecutor).do+0x1c6
#	0x7086cd	github.com/gocql/gocql.(*queryExecutor).executeQuery+0xed
#	0x70c9b1	github.com/gocql/gocql.(*Session).executeQuery+0xb1
#	0x70fce4	github.com/gocql/gocql.(*Query).Iter+0x44

1842734 @ 
#	0x46cf66	sync.runtime_SemacquireMutex+0x46
#	0x47bd84	sync.(*Mutex).lockSlow+0x104
#	0x47c224	sync.(*Mutex).Lock+0x104
#	0x47c153	sync.(*Once).doSlow+0x33
#	0x7117cd	sync.(*Once).Do+0x6d
#	0x71177d	github.com/gocql/gocql.(*nextIter).fetch+0x1d
```
After that our app spend almost all its CPU time to park this amount of routines.

For fixing this lets add another sync.Once that will guarantee that only one extra routine is created.