### PR TITLE
Make sure policies are not reused between sessions

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -17,6 +17,8 @@ import (
 type PoolConfig struct {
 	// HostSelectionPolicy sets the policy for selecting which host to use for a
 	// given query (default: RoundRobinHostPolicy())
+	// It is not supported to use a single HostSelectionPolicy in multiple sessions
+	// (even if you close the old session before using in a new session).
 	HostSelectionPolicy HostSelectionPolicy
 }
 


### PR DESCRIPTION
Sharing a policy between sessions is not supported because the policy
receives state updates from the session.

Let's update the documentation and add a panic in TokenAwareHostPolicy
constructor. It is better to panic early than to have races and
undefined behavior later.

See also discussion in https://github.com/scylladb/gocql/issues/94