### PR TITLE
errors: Expose predefined raw protocol error codes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -2,26 +2,85 @@ package gocql
 
 import "fmt"
 
+// See CQL Binary Protocol v5, section 8 for more details.
+// https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec
 const (
-	errServer          = 0x0000
-	errProtocol        = 0x000A
-	errCredentials     = 0x0100
-	errUnavailable     = 0x1000
-	errOverloaded      = 0x1001
-	errBootstrapping   = 0x1002
-	errTruncate        = 0x1003
-	errWriteTimeout    = 0x1100
-	errReadTimeout     = 0x1200
-	errReadFailure     = 0x1300
-	errFunctionFailure = 0x1400
-	errWriteFailure    = 0x1500
-	errCDCWriteFailure = 0x1600
-	errSyntax          = 0x2000
-	errUnauthorized    = 0x2100
-	errInvalid         = 0x2200
-	errConfig          = 0x2300
-	errAlreadyExists   = 0x2400
-	errUnprepared      = 0x2500
+	// ErrCodeServer indicates unexpected error on server-side.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1246-L1247
+	ErrCodeServer = 0x0000
+	// ErrCodeProtocol indicates a protocol violation by some client message.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1248-L1250
+	ErrCodeProtocol = 0x000A
+	// ErrCodeCredentials indicates missing required authentication.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1251-L1254
+	ErrCodeCredentials = 0x0100
+	// ErrCodeUnavailable indicates unavailable error.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1255-L1265
+	ErrCodeUnavailable = 0x1000
+	// ErrCodeOverloaded returned in case of request on overloaded node coordinator.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1266-L1267
+	ErrCodeOverloaded = 0x1001
+	// ErrCodeBootstrapping returned from the coordinator node in bootstrapping phase.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1268-L1269
+	ErrCodeBootstrapping = 0x1002
+	// ErrCodeTruncate indicates truncation exception.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1270
+	ErrCodeTruncate = 0x1003
+	// ErrCodeWriteTimeout returned in case of timeout during the request write.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1271-L1304
+	ErrCodeWriteTimeout = 0x1100
+	// ErrCodeReadTimeout returned in case of timeout during the request read.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1305-L1321
+	ErrCodeReadTimeout = 0x1200
+	// ErrCodeReadFailure indicates request read error which is not covered by ErrCodeReadTimeout.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1322-L1340
+	ErrCodeReadFailure = 0x1300
+	// ErrCodeFunctionFailure indicates an error in user-defined function.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1341-L1347
+	ErrCodeFunctionFailure = 0x1400
+	// ErrCodeWriteFailure indicates request write error which is not covered by ErrCodeWriteTimeout.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1348-L1385
+	ErrCodeWriteFailure = 0x1500
+	// ErrCodeCDCWriteFailure is defined, but not yet documented in CQLv5 protocol.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1386
+	ErrCodeCDCWriteFailure = 0x1600
+	// ErrCodeSyntax indicates the syntax error in the query.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1399
+	ErrCodeSyntax = 0x2000
+	// ErrCodeUnauthorized indicates access rights violation by user on performed operation.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1400-L1401
+	ErrCodeUnauthorized = 0x2100
+	// ErrCodeInvalid indicates invalid query error which is not covered by ErrCodeSyntax.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1402
+	ErrCodeInvalid = 0x2200
+	// ErrCodeConfig indicates the configuration error.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1403
+	ErrCodeConfig = 0x2300
+	// ErrCodeAlreadyExists is returned for the requests creating the existing keyspace/table.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1404-L1413
+	ErrCodeAlreadyExists = 0x2400
+	// ErrCodeUnprepared returned from the host for prepared statement which is unknown.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1414-L1417
+	ErrCodeUnprepared = 0x2500
 )
 
 type RequestError interface {

--- a/frame.go
+++ b/frame.go
@@ -590,7 +590,7 @@ func (f *framer) parseErrorFrame() frame {
 	}
 
 	switch code {
-	case errUnavailable:
+	case ErrCodeUnavailable:
 		cl := f.readConsistency()
 		required := f.readInt()
 		alive := f.readInt()
@@ -600,7 +600,7 @@ func (f *framer) parseErrorFrame() frame {
 			Required:    required,
 			Alive:       alive,
 		}
-	case errWriteTimeout:
+	case ErrCodeWriteTimeout:
 		cl := f.readConsistency()
 		received := f.readInt()
 		blockfor := f.readInt()
@@ -612,7 +612,7 @@ func (f *framer) parseErrorFrame() frame {
 			BlockFor:    blockfor,
 			WriteType:   writeType,
 		}
-	case errReadTimeout:
+	case ErrCodeReadTimeout:
 		cl := f.readConsistency()
 		received := f.readInt()
 		blockfor := f.readInt()
@@ -624,7 +624,7 @@ func (f *framer) parseErrorFrame() frame {
 			BlockFor:    blockfor,
 			DataPresent: dataPresent,
 		}
-	case errAlreadyExists:
+	case ErrCodeAlreadyExists:
 		ks := f.readString()
 		table := f.readString()
 		return &RequestErrAlreadyExists{
@@ -632,13 +632,13 @@ func (f *framer) parseErrorFrame() frame {
 			Keyspace:   ks,
 			Table:      table,
 		}
-	case errUnprepared:
+	case ErrCodeUnprepared:
 		stmtId := f.readShortBytes()
 		return &RequestErrUnprepared{
 			errorFrame:  errD,
 			StatementId: copyBytes(stmtId), // defensively copy
 		}
-	case errReadFailure:
+	case ErrCodeReadFailure:
 		res := &RequestErrReadFailure{
 			errorFrame: errD,
 		}
@@ -654,7 +654,7 @@ func (f *framer) parseErrorFrame() frame {
 		res.DataPresent = f.readByte() != 0
 
 		return res
-	case errWriteFailure:
+	case ErrCodeWriteFailure:
 		res := &RequestErrWriteFailure{
 			errorFrame: errD,
 		}
@@ -669,7 +669,7 @@ func (f *framer) parseErrorFrame() frame {
 		}
 		res.WriteType = f.readString()
 		return res
-	case errFunctionFailure:
+	case ErrCodeFunctionFailure:
 		res := &RequestErrFunctionFailure{
 			errorFrame: errD,
 		}
@@ -678,14 +678,14 @@ func (f *framer) parseErrorFrame() frame {
 		res.ArgTypes = f.readStringList()
 		return res
 
-	case errCDCWriteFailure:
+	case ErrCodeCDCWriteFailure:
 		res := &RequestErrCDCWriteFailure{
 			errorFrame: errD,
 		}
 		return res
 
-	case errInvalid, errBootstrapping, errConfig, errCredentials, errOverloaded,
-		errProtocol, errServer, errSyntax, errTruncate, errUnauthorized:
+	case ErrCodeInvalid, ErrCodeBootstrapping, ErrCodeConfig, ErrCodeCredentials, ErrCodeOverloaded,
+		ErrCodeProtocol, ErrCodeServer, ErrCodeSyntax, ErrCodeTruncate, ErrCodeUnauthorized:
 		// TODO(zariel): we should have some distinct types for these errors
 		return errD
 	default:

--- a/host_source.go
+++ b/host_source.go
@@ -399,7 +399,7 @@ func checkSystemSchema(control *controlConn) (bool, error) {
 	iter := control.query("SELECT * FROM system_schema.keyspaces")
 	if err := iter.err; err != nil {
 		if errf, ok := err.(*errorFrame); ok {
-			if errf.code == errSyntax {
+			if errf.code == ErrCodeSyntax {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
This commit is required to simplify the distinguishing between errors on
caller side especially for ones without distinct error type. The API of
the package already provides the exported RequestError interface which
returns the integer value of error code, but code itself were as
non-exported constants.

To achieve this the next changes has been done:
1. Type ErrorCode has been created.
2. Signature of the RequestError interface has been changed to return
newly introduced type instead of plain integer.
3. All preedfined error codes has been renamed with pattern
s/err/ErrCode/
4. Every constant of type ErrorCode has been documented according to the
specification of the protocol v5 (section 8)
https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec

Fixes #1335