### PR TITLE
Fix reconnecting to cluster

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -441,7 +441,7 @@ func (pool *hostConnPool) fill() {
 			return
 		}
 		// notify the session that this node is connected
-		go pool.session.handleNodeUp(pool.host.ConnectAddress(), pool.port)
+		go pool.session.handleNodeConnected(pool.host)
 
 		// filled one
 		fillCount--
@@ -456,7 +456,7 @@ func (pool *hostConnPool) fill() {
 
 		if err == nil && startCount > 0 {
 			// notify the session that this node is connected again
-			go pool.session.handleNodeUp(pool.host.ConnectAddress(), pool.port)
+			go pool.session.handleNodeConnected(pool.host)
 		}
 	}()
 }

--- a/control.go
+++ b/control.go
@@ -285,6 +285,15 @@ func (c *controlConn) setupConn(conn *Conn) error {
 	}
 
 	c.conn.Store(ch)
+	if c.session.initialized() {
+		// We connected to control conn, so add the connect the host in pool as well.
+		// Notify session we can start trying to connect to the node.
+		// We can't start the fill before the session is initialized, otherwise the fill would interfere
+		// with the fill called by Session.init. Session.init needs to wait for its fill to finish and that
+		// would return immediately if we started the fill here.
+		// TODO(martin-sucha): Trigger pool refill for all hosts, like in reconnectDownedHosts?
+		go c.session.startPoolFill(host)
+	}
 	return nil
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -645,8 +645,7 @@ func (r *ringDescriber) refreshRing() error {
 		}
 
 		if host, ok := r.session.ring.addHostIfMissing(h); !ok {
-			r.session.pool.addHost(h)
-			r.session.policy.AddHost(h)
+			r.session.startPoolFill(h)
 		} else {
 			host.update(h)
 		}


### PR DESCRIPTION
After merging https://github.com/gocql/gocql/pull/1369 it could happen
that after losing connection to a host, it is not reconnected.

That could happen in the following case:

1. We lose connection to a host.
2. We receive UP event for the host, the host is marked as UP even
   though we don't have active connections to it.
3. We don't reconnect to the host in reconnectDownedHosts because it's
   marked as UP already.

In PR 1369 we intended to change the host states so that a host is
marked as UP only after we have some connection to it. However, we also
removed the call to fill the pool on UP event in case the host already
existed.

This commit adds the call to fill the pool back to handleNodeUp.
We introduce handleNodeConnected for marking the host as up,
so that handleNodeUp handles only the UP event and the responsibilities
are clear.

Control connection is tried to be reconnected every second after
it is lost.
Before PR 1369, after establishing a control connection to a host,
we triggered pool refill for the same host.
PR 1369 removed this behaviour so that it is possible to wait
for the connection to be added to the pool in Session.init (and not
mark the host UP if we have only control connection.
This means that it could take up to cfg.ReconnectInterval after
estabilishing control connection to have some usable host in the pool
to service user queries after PR 1369.

To restore the old behavior, we add back triggering of pool refill after
control connection is connected. We can only do so after the session is
initialized, so that we don't the interfere with initialization code
in Session.init.

Related https://github.com/gocql/gocql/issues/915