### PR TITLE
Add HostAddressTranslator

### DIFF
--- a/address_translators.go
+++ b/address_translators.go
@@ -5,6 +5,7 @@ import "net"
 // AddressTranslator provides a way to translate node addresses (and ports) that are
 // discovered or received as a node event. This can be useful in an ec2 environment,
 // for instance, to translate public IPs to private IPs.
+// Deprecated: Use HostAddressTranslator
 type AddressTranslator interface {
 	// Translate will translate the provided address and/or port to another
 	// address and/or port. If no translation is possible, Translate will return the
@@ -12,15 +13,44 @@ type AddressTranslator interface {
 	Translate(addr net.IP, port int) (net.IP, int)
 }
 
+// Deprecated: Use HostAddressTranslatorFunc
 type AddressTranslatorFunc func(addr net.IP, port int) (net.IP, int)
 
 func (fn AddressTranslatorFunc) Translate(addr net.IP, port int) (net.IP, int) {
 	return fn(addr, port)
 }
 
-// IdentityTranslator will do nothing but return what it was provided. It is essentially a no-op.
+// IdentityTranslator will do nothing but return what it was provided. It is
+// essentially a no-op.
+// Deprecated: Use HostIdentityTranslator
 func IdentityTranslator() AddressTranslator {
 	return AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
+		return addr, port
+	})
+}
+
+// HostAddressTranslator provides a way to translate node addresses (and ports)
+// that are discovered or received as a node event. This can be useful in an ec2
+// environment, for instance, to translate public IPs to private IPs. The
+// HostInfo is provided to allow for inspecting the various attributes of the
+// node but depending on the context the HostInfo might not be filled in
+// completely.
+type HostAddressTranslator interface {
+	// Translate will translate the provided address and/or port to another
+	// address and/or port. If no translation is possible, Translate will return the
+	// address and port provided to it.
+	Translate(addr net.IP, port int, host *HostInfo) (net.IP, int)
+}
+
+type HostAddressTranslatorFunc func(addr net.IP, port int, host *HostInfo) (net.IP, int)
+
+func (fn HostAddressTranslatorFunc) Translate(addr net.IP, port int, host *HostInfo) (net.IP, int) {
+	return fn(addr, port, host)
+}
+
+// IdentityTranslator will do nothing but return what it was provided. It is essentially a no-op.
+func HostIdentityTranslator() HostAddressTranslator {
+	return HostAddressTranslatorFunc(func(addr net.IP, port int, host *HostInfo) (net.IP, int) {
 		return addr, port
 	})
 }

--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -32,3 +32,31 @@ func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
 	}
 	assertEqual(t, "translated port", 9042, port)
 }
+
+func TestHostIdentityAddressTranslator_NilAddrAndZeroPort(t *testing.T) {
+	var tr HostAddressTranslator = HostIdentityTranslator()
+	hostIP := net.ParseIP("")
+	if hostIP != nil {
+		t.Errorf("expected host ip to be (nil) but was (%+v) instead", hostIP)
+	}
+
+	addr, port := tr.Translate(hostIP, 0, &HostInfo{})
+	if addr != nil {
+		t.Errorf("expected translated host to be (nil) but was (%+v) instead", addr)
+	}
+	assertEqual(t, "translated port", 0, port)
+}
+
+func TestHostIdentityAddressTranslator_HostProvided(t *testing.T) {
+	var tr HostAddressTranslator = HostIdentityTranslator()
+	hostIP := net.ParseIP("10.1.2.3")
+	if hostIP == nil {
+		t.Error("expected host ip not to be (nil)")
+	}
+
+	addr, port := tr.Translate(hostIP, 9042, &HostInfo{})
+	if !hostIP.Equal(addr) {
+		t.Errorf("expected translated addr to be (%+v) but was (%+v) instead", hostIP, addr)
+	}
+	assertEqual(t, "translated port", 9042, port)
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -36,7 +36,7 @@ func TestNewCluster_WithHosts(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	cfg := NewCluster()
 	assertNil(t, "cluster config address translator", cfg.AddressTranslator)
-	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234, &HostInfo{})
 	assertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
 	assertEqual(t, "translated host and port", 1234, newPort)
 }
@@ -44,7 +44,7 @@ func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0)
+	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0, &HostInfo{})
 	assertTrue(t, "translated address is still empty", len(newAddr) == 0)
 	assertEqual(t, "translated port", 0, newPort)
 }
@@ -52,7 +52,31 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345, &HostInfo{})
+	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
+	assertEqual(t, "translated port", 5432, newPort)
+}
+
+func TestClusterConfig_translateHostAddressAndPort_NilTranslator(t *testing.T) {
+	cfg := NewCluster()
+	assertNil(t, "cluster config address translator", cfg.HostAddressTranslator)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234, &HostInfo{})
+	assertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
+	assertEqual(t, "translated host and port", 1234, newPort)
+}
+
+func TestClusterConfig_translateHostAddressAndPort_EmptyAddr(t *testing.T) {
+	cfg := NewCluster()
+	cfg.HostAddressTranslator = staticHostAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
+	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0, &HostInfo{})
+	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
+	assertEqual(t, "translated port", 5432, newPort)
+}
+
+func TestClusterConfig_translateHostAddressAndPort_Success(t *testing.T) {
+	cfg := NewCluster()
+	cfg.HostAddressTranslator = staticHostAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345, &HostInfo{})
 	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
 	assertEqual(t, "translated port", 5432, newPort)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -246,6 +246,12 @@ func staticAddressTranslator(newAddr net.IP, newPort int) AddressTranslator {
 	})
 }
 
+func staticHostAddressTranslator(newAddr net.IP, newPort int) HostAddressTranslator {
+	return HostAddressTranslatorFunc(func(addr net.IP, port int, host *HostInfo) (net.IP, int) {
+		return newAddr, newPort
+	})
+}
+
 func assertTrue(t *testing.T, description string, value bool) {
 	t.Helper()
 	if !value {

--- a/session.go
+++ b/session.go
@@ -226,7 +226,9 @@ func (s *Session) init() error {
 					filteredHosts = append(filteredHosts, host)
 				}
 			}
-			hosts = append(hosts, filteredHosts...)
+			// we replace filteredHosts because we might've done translation on the IPs
+			// compared to the original addresses that were sent
+			hosts = filteredHosts
 		}
 	}
 
@@ -513,7 +515,7 @@ func (s *Session) executeQuery(qry *Query) (it *Iter) {
 func (s *Session) removeHost(h *HostInfo) {
 	s.policy.RemoveHost(h)
 	s.pool.removeHost(h.ConnectAddress())
-	s.ring.removeHost(h.ConnectAddress())
+	s.ring.removeIP(h.ConnectAddress())
 }
 
 // KeyspaceMetadata returns the schema metadata for the keyspace specified. Returns an error if the keyspace does not exist.


### PR DESCRIPTION
This is related to https://github.com/gocql/gocql/pull/1609 but only so much as it solves the problem in a better way. That PR is still necessary to prevent making control connections to unwanted nodes but rather than doing any `connectAddress` mucking in `FilterHost` this new interface provides the `HostInfo` struct necessary to do it here instead.

This is intended on completely replacing the old `AddressTranslator`.

Since translation might change the connect address I added checking against the original `peer` address as well for events.

Fixes #1608