### PR TITLE
Add Go version to issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -6,6 +6,9 @@ Please answer these questions before submitting your issue. Thanks!
 ### What version of Gocql are you using?
 
 
+### What version of Go are you using?
+
+
 ### What did you do?
 
 


### PR DESCRIPTION
Some issues might be reproducible only using specific
Go version. If someone is not using latest Go version,
we might want to ask them to upgrade and try to reproduce.

This change is inspired by the following comment:
https://github.com/gocql/gocql/issues/1481#issuecomment-728758618