### PR TITLE
Copy query when fetching next page

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1205,12 +1205,16 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		}
 
 		if x.meta.morePages() && !qry.disableAutoPage {
+			newQry := new(Query)
+			*newQry = *qry
+			newQry.pageState = copyBytes(x.meta.pagingState)
+			newQry.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+
 			iter.next = &nextIter{
-				qry: qry,
+				qry: newQry,
 				pos: int((1 - qry.prefetch) * float64(x.numRows)),
 			}
 
-			iter.next.qry.pageState = copyBytes(x.meta.pagingState)
 			if iter.next.pos < 1 {
 				iter.next.pos = 1
 			}

--- a/session.go
+++ b/session.go
@@ -1533,6 +1533,8 @@ func (iter *Iter) NumRows() int {
 	return iter.numRows
 }
 
+// nextIter holds state for fetching a single page in an iterator.
+// single page might be attempted multiple times due to retries.
 type nextIter struct {
 	qry   *Query
 	pos   int
@@ -1991,7 +1993,6 @@ type ObservedQuery struct {
 	Err error
 
 	// Attempt is the index of attempt at executing this query.
-	// An attempt might be either retry or fetching next page of a query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
 }
@@ -2024,7 +2025,6 @@ type ObservedBatch struct {
 	Metrics *hostMetrics
 
 	// Attempt is the index of attempt at executing this query.
-	// An attempt might be either retry or fetching next page of a query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
 }


### PR DESCRIPTION
Currently the attempt count in query metrics is incremented both on
retries and when fetching next page, making it impossible to track just
the retry count. By shallow-copying the query and changing the metrics
we ensure that attempts are counted per-age (so attempts>0 means always
a retry).

We were copying the Query previously
(before 271c061c7f16702ca550b0e9721320b1c92e00cb), but I don't know why
exactly the copying was removed there.

In any case we can't change the paging state in the original Query
because there might be a separate goroutine spawned by speculative
execution that accesses the field. Even if we added a lock around
Query.pagingState field, the speculative execution could try to fetch
different page.

We could possibly move pagingState and metrics to nextIter or other
struct to avoid copying whole Query, but that would require changing
signature of executeQuery to take that struct as parameter instead.

Batches don't implement fetching subsequent pages, so removing the note
about pages from ObservedBatch.Attempts as well.