### PR TITLE
Fix pool imbalance when using DNS for contact points

### DIFF
--- a/control.go
+++ b/control.go
@@ -148,7 +148,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 	}
 
 	for _, ip := range ips {
-		hosts = append(hosts, &HostInfo{hostname: host, connectAddress: ip, port: port})
+		hosts = append(hosts, &HostInfo{hostname: ip.String(), connectAddress: ip, port: port})
 	}
 
 	return hosts, nil


### PR DESCRIPTION
When a hostname is used for contact points it's resolved initially as
part of the initialization process then `HostInfo` objects are created
with the original `hostname` and the resolved `connectAddress`.
`hostname` is then used to dial the pool connections when causes another
DNS resolve which could result in a different IP then the original
`connectAddress` because A records can change order for each resolve.
This results in a connection pool for a given IP address containing
connections to multiple different IP addresses.

This patch removes the second resolve when dialing by setting the
`hostname` member to the resolved IP in the initialization step.

Resolves #1575