### PR TITLE
Add port number into error message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,3 +116,4 @@ Rintaro Okamura <rintaro.okamura@gmail.com>
 Yura Sokolov <y.sokolov@joom.com>; <funny.falcon@gmail.com>
 Jorge Bay <jorgebg@apache.org>
 Dmitriy Kozlov <hummerd@mail.ru>
+Alexey Romanovsky <alexus1024+gocql@gmail.com>

--- a/control.go
+++ b/control.go
@@ -177,7 +177,7 @@ func (c *controlConn) shuffleDial(endpoints []*HostInfo) (*Conn, error) {
 			return conn, nil
 		}
 
-		Logger.Printf("gocql: unable to dial control conn %v: %v\n", host.ConnectAddress(), err)
+		Logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
 	}
 
 	return nil, err


### PR DESCRIPTION
Just adding port number into "unable to dial control conn" error message to simplify debugging 