### PR TITLE
Update supported go version in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ env:
       COMPRESSOR=snappy
 
 go:
-  - 1.15.x
   - 1.16.x
+  - 1.17.x
 
 go_import_path: github.com/gocql/gocql
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -126,3 +126,4 @@ Bogdan-Ciprian Rusu <bogdanciprian.rusu@crowdstrike.com>
 Yuto Doi <yutodoi.seattle@gmail.com>
 Krishna Vadali <tejavadali@gmail.com>
 Jens-W. Schicke-Uffmann <drahflow@gmx.de>
+Ondrej Polakovič <ondrej.polakovic@kiwi.com>

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.15 | yes | yes | yes
 1.16 | yes | yes | yes
+1.17 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
Update go version from 1.15, 1.16 to 1.16, 1.17.