### PR TITLE
Move lz4 compressor to separate module

### DIFF
--- a/compressor.go
+++ b/compressor.go
@@ -1,11 +1,7 @@
 package gocql
 
 import (
-	"encoding/binary"
-	"fmt"
-
 	"github.com/golang/snappy"
-	"github.com/pierrec/lz4/v4"
 )
 
 type Compressor interface {
@@ -29,47 +25,4 @@ func (s SnappyCompressor) Encode(data []byte) ([]byte, error) {
 
 func (s SnappyCompressor) Decode(data []byte) ([]byte, error) {
 	return snappy.Decode(nil, data)
-}
-
-// LZ4Compressor implements the gocql.Compressor interface and can be used to
-// compress incoming and outgoing frames. According to the Cassandra docs the
-// LZ4 protocol should be preferred over snappy. (For details refer to
-// https://cassandra.apache.org/doc/latest/operating/compression.html)
-//
-// Implementation note: Cassandra prefixes each compressed block with 4 bytes
-// of the uncompressed block length, written in big endian order. But the LZ4
-// compression library github.com/pierrec/lz4/v4 does not expect the length
-// field, so it needs to be added to compressed blocks sent to Cassandra, and
-// removed from ones received from Cassandra before decompression.
-type LZ4Compressor struct{}
-
-func (s LZ4Compressor) Name() string {
-	return "lz4"
-}
-
-func (s LZ4Compressor) Encode(data []byte) ([]byte, error) {
-	buf := make([]byte, lz4.CompressBlockBound(len(data)+4))
-	var compressor lz4.Compressor
-	n, err := compressor.CompressBlock(data, buf[4:])
-	// According to lz4.CompressBlock doc, it doesn't fail as long as the dst
-	// buffer length is at least lz4.CompressBlockBound(len(data))) bytes, but
-	// we check for error anyway just to be thorough.
-	if err != nil {
-		return nil, err
-	}
-	binary.BigEndian.PutUint32(buf, uint32(len(data)))
-	return buf[:n+4], nil
-}
-
-func (s LZ4Compressor) Decode(data []byte) ([]byte, error) {
-	if len(data) < 4 {
-		return nil, fmt.Errorf("cassandra lz4 block size should be >4, got=%d", len(data))
-	}
-	uncompressedLength := binary.BigEndian.Uint32(data)
-	if uncompressedLength == 0 {
-		return nil, nil
-	}
-	buf := make([]byte, uncompressedLength)
-	n, err := lz4.UncompressBlock(data[4:], buf)
-	return buf[:n], err
 }

--- a/compressor_test.go
+++ b/compressor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/golang/snappy"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSnappyCompressor(t *testing.T) {
@@ -36,27 +35,4 @@ func TestSnappyCompressor(t *testing.T) {
 	} else if bytes.Compare(expected, res) != 0 {
 		t.Fatal("failed to match the expected decoded value with the result decoded value.")
 	}
-}
-
-func TestLZ4Compressor(t *testing.T) {
-	var c LZ4Compressor
-	require.Equal(t, "lz4", c.Name())
-
-	_, err := c.Decode([]byte{0, 1, 2})
-	require.EqualError(t, err, "cassandra lz4 block size should be >4, got=3")
-
-	_, err = c.Decode([]byte{0, 1, 2, 4, 5})
-	require.EqualError(t, err, "lz4: invalid source or destination buffer too short")
-
-	// If uncompressed size is zero then nothing is decoded even if present.
-	decoded, err := c.Decode([]byte{0, 0, 0, 0, 5, 7, 8})
-	require.NoError(t, err)
-	require.Nil(t, decoded)
-
-	original := []byte("My Test String")
-	encoded, err := c.Encode(original)
-	require.NoError(t, err)
-	decoded, err = c.Decode(encoded)
-	require.NoError(t, err)
-	require.Equal(t, original, decoded)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,7 @@ require (
 	github.com/golang/snappy v0.0.3
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pierrec/lz4/v4 v4.1.7
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,10 +13,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pierrec/lz4 v1.0.1 h1:w6GMGWSsCI04fTM8wQRdnW74MuJISakuUU0onU0TYB4=
-github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
-github.com/pierrec/lz4/v4 v4.1.7 h1:UDV9geJWhFIufAliH7HQlz9wP3JA0t748w+RwbWMLow=
-github.com/pierrec/lz4/v4 v4.1.7/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/lz4/go.mod
+++ b/lz4/go.mod
@@ -1,0 +1,8 @@
+module github.com/gocql/gocql/lz4
+
+go 1.16
+
+require (
+	github.com/pierrec/lz4/v4 v4.1.8
+	github.com/stretchr/testify v1.7.0
+)

--- a/lz4/go.sum
+++ b/lz4/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
+github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -1,0 +1,51 @@
+package lz4
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// LZ4Compressor implements the gocql.Compressor interface and can be used to
+// compress incoming and outgoing frames. According to the Cassandra docs the
+// LZ4 protocol should be preferred over snappy. (For details refer to
+// https://cassandra.apache.org/doc/latest/operating/compression.html)
+//
+// Implementation note: Cassandra prefixes each compressed block with 4 bytes
+// of the uncompressed block length, written in big endian order. But the LZ4
+// compression library github.com/pierrec/lz4/v4 does not expect the length
+// field, so it needs to be added to compressed blocks sent to Cassandra, and
+// removed from ones received from Cassandra before decompression.
+type LZ4Compressor struct{}
+
+func (s LZ4Compressor) Name() string {
+	return "lz4"
+}
+
+func (s LZ4Compressor) Encode(data []byte) ([]byte, error) {
+	buf := make([]byte, lz4.CompressBlockBound(len(data)+4))
+	var compressor lz4.Compressor
+	n, err := compressor.CompressBlock(data, buf[4:])
+	// According to lz4.CompressBlock doc, it doesn't fail as long as the dst
+	// buffer length is at least lz4.CompressBlockBound(len(data))) bytes, but
+	// we check for error anyway just to be thorough.
+	if err != nil {
+		return nil, err
+	}
+	binary.BigEndian.PutUint32(buf, uint32(len(data)))
+	return buf[:n+4], nil
+}
+
+func (s LZ4Compressor) Decode(data []byte) ([]byte, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("cassandra lz4 block size should be >4, got=%d", len(data))
+	}
+	uncompressedLength := binary.BigEndian.Uint32(data)
+	if uncompressedLength == 0 {
+		return nil, nil
+	}
+	buf := make([]byte, uncompressedLength)
+	n, err := lz4.UncompressBlock(data[4:], buf)
+	return buf[:n], err
+}

--- a/lz4/lz4_test.go
+++ b/lz4/lz4_test.go
@@ -1,0 +1,30 @@
+package lz4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLZ4Compressor(t *testing.T) {
+	var c LZ4Compressor
+	require.Equal(t, "lz4", c.Name())
+
+	_, err := c.Decode([]byte{0, 1, 2})
+	require.EqualError(t, err, "cassandra lz4 block size should be >4, got=3")
+
+	_, err = c.Decode([]byte{0, 1, 2, 4, 5})
+	require.EqualError(t, err, "lz4: invalid source or destination buffer too short")
+
+	// If uncompressed size is zero then nothing is decoded even if present.
+	decoded, err := c.Decode([]byte{0, 0, 0, 0, 5, 7, 8})
+	require.NoError(t, err)
+	require.Nil(t, decoded)
+
+	original := []byte("My Test String")
+	encoded, err := c.Encode(original)
+	require.NoError(t, err)
+	decoded, err = c.Decode(encoded)
+	require.NoError(t, err)
+	require.Equal(t, original, decoded)
+}


### PR DESCRIPTION
Some users have problems using gocql/gocql with dep as
dep can't work with v4 dependency.
Moving the lz4 compressor to a separate module.
This is a breaking change, but there probably aren't many
people using the lz4 compressor yet.