### PR TITLE
Use legacy URL parsing for ccm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
           rm -rf $HOME/.ccm/test/node1/data/system_auth
 
           export JVM_EXTRA_OPTS=" -Dcassandra.test.fail_writes_ks=test -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"
+          export JAVA_TOOL_OPTIONS=" -Dcom.sun.jndi.rmiURLParsing=legacy"
 
           ccm start --wait-for-binary-proto
           ccm status


### PR DESCRIPTION
nodetool launched by ccm fails with:

 nodetool: Failed to connect to 'localhost:7100' - URISyntaxException: 'Malformed IPv6 address at index 7: rmi://[localhost]:7100'

Switching back to legacy parsing mode should fix the error.