### PR TITLE
Make DESC a ColumnOrder, not a bool

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,3 +125,4 @@ Maxim Vladimirskiy <horkhe@gmail.com>
 Bogdan-Ciprian Rusu <bogdanciprian.rusu@crowdstrike.com>
 Yuto Doi <yutodoi.seattle@gmail.com>
 Krishna Vadali <tejavadali@gmail.com>
+Jens-W. Schicke-Uffmann <drahflow@gmx.de>

--- a/metadata.go
+++ b/metadata.go
@@ -133,7 +133,7 @@ type ColumnOrder bool
 
 const (
 	ASC  ColumnOrder = false
-	DESC             = true
+	DESC ColumnOrder = true
 )
 
 type ColumnIndexMetadata struct {


### PR DESCRIPTION
Discovered while trying something along the lines of https://play.golang.com/p/kMijXA7kW0E, i.e.
```
a := gocql.DESC
if someCondition() {
	a = gocql.ASC
}
```

https://go.dev/ref/spec#Constant_expressions says only the expression part repeats and gives
```
const (
	u         = iota * 42  // u == 0     (untyped integer constant)
	v float64 = iota * 42  // v == 42.0  (float64 constant)
	w         = iota * 42  // w == 84    (untyped integer constant)
)
```