### PR TITLE
Fixed small typo in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@
 //
 //  cluster.Keyspace = "example"
 //  cluster.Consistency = gocql.Quorum
-//  cluster.ProtocolVersion = 4
+//  cluster.ProtoVersion = 4
 //
 // The driver tries to automatically detect the protocol version to use if not set, but you might want to set the
 // protocol version explicitly, as it's not defined which version will be used in certain situations (for example


### PR DESCRIPTION
In the short introduction on how to connect to a cluster there was a small typo for a ClusterConfig option, fixed with this PR.
