### PR TITLE
Maxim/develop2

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1435,7 +1435,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 		}
 
 		for _, row := range rows {
-			host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.ConnectAddress(), port: c.session.cfg.Port})
+			host, err := c.session.hostInfoFromMap(row, c.host.ConnectAddress(), c.session.cfg.Port)
 			if err != nil {
 				goto cont
 			}
@@ -1495,7 +1495,7 @@ func (c *Conn) localHostInfo(ctx context.Context) (*HostInfo, error) {
 	port := c.conn.RemoteAddr().(*net.TCPAddr).Port
 
 	// TODO(zariel): avoid doing this here
-	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.connectAddress, port: port})
+	host, err := c.session.hostInfoFromMap(row, c.host.connectAddress, port)
 	if err != nil {
 		return nil, err
 	}

--- a/policies.go
+++ b/policies.go
@@ -604,7 +604,6 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		}
 
 		if fallbackIter == nil {
-			// fallback
 			fallbackIter = t.fallback.Pick(qry)
 		}
 
@@ -1023,6 +1022,8 @@ type SpeculativeExecutionPolicy interface {
 }
 
 type NonSpeculativeExecution struct{}
+
+var nonSpeculativeExecution NonSpeculativeExecution
 
 func (sp NonSpeculativeExecution) Attempts() int        { return 0 } // No additional attempts
 func (sp NonSpeculativeExecution) Delay() time.Duration { return 1 } // The delay. Must be positive to be used in a ticker.

--- a/session.go
+++ b/session.go
@@ -875,7 +875,7 @@ type Query struct {
 
 	disableAutoPage bool
 
-	// getKeyspace is field so that it can be overriden in tests
+	// getKeyspace is field so that it can be overridden in tests
 	getKeyspace func() string
 
 	// used by control conn queries to prevent triggering a write to systems
@@ -896,10 +896,10 @@ func (q *Query) defaultsFromSession() {
 	q.serialCons = s.cfg.SerialConsistency
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
-	q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
-
-	q.spec = &NonSpeculativeExecution{}
 	s.mu.RUnlock()
+
+	q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+	q.spec = &nonSpeculativeExecution
 }
 
 // Statement returns the statement that was used to generate this query.


### PR DESCRIPTION
### Summary
When Cassandra is provisioned in a cloud environment, in such a way that nodes are spread across multiple availability zones, it is more const effective to query nodes in the same availability zone. Currently `gocql` provides [DC-aware round-robin host policy](https://github.com/gocql/gocql/blob/master/policies.go#L772-L777), but it does not respect availability zone. This PR introduces rack-aware round-robin policy that prefers nodes in the same rack, if there are no nodes in the same rack then nodes from the same datacenter are preferred.

### Usage Guidelines
 * When Cassandra is provisioned in AWS with [Ec2Snitch](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archSnitchEC2.html), it converts availability zone to datacenter/rack pair breaking it in half on the last dash, so **availability zone** `eu-central-1c` becomes **datacenter** `eu-central` and **rack** `1c`;
 * When Cassandra is provisioned in GCP with [GoogleCloudSnitch](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archSnitchGoogle.html), it converts availability zone to datacenter/rack pair breaking it in half on the last dash, so **availability zone** `us-central1-a` becomes **datacenter** `us-central1` and **rack** `a`;

For maximum efficiency we recommend using this policy as a fallback for token aware host policy as follows:
```Go
cluster := gocql.NewCluster(servers)
cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(
    gocql.RackAwareRRHostPolicy(datacenter, rack), , gocql.NonLocalReplicasFallback())
``` 
Note that the token-aware policy uses the rack-aware policy to determine if a host is local. Only hosts from the same rack are considered to be local by the rack-aware policy. Non-local replica fallback is enabled to ensure that the token-aware policy still connects to a host that has a replica, even when there are no replicas in the same rack, otherwise decision making would have been handed over to the rack-aware policy that would connect to an arbitrary host from the same datacenter.