### PR TITLE
Do not allocate extra bytes in unmarshalUUID

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1711,7 +1711,7 @@ func marshalUUID(info TypeInfo, value interface{}) ([]byte, error) {
 }
 
 func unmarshalUUID(info TypeInfo, data []byte, value interface{}) error {
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		switch v := value.(type) {
 		case *string:
 			*v = ""
@@ -1726,9 +1726,22 @@ func unmarshalUUID(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	}
 
+	if len(data) != 16 {
+		return unmarshalErrorf("unable to parse UUID: UUIDs must be exactly 16 bytes long")
+	}
+
+	switch v := value.(type) {
+	case *[16]byte:
+		copy((*v)[:], data)
+		return nil
+	case *UUID:
+		copy((*v)[:], data)
+		return nil
+	}
+
 	u, err := UUIDFromBytes(data)
 	if err != nil {
-		return unmarshalErrorf("Unable to parse UUID: %s", err)
+		return unmarshalErrorf("unable to parse UUID: %s", err)
 	}
 
 	switch v := value.(type) {
@@ -1737,9 +1750,6 @@ func unmarshalUUID(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	case *[]byte:
 		*v = u[:]
-		return nil
-	case *UUID:
-		*v = u
 		return nil
 	}
 	return unmarshalErrorf("can not unmarshal X %s into %T", info, value)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2172,3 +2172,17 @@ func TestReadCollectionSize(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkUnmarshalUUID(b *testing.B) {
+	b.ReportAllocs()
+	src := make([]byte, 16)
+	dst := UUID{}
+	var ti TypeInfo = NativeType{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := unmarshalUUID(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
If unmarshalUUID called with value of type gocql.UUID, we already have allocated bytes for UUID, so do not allocate extra UUID, but just copy data to value. 

Also add ability to unmarshal directly to array of 16 bytes.