### PR TITLE
Use the same host iterator in speculative execution

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -304,7 +304,10 @@ type HostSelectionPolicy interface {
 	KeyspaceChanged(KeyspaceUpdateEvent)
 	Init(*Session)
 	IsLocal(host *HostInfo) bool
-	//Pick returns an iteration function over selected hosts
+	// Pick returns an iteration function over selected hosts.
+	// Multiple attempts of a single query execution won't call the returned NextHost function concurrently,
+	// so it's safe to have internal state without additional synchronization as long as every call to Pick returns
+	// a different instance of NextHost.
 	Pick(ExecutableQuery) NextHost
 }
 


### PR DESCRIPTION
Before this commit, regular query execution path and speculative
execution path did not use the same host iterator.
This means that speculative execution could retry on the same
host as the original attempt. This could lead to overloading that
slow host even more instead of trying on some other host if
the policy consistently selects that host (for example based on
token).

We fix this by sharing the host iterator returned by the host selection
policy. The returned iterator could now accessed from multiple
goroutines, so we need to synchronize access to it. I chose this instead
of implementing synchronization in each policy because I can't fix
any user-provided policies. Synchronizing in the driver avoids
introducing new data race for user-provided policies as those likely
won't be updated.

Fixes https://github.com/gocql/gocql/issues/1530