### PR TITLE
Add rack aware round-robin host policy

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1435,7 +1435,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 		}
 
 		for _, row := range rows {
-			host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.ConnectAddress(), port: c.session.cfg.Port})
+			host, err := c.session.hostInfoFromMap(row, c.host.ConnectAddress(), c.session.cfg.Port)
 			if err != nil {
 				goto cont
 			}
@@ -1495,7 +1495,7 @@ func (c *Conn) localHostInfo(ctx context.Context) (*HostInfo, error) {
 	port := c.conn.RemoteAddr().(*net.TCPAddr).Port
 
 	// TODO(zariel): avoid doing this here
-	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.connectAddress, port: port})
+	host, err := c.session.hostInfoFromMap(row, c.host.connectAddress, port)
 	if err != nil {
 		return nil, err
 	}

--- a/policies_test.go
+++ b/policies_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hailocab/go-hostpool"
 )
 
@@ -618,4 +620,126 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 	iterCheck(t, iter, "5")
 	iterCheck(t, iter, "6")
 	iterCheck(t, iter, "8")
+}
+
+// Hosts from the same rack are preferred.
+func TestHostPolicy_RackAwareRR_SameRack(t *testing.T) {
+	p := RackAwareRRHostPolicy("dc2", "rack2")
+
+	hosts := []*HostInfo{
+		{hostId: "1", connectAddress: net.ParseIP("10.0.0.1"), dataCenter: "dc1", rack: "rack1"},
+		{hostId: "2", connectAddress: net.ParseIP("10.0.0.2"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "3", connectAddress: net.ParseIP("10.0.0.3"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "4", connectAddress: net.ParseIP("10.0.0.4"), dataCenter: "dc2", rack: "rack1"},
+		{hostId: "5", connectAddress: net.ParseIP("10.0.0.5"), dataCenter: "dc2", rack: "rack2"},
+		{hostId: "6", connectAddress: net.ParseIP("10.0.0.6"), dataCenter: "dc2", rack: "rack2"},
+		{hostId: "7", connectAddress: net.ParseIP("10.0.0.7"), dataCenter: "dc3", rack: "rack1"},
+		{hostId: "8", connectAddress: net.ParseIP("10.0.0.8"), dataCenter: "dc3", rack: "rack2"},
+		{hostId: "9", connectAddress: net.ParseIP("10.0.0.9"), dataCenter: "dc3", rack: "rack2"},
+	}
+	for _, host := range hosts {
+		p.AddHost(host)
+	}
+
+	got := make(map[string]bool, len(hosts))
+	order := make([]*HostInfo, 0, len(hosts))
+
+	// Make sure the same host is not returned twice.
+	it := p.Pick(nil)
+	for h := it(); h != nil; h = it() {
+		id := h.Info().hostId
+		require.NotNilf(t, got[id], "got duplicate host %s", id)
+		got[id] = true
+		order = append(order, h.Info())
+	}
+	// Make sure all available hosts has been offered.
+	require.Len(t, order, len(hosts))
+
+	require.Equal(t, "dc2", order[0].DataCenter())
+	require.Equal(t, "dc2", order[1].DataCenter())
+	require.Equal(t, "dc2", order[2].DataCenter())
+	require.NotEqual(t, "dc2", order[3].DataCenter())
+
+	require.Equal(t, "rack2", order[0].Rack())
+	require.Equal(t, "rack2", order[1].Rack())
+	require.NotEqual(t, "rack2", order[2].Rack())
+}
+
+// If there are no hosts in the same rack then hosts from the same datacenter
+// are preferred.
+func TestHostPolicy_RackAwareRR_SameDatacenter(t *testing.T) {
+	p := RackAwareRRHostPolicy("dc2", "rack2")
+
+	hosts := []*HostInfo{
+		{hostId: "1", connectAddress: net.ParseIP("10.0.0.1"), dataCenter: "dc1", rack: "rack1"},
+		{hostId: "2", connectAddress: net.ParseIP("10.0.0.2"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "3", connectAddress: net.ParseIP("10.0.0.3"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "4", connectAddress: net.ParseIP("10.0.0.4"), dataCenter: "dc2", rack: "rack1"},
+		{hostId: "5", connectAddress: net.ParseIP("10.0.0.5"), dataCenter: "dc2", rack: "rack4"},
+		{hostId: "6", connectAddress: net.ParseIP("10.0.0.6"), dataCenter: "dc2", rack: "rack4"},
+		{hostId: "7", connectAddress: net.ParseIP("10.0.0.7"), dataCenter: "dc3", rack: "rack1"},
+		{hostId: "8", connectAddress: net.ParseIP("10.0.0.8"), dataCenter: "dc3", rack: "rack2"},
+		{hostId: "9", connectAddress: net.ParseIP("10.0.0.9"), dataCenter: "dc3", rack: "rack2"},
+	}
+	for _, host := range hosts {
+		p.AddHost(host)
+	}
+
+	got := make(map[string]bool, len(hosts))
+	order := make([]*HostInfo, 0, len(hosts))
+
+	// Make sure the same host is not returned twice.
+	it := p.Pick(nil)
+	for h := it(); h != nil; h = it() {
+		id := h.Info().hostId
+		require.NotNilf(t, got[id], "got duplicate host %s", id)
+		got[id] = true
+		order = append(order, h.Info())
+	}
+	// Make sure all available hosts has been offered.
+	require.Len(t, order, len(hosts))
+
+	require.Equal(t, "dc2", order[0].DataCenter())
+	require.Equal(t, "dc2", order[1].DataCenter())
+	require.Equal(t, "dc2", order[2].DataCenter())
+	require.NotEqual(t, "dc2", order[3].DataCenter())
+
+	require.NotEqual(t, "rack2", order[0].Rack())
+}
+
+// If there are no hosts from the same datacenter, then the exact order of
+// other hosts does not matter.
+func TestHostPolicy_RackAwareRR_Remote(t *testing.T) {
+	p := RackAwareRRHostPolicy("dc2", "rack2")
+
+	hosts := []*HostInfo{
+		{hostId: "1", connectAddress: net.ParseIP("10.0.0.1"), dataCenter: "dc1", rack: "rack1"},
+		{hostId: "2", connectAddress: net.ParseIP("10.0.0.2"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "3", connectAddress: net.ParseIP("10.0.0.3"), dataCenter: "dc1", rack: "rack2"},
+		{hostId: "4", connectAddress: net.ParseIP("10.0.0.4"), dataCenter: "dc4", rack: "rack1"},
+		{hostId: "5", connectAddress: net.ParseIP("10.0.0.5"), dataCenter: "dc4", rack: "rack2"},
+		{hostId: "6", connectAddress: net.ParseIP("10.0.0.6"), dataCenter: "dc4", rack: "rack2"},
+		{hostId: "7", connectAddress: net.ParseIP("10.0.0.7"), dataCenter: "dc3", rack: "rack1"},
+		{hostId: "8", connectAddress: net.ParseIP("10.0.0.8"), dataCenter: "dc3", rack: "rack2"},
+		{hostId: "9", connectAddress: net.ParseIP("10.0.0.9"), dataCenter: "dc3", rack: "rack2"},
+	}
+	for _, host := range hosts {
+		p.AddHost(host)
+	}
+
+	got := make(map[string]bool, len(hosts))
+	order := make([]*HostInfo, 0, len(hosts))
+
+	// Make sure the same host is not returned twice.
+	it := p.Pick(nil)
+	for h := it(); h != nil; h = it() {
+		id := h.Info().hostId
+		require.NotNilf(t, got[id], "got duplicate host %s", id)
+		got[id] = true
+		order = append(order, h.Info())
+	}
+	// Make sure all available hosts has been offered.
+	require.Len(t, order, len(hosts))
+
+	require.NotEqual(t, "dc2", order[0].DataCenter())
 }


### PR DESCRIPTION
### Summary
When Cassandra is provisioned in a cloud environment, in such a way that nodes are spread across multiple availability zones, it is more const effective to query nodes in the same availability zone. Currently `gocql` provides [DC-aware round-robin host policy](https://github.com/gocql/gocql/blob/master/policies.go#L772-L777), but it does not respect availability zone. This PR introduces rack-aware round-robin policy that prefers nodes in the same rack, if there are no nodes in the same rack then nodes from the same datacenter are preferred.

### Usage Guidelines
 * When Cassandra is provisioned in AWS with [Ec2Snitch](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archSnitchEC2.html), it converts availability zone to datacenter/rack pair breaking it in half on the last dash, so **availability zone** `eu-central-1c` becomes **datacenter** `eu-central` and **rack** `1c`;
 * When Cassandra is provisioned in GCP with [GoogleCloudSnitch](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archSnitchGoogle.html), it converts availability zone to datacenter/rack pair breaking it in half on the last dash, so **availability zone** `us-central1-a` becomes **datacenter** `us-central1` and **rack** `a`;

For maximum efficiency we recommend using this policy as a fallback for token aware host policy as follows:
```Go
cluster := gocql.NewCluster(servers)
cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RackAwareRRHostPolicy(datacenter, rack))
``` 
