### PR TITLE
Run tests with Go 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.16', '1.17' ]
+        go: [ '1.17', '1.18' ]
         cassandra_version: [ '3.0.24', '3.11.10' ]
         auth: [ "false" ]
         compressor: [ "snappy" ]
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ 1.16, 1.17 ]
+        go: [ 1.17, 1.18 ]
         cassandra_version: [ 3.11.10 ]
         compressor: [ "snappy" ]
         tags: [ "integration" ]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.16 | yes | yes | yes
 1.17 | yes | yes | yes
+1.18 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
Go 1.18 was released, let's test with 1.17 and 1.18 as those
are the only supported versions of Go now.