### PR TITLE
Prevent session Close() from hanging up

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -123,3 +123,4 @@ Piotr Dulikowski <piodul@scylladb.com>
 Tushar Das <tushar.das5@gmail.com>
 Maxim Vladimirskiy <horkhe@gmail.com>
 Bogdan-Ciprian Rusu <bogdanciprian.rusu@crowdstrike.com>
+Yuto Doi <yutodoi.seattle@gmail.com>

--- a/control.go
+++ b/control.go
@@ -395,6 +395,10 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 
+	if atomic.LoadInt32(&c.started) == -1 {
+		return
+	}
+
 	oldConn := c.getConn()
 
 	// If connection has long gone, and not been attempted for awhile,


### PR DESCRIPTION
**Summary**
Check closed flag on controlConn HandleError to avoid reconnecting when session closes

**Problem**
When trying to close connection pool via `session.Close()`, the method hangs up due to the following line.
https://github.com/gocql/gocql/blob/master/session.go#L464
https://github.com/gocql/gocql/blob/master/conn.go#L546

**Description**
This PR is adding a flag that is turned on when close method is called and HandleError method skip the main logic when the flag is on. The implementation is following `hostConnPool` on connectionpool.go ([ref](https://github.com/gocql/gocql/blob/master/connectionpool.go#L579-L587))


