### PR TITLE
marshal: UDT, when values are a map force presence of all elements

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2178,7 +2178,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		for _, e := range udt.Elements {
 			val, ok := v[e.Name]
 			if !ok {
-				continue
+				return nil, marshalErrorf("marshal missing map key %q", e.Name)
 			}
 
 			data, err := Marshal(e.Type, val)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1928,6 +1928,41 @@ func TestUnmarshalTuple(t *testing.T) {
 	})
 }
 
+func TestMarshalUDTMap(t *testing.T) {
+	typeInfo := UDTTypeInfo{NativeType{proto: 3, typ: TypeUDT}, "", "xyz", []UDTField{
+		{Name: "x", Type: NativeType{proto: 3, typ: TypeInt}},
+		{Name: "y", Type: NativeType{proto: 3, typ: TypeInt}},
+		{Name: "z", Type: NativeType{proto: 3, typ: TypeInt}},
+	}}
+
+	t.Run("partially bound", func(t *testing.T) {
+		value := map[string]interface{}{
+			"y": 2,
+			"z": 3,
+		}
+		me := MarshalError(`marshal missing map key "x"`)
+		if _, err := Marshal(typeInfo, value); err != me {
+			t.Errorf("got error %#v, want %#v", err, me)
+		}
+	})
+	t.Run("fully bound", func(t *testing.T) {
+		value := map[string]interface{}{
+			"x": 1,
+			"y": 2,
+			"z": 3,
+		}
+		expected := []byte("\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x03")
+
+		data, err := Marshal(typeInfo, value)
+		if err != nil {
+			t.Errorf("got error %#v", err)
+		}
+		if !bytes.Equal(data, expected) {
+			t.Errorf("got error %x", data)
+		}
+	})
+}
+
 func TestMarshalNil(t *testing.T) {
 	types := []Type{
 		TypeAscii,


### PR DESCRIPTION
User shall send the values in the order specified by the UDT.

> A UDT value is composed of successive [bytes] values, one for each field of the UDT
> value (in the order defined by the type). A UDT value will generally have one value
> for each field of the type it represents, but it is allowed to have less values than
> the type has fields.

Skipping a value causes DATA CORRUPTION by assigning next field value to the current value and clearing the tailing values.

Fixes #1624