### PR TITLE
Return table configuration parameters in TableMetadata

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "gopls": {
+        "build.buildFlags": ["-tags=all"]
+    }
+}

--- a/AUTHORS
+++ b/AUTHORS
@@ -121,3 +121,4 @@ Jaume Marhuenda Beltran <jaumemarhuenda@gmail.com>
 Piotr Dulikowski <piodul@scylladb.com>
 Árni Dagur <arni@dagur.eu>
 Tushar Das <tushar.das5@gmail.com>
+Eric Evans <eevans@wikimedia.org>

--- a/install_test_deps.sh
+++ b/install_test_deps.sh
@@ -4,7 +4,7 @@
 
 # Install CCM
 pip install --user cql PyYAML six
-git clone https://github.com/pcmanus/ccm.git
+git clone https://github.com/riptano/ccm.git
 pushd ccm
 ./setup.py install --user
 popd


### PR DESCRIPTION
This adds attributes to `TableMetadata` for table config parameters (compression, compaction, default time to live, speculative retries, etc).  However, because the number and disposition of parameters differs across versions of Cassandra, it (currently) only does so for Cassandra versions >= 3.  The rationale for this (such as it is), was to add support moving forward for recent/popular versions, and avoid contributing any more conditional behavior to this area of the code than was necessary.  It's not perfect though, users of older versions will see uninitialized struct members – some which are valid for their version of Cassandra, and some which are not.

TL;DR I didn't see an obvious Good Answer here, so consider this my attempt to exploit [Cunningham's Law](https://meta.wikimedia.org/wiki/Cunningham%27s_Law); Happy to iterate on this if there are ideas for making it better