### PR TITLE
Fix TestMarshal_Decode

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -93,7 +93,7 @@ var marshalTests = []struct {
 		[]byte{0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		[]byte{0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		MarshalError("can not marshal []byte 6 bytes long into timeuuid, must be exactly 16 bytes long"),
-		UnmarshalError("Unable to parse UUID: UUIDs must be exactly 16 bytes long"),
+		UnmarshalError("unable to parse UUID: UUIDs must be exactly 16 bytes long"),
 	},
 	{
 		NativeType{proto: 2, typ: TypeInt},


### PR DESCRIPTION
In 179bae5f16901945ab66d7c2d9088dc4282281c4 we changed the error
message from upper case to lower case, but the test was not updated.
I don't know whether I missed failing CI build when merging or
whether CI did not run at all.

Anyway, this commit fixes the test.