### PR TITLE
Fix flaky test TestStartupTimeout

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -238,7 +238,8 @@ func TestStartupTimeout(t *testing.T) {
 		t.Fatalf("Expected to receive no connections error - got '%s'", err)
 	}
 
-	if !strings.Contains(log.String(), "no response to connection startup within timeout") {
+	if !strings.Contains(log.String(), "no response to connection startup within timeout") &&
+		!strings.Contains(log.String(), "no response received from cassandra within timeout period") {
 		t.Fatalf("Expected to receive timeout log message  - got '%s'", log.String())
 	}
 


### PR DESCRIPTION
In conn_test.go, "TestStartupTimeout" at the very last step requires the log to contain "no response to connection startup within timeout".

However, during my test, it fails sometimes, not always, with log containing "no response received from cassandra within timeout period" instead.

Fixing the flaky test by allowing log to contain either message.