### PR TITLE
Bound values added in fields of ObservedQuery and ObservedBatch struct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,3 +115,4 @@ Pavel Buchinchik <p.buchinchik@gmail.com>
 Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
 Jorge Bay <jorgebg@apache.org>
+Tushar Das <tushar.das5@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1867,7 +1867,7 @@ func TestBatchObserve(t *testing.T) {
 		observedErr      error
 		observedKeyspace string
 		observedStmts    []string
-		observedEntries  map[string][]interface{}
+		observedValues   [][]interface{}
 	}
 
 	var observedBatch *observation
@@ -1882,7 +1882,7 @@ func TestBatchObserve(t *testing.T) {
 			observedKeyspace: o.Keyspace,
 			observedStmts:    o.Statements,
 			observedErr:      o.Err,
-			observedEntries:  o.Entries,
+			observedValues:   o.Values,
 		}
 	}))
 	for i := 0; i < 100; i++ {
@@ -1909,8 +1909,8 @@ func TestBatchObserve(t *testing.T) {
 		if stmt != fmt.Sprintf(`INSERT INTO batch_observe_table (id,other) VALUES (?,%d)`, i) {
 			t.Fatal("unexpected query", stmt)
 		}
-		if observedBatch.observedEntries[stmt] != i {
-			t.Fatal("expecting bound value '%v', got %q", i, observedBatch.observedEntries[stmt])
+		if observedBatch.observedValues[i] != []interface{}{i} {
+			t.Fatal("expecting bound value '%v', got %q", []interface{}{i}, observedBatch.observedEntries[i])
 		}
 	}
 }

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1909,9 +1909,8 @@ func TestBatchObserve(t *testing.T) {
 		if stmt != fmt.Sprintf(`INSERT INTO batch_observe_table (id,other) VALUES (?,%d)`, i) {
 			t.Fatal("unexpected query", stmt)
 		}
-		if observedBatch.observedValues[i] != []interface{}{i} {
-			t.Fatal("expecting bound value '%v', got %q", []interface{}{i}, observedBatch.observedEntries[i])
-		}
+
+		assertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
 	}
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1867,6 +1867,7 @@ func TestBatchObserve(t *testing.T) {
 		observedErr      error
 		observedKeyspace string
 		observedStmts    []string
+		observedEntries  map[string][]interface{}
 	}
 
 	var observedBatch *observation
@@ -1881,6 +1882,7 @@ func TestBatchObserve(t *testing.T) {
 			observedKeyspace: o.Keyspace,
 			observedStmts:    o.Statements,
 			observedErr:      o.Err,
+			observedEntries:  o.Entries,
 		}
 	}))
 	for i := 0; i < 100; i++ {
@@ -1906,6 +1908,9 @@ func TestBatchObserve(t *testing.T) {
 	for i, stmt := range observedBatch.observedStmts {
 		if stmt != fmt.Sprintf(`INSERT INTO batch_observe_table (id,other) VALUES (?,%d)`, i) {
 			t.Fatal("unexpected query", stmt)
+		}
+		if observedBatch.observedEntries[stmt] != i {
+			t.Fatal("expecting bound value '%v', got %q", i, observedBatch.observedEntries[stmt])
 		}
 	}
 }

--- a/session.go
+++ b/session.go
@@ -1748,18 +1748,18 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		return
 	}
 
-	entries := make(map[string][]interface{}, len(b.Entries))
+	values := make([][]interface{}, len(b.Entries))
 	statements := make([]string, len(b.Entries))
 
 	for i, entry := range b.Entries {
 		statements[i] = entry.Stmt
-		entries[entry.Stmt] = entry.Args
+		values[i] = entry.Args
 	}
 
 	b.observer.ObserveBatch(b.Context(), ObservedBatch{
 		Keyspace:   keyspace,
 		Statements: statements,
-		Entries:    entries,
+		Values:     values,
 		Start:      start,
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
@@ -2001,7 +2001,7 @@ type QueryObserver interface {
 type ObservedBatch struct {
 	Keyspace   string
 	Statements []string
-	Entries    map[string][]interface{}
+	Values     [][]interface{}
 
 	Start time.Time // time immediately before the batch query was called
 	End   time.Time // time immediately after the batch query returned

--- a/session.go
+++ b/session.go
@@ -1748,8 +1748,8 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		return
 	}
 
-	values := make([][]interface{}, len(b.Entries))
 	statements := make([]string, len(b.Entries))
+	values := make([][]interface{}, len(b.Entries))
 
 	for i, entry := range b.Entries {
 		statements[i] = entry.Stmt
@@ -1962,7 +1962,10 @@ func (t *traceWriter) Trace(traceId []byte) {
 type ObservedQuery struct {
 	Keyspace  string
 	Statement string
-	Values    []interface{}
+
+	// Values holds a slice of bound values for the query.
+	// Do not modify the values here, they are shared with multiple goroutines.
+	Values []interface{}
 
 	Start time.Time // time immediately before the query was called
 	End   time.Time // time immediately after the query returned
@@ -2001,7 +2004,11 @@ type QueryObserver interface {
 type ObservedBatch struct {
 	Keyspace   string
 	Statements []string
-	Values     [][]interface{}
+
+	// Values holds a slice of bound values for each statement.
+	// Values[i] are bound values passed to Statements[i].
+	// Do not modify the values here, they are shared with multiple goroutines.
+	Values [][]interface{}
 
 	Start time.Time // time immediately before the batch query was called
 	End   time.Time // time immediately after the batch query returned


### PR DESCRIPTION
The statements passed in the statement fields of ObservedQuery and ObservedBatch, do not account for the bound values passed while executing a query. 

Refer issue: #1497 for more details