### PR TITLE
Don't panic when there is no Go type available

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -20,52 +20,64 @@ type RowData struct {
 	Values  []interface{}
 }
 
-func goType(t TypeInfo) reflect.Type {
+func goType(t TypeInfo) (reflect.Type, error) {
 	switch t.Type() {
 	case TypeVarchar, TypeAscii, TypeInet, TypeText:
-		return reflect.TypeOf(*new(string))
+		return reflect.TypeOf(*new(string)), nil
 	case TypeBigInt, TypeCounter:
-		return reflect.TypeOf(*new(int64))
+		return reflect.TypeOf(*new(int64)), nil
 	case TypeTime:
-		return reflect.TypeOf(*new(time.Duration))
+		return reflect.TypeOf(*new(time.Duration)), nil
 	case TypeTimestamp:
-		return reflect.TypeOf(*new(time.Time))
+		return reflect.TypeOf(*new(time.Time)), nil
 	case TypeBlob:
-		return reflect.TypeOf(*new([]byte))
+		return reflect.TypeOf(*new([]byte)), nil
 	case TypeBoolean:
-		return reflect.TypeOf(*new(bool))
+		return reflect.TypeOf(*new(bool)), nil
 	case TypeFloat:
-		return reflect.TypeOf(*new(float32))
+		return reflect.TypeOf(*new(float32)), nil
 	case TypeDouble:
-		return reflect.TypeOf(*new(float64))
+		return reflect.TypeOf(*new(float64)), nil
 	case TypeInt:
-		return reflect.TypeOf(*new(int))
+		return reflect.TypeOf(*new(int)), nil
 	case TypeSmallInt:
-		return reflect.TypeOf(*new(int16))
+		return reflect.TypeOf(*new(int16)), nil
 	case TypeTinyInt:
-		return reflect.TypeOf(*new(int8))
+		return reflect.TypeOf(*new(int8)), nil
 	case TypeDecimal:
-		return reflect.TypeOf(*new(*inf.Dec))
+		return reflect.TypeOf(*new(*inf.Dec)), nil
 	case TypeUUID, TypeTimeUUID:
-		return reflect.TypeOf(*new(UUID))
+		return reflect.TypeOf(*new(UUID)), nil
 	case TypeList, TypeSet:
-		return reflect.SliceOf(goType(t.(CollectionType).Elem))
+		elemType, err := goType(t.(CollectionType).Elem)
+		if err != nil {
+			return nil, err
+		}
+		return reflect.SliceOf(elemType), nil
 	case TypeMap:
-		return reflect.MapOf(goType(t.(CollectionType).Key), goType(t.(CollectionType).Elem))
+		keyType, err := goType(t.(CollectionType).Key)
+		if err != nil {
+			return nil, err
+		}
+		valueType, err := goType(t.(CollectionType).Elem)
+		if err != nil {
+			return nil, err
+		}
+		return reflect.MapOf(keyType, valueType), nil
 	case TypeVarint:
-		return reflect.TypeOf(*new(*big.Int))
+		return reflect.TypeOf(*new(*big.Int)), nil
 	case TypeTuple:
 		// what can we do here? all there is to do is to make a list of interface{}
 		tuple := t.(TupleTypeInfo)
-		return reflect.TypeOf(make([]interface{}, len(tuple.Elems)))
+		return reflect.TypeOf(make([]interface{}, len(tuple.Elems))), nil
 	case TypeUDT:
-		return reflect.TypeOf(make(map[string]interface{}))
+		return reflect.TypeOf(make(map[string]interface{})), nil
 	case TypeDate:
-		return reflect.TypeOf(*new(time.Time))
+		return reflect.TypeOf(*new(time.Time)), nil
 	case TypeDuration:
-		return reflect.TypeOf(*new(Duration))
+		return reflect.TypeOf(*new(Duration)), nil
 	default:
-		return nil
+		return nil, fmt.Errorf("cannot create Go type for unknown CQL type %s", t)
 	}
 }
 
@@ -300,13 +312,20 @@ func (iter *Iter) RowData() (RowData, error) {
 
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
-			val := column.TypeInfo.New()
+			val, err := column.TypeInfo.NewWithError()
+			if err != nil {
+				return RowData{}, err
+			}
 			columns = append(columns, column.Name)
 			values = append(values, val)
 		} else {
 			for i, elem := range c.Elems {
 				columns = append(columns, TupleColumnName(column.Name, i))
-				values = append(values, elem.New())
+				val, err := elem.NewWithError()
+				if err != nil {
+					return RowData{}, err
+				}
+				values = append(values, val)
 			}
 		}
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -2071,7 +2071,10 @@ func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
 				p, data = readBytes(data)
 			}
 
-			v := elem.New()
+			v, err := elem.NewWithError()
+			if err != nil {
+				return err
+			}
 			if err := Unmarshal(elem, p, v); err != nil {
 				return err
 			}
@@ -2105,7 +2108,10 @@ func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
 				p, data = readBytes(data)
 			}
 
-			v := elem.New()
+			v, err := elem.NewWithError()
+			if err != nil {
+				return err
+			}
 			if err := Unmarshal(elem, p, v); err != nil {
 				return err
 			}
@@ -2276,7 +2282,12 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 				return nil
 			}
 
-			val := reflect.New(goType(e.Type))
+			valType, err := goType(e.Type)
+			if err != nil {
+				return unmarshalErrorf("can not unmarshal %s: %v", info, err)
+			}
+
+			val := reflect.New(valType)
 
 			var p []byte
 			p, data = readBytes(data)
@@ -2358,8 +2369,18 @@ type TypeInfo interface {
 	Custom() string
 
 	// New creates a pointer to an empty version of whatever type
-	// is referenced by the TypeInfo receiver
+	// is referenced by the TypeInfo receiver.
+	//
+	// If there is no corresponding Go type for the CQL type, New panics.
+	//
+	// Deprecated: Use NewWithError instead.
 	New() interface{}
+
+	// NewWithError creates a pointer to an empty version of whatever type
+	// is referenced by the TypeInfo receiver.
+	//
+	// If there is no corresponding Go type for the CQL type, NewWithError returns an error.
+	NewWithError() (interface{}, error)
 }
 
 type NativeType struct {
@@ -2372,8 +2393,20 @@ func NewNativeType(proto byte, typ Type, custom string) NativeType {
 	return NativeType{proto, typ, custom}
 }
 
+func (t NativeType) NewWithError() (interface{}, error) {
+	typ, err := goType(t)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.New(typ).Interface(), nil
+}
+
 func (t NativeType) New() interface{} {
-	return reflect.New(goType(t)).Interface()
+	val, err := t.NewWithError()
+	if err != nil {
+		panic(err.Error())
+	}
+	return val
 }
 
 func (s NativeType) Type() Type {
@@ -2403,8 +2436,20 @@ type CollectionType struct {
 	Elem TypeInfo // only used for TypeMap, TypeList and TypeSet
 }
 
+func (t CollectionType) NewWithError() (interface{}, error) {
+	typ, err := goType(t)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.New(typ).Interface(), nil
+}
+
 func (t CollectionType) New() interface{} {
-	return reflect.New(goType(t)).Interface()
+	val, err := t.NewWithError()
+	if err != nil {
+		panic(err.Error())
+	}
+	return val
 }
 
 func (c CollectionType) String() string {
@@ -2436,8 +2481,20 @@ func (t TupleTypeInfo) String() string {
 	return buf.String()
 }
 
+func (t TupleTypeInfo) NewWithError() (interface{}, error) {
+	typ, err := goType(t)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.New(typ).Interface(), nil
+}
+
 func (t TupleTypeInfo) New() interface{} {
-	return reflect.New(goType(t)).Interface()
+	val, err := t.NewWithError()
+	if err != nil {
+		panic(err.Error())
+	}
+	return val
 }
 
 type UDTField struct {
@@ -2452,8 +2509,20 @@ type UDTTypeInfo struct {
 	Elements []UDTField
 }
 
+func (u UDTTypeInfo) NewWithError() (interface{}, error) {
+	typ, err := goType(u)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.New(typ).Interface(), nil
+}
+
 func (u UDTTypeInfo) New() interface{} {
-	return reflect.New(goType(u)).Interface()
+	val, err := u.NewWithError()
+	if err != nil {
+		panic(err.Error())
+	}
+	return val
 }
 
 func (u UDTTypeInfo) String() string {


### PR DESCRIPTION
When there is no corresponding Go type available,
unmarshaling panics. We want to return an error instead.

Unfortunately, TypeInfo.New() can't return an error.
We can't change the signature of New as it might be used
externally. For New(), the only option is to keep panicking.
We now at least provide a more useful panic message.

We are adding a new method to interface TypeInfo that returns
as error instead of panicking. Changing the interface is a
breaking change for users that implement custom TypeInfo.
I don't expect any custom implementations of this interface
though, so I think this change is safe.

An alternative to adding the method to the interface would
be to add a separate interface and a function to use the
new interface when available, with fallback to TypeInfo:

    type TypeInfo2 interface {
        TypeInfo
        NewWithError() (interface{}, error)
    }

    func NewFromType(t TypeInfo) (interface{}, error) {
        if t2, ok := t.(TypeInfo2); ok {
            return t2.NewWithError()
        }
        return t.New(), nil
    }

However, I think that is overkill in this case as it's unlikely there
are custom implementations of TypeInfo and NewFromType still wouldn't
guarantee no panics.

Related gocql/gocql#1148