### PR TITLE
errors: Add CAS Write Unknown Error from CQL protocol

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -57,6 +57,10 @@ const (
 	//
 	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1386
 	ErrCodeCDCWriteFailure = 0x1600
+	// ErrCodeCASWriteUnknown indicates only partially completed CAS operation.
+	//
+	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1387-L1397
+	ErrCodeCASWriteUnknown = 0x1700
 	// ErrCodeSyntax indicates the syntax error in the query.
 	//
 	// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1399
@@ -181,4 +185,14 @@ type RequestErrFunctionFailure struct {
 	Keyspace string
 	Function string
 	ArgTypes []string
+}
+
+// RequestErrCASWriteUnknown is distinct error for ErrCodeCasWriteUnknown.
+//
+// See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1387-L1397
+type RequestErrCASWriteUnknown struct {
+	errorFrame
+	Consistency Consistency
+	Received    int
+	BlockFor    int
 }

--- a/frame.go
+++ b/frame.go
@@ -683,7 +683,14 @@ func (f *framer) parseErrorFrame() frame {
 			errorFrame: errD,
 		}
 		return res
-
+	case ErrCodeCASWriteUnknown:
+		res := &RequestErrCASWriteUnknown{
+			errorFrame: errD,
+		}
+		res.Consistency = f.readConsistency()
+		res.Received = f.readInt()
+		res.BlockFor = f.readInt()
+		return res
 	case ErrCodeInvalid, ErrCodeBootstrapping, ErrCodeConfig, ErrCodeCredentials, ErrCodeOverloaded,
 		ErrCodeProtocol, ErrCodeServer, ErrCodeSyntax, ErrCodeTruncate, ErrCodeUnauthorized:
 		// TODO(zariel): we should have some distinct types for these errors


### PR DESCRIPTION
This commit adds a support for error code 0x1700 added with CQL v5
binary protocol by adding new constant and separate error type with
parsed message from server.

See:
- https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1387-L1397