### PR TITLE
Adding TokenAwareAuthenticator plugin to connection whitelist.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,7 @@ var (
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator",
 		"com.amazon.helenus.auth.HelenusAuthenticator",
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator",
+		"com.bloomberg.cassandra.auth.TokenAwareAuthenticator",
 	}
 )
 


### PR DESCRIPTION
This is a seemingly trivial change to a plugin whitelist. It uses a drop-in replacement to cassandra username/password authenticator which also supports Token based authentication. Based on https://github.com/gocql/gocql/pull/1441