### PR TITLE
Add check for pointer kind to unmarshalUDT

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2291,7 +2291,11 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 		return nil
 	}
 
-	k := reflect.ValueOf(value).Elem()
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Ptr {
+		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
+	}
+	k := rv.Elem()
 	if k.Kind() != reflect.Struct || !k.IsValid() {
 		return unmarshalErrorf("cannot unmarshal %s into %T", info, value)
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,4 +1,5 @@
-//+build all unit
+//go:build all || unit
+// +build all unit
 
 package gocql
 
@@ -2191,5 +2192,31 @@ func BenchmarkUnmarshalUUID(b *testing.B) {
 		if err := unmarshalUUID(ti, src, &dst); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestUnmarshalUDT(t *testing.T) {
+	info := UDTTypeInfo{
+		NativeType: NativeType{proto: 4, typ: TypeUDT},
+		Name:       "myudt",
+		KeySpace:   "myks",
+		Elements: []UDTField{
+			{
+				Name: "first",
+				Type: NativeType{proto: 4, typ: TypeAscii},
+			},
+			{
+				Name: "second",
+				Type: NativeType{proto: 4, typ: TypeSmallInt},
+			},
+		},
+	}
+	data := []byte("\x00\x00\x00\x0f\x00\x00\x00\x05Hello\x00\x00\x00\x02\x00\x2a")
+	value := map[string]interface{}{}
+	expectedErr := UnmarshalError("can not unmarshal into non-pointer map[string]interface {}")
+
+	if err := Unmarshal(info, data, value); err != expectedErr {
+		t.Errorf("(%v=>%T): %#v returned error %#v, want %#v.",
+			info, value, value, err, expectedErr)
 	}
 }


### PR DESCRIPTION
reflect.Value.Elem panics when the value is not a suitable type.
In all other places we check that we received a pointer value,
but the check was missing in unmarshalUDT.

We want to return an error instead of the panic that happened
previously:

```
panic: reflect: call of reflect.Value.Elem on map Value [recovered]
	panic: reflect: call of reflect.Value.Elem on map Value

goroutine 6 [running]:
testing.tRunner.func1.2({0x72af00, 0xc00000e150})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x72af00, 0xc00000e150})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
reflect.Value.Elem({0x72dd60, 0xc000108f00, 0xc000108f00})
	/usr/local/go/src/reflect/value.go:1178 +0x15a
github.com/gocql/gocql.unmarshalUDT({0x801eb0, 0xc000028360},
{0xc00001c540, 0x13, 0x13}, {0x72dd60, 0xc000108f00})
	/home/martin/Projects/gocql/marshal.go:2294 +0x69f
github.com/gocql/gocql.Unmarshal({0x801eb0, 0xc000028360},
{0xc00001c540, 0x829974, 0x13}, {0x72dd60, 0xc000108f00})
	/home/martin/Projects/gocql/marshal.go:252 +0x7b1
github.com/gocql/gocql.TestUnmarshalUDT(0xc00011ed00)
	/home/martin/Projects/gocql/marshal_test.go:2218 +0x285
testing.tRunner(0xc00011ed00, 0x79f508)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
```