### PR TITLE
Handle nil values when (un)marshalling lists and maps

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -127,3 +127,4 @@ Yuto Doi <yutodoi.seattle@gmail.com>
 Krishna Vadali <tejavadali@gmail.com>
 Jens-W. Schicke-Uffmann <drahflow@gmx.de>
 Ondrej Polakovič <ondrej.polakovic@kiwi.com>
+Sergei Karetnikov <sergei.karetnikov@gmail.com>

--- a/marshal.go
+++ b/marshal.go
@@ -1651,11 +1651,15 @@ func unmarshalList(info TypeInfo, data []byte, value interface{}) error {
 			if len(data) < m {
 				return unmarshalErrorf("unmarshal list: unexpected eof")
 			}
+
+			// In case m < 0, the value is null, and unmarshalData should be nil.
+			var unmarshalData []byte
 			if m >= 0 {
-				if err := Unmarshal(listInfo.Elem, data[:m], rv.Index(i).Addr().Interface()); err != nil {
-					return err
-				}
+				unmarshalData = data[:m]
 				data = data[m:]
+			}
+			if err := Unmarshal(listInfo.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -1699,7 +1703,12 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := writeCollectionSize(mapInfo, len(item), buf); err != nil {
+		itemLen := len(item)
+		// Set the key to null for supported protocols
+		if item == nil && mapInfo.proto > protoVersion2 {
+			itemLen = -1
+		}
+		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
@@ -1708,7 +1717,12 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := writeCollectionSize(mapInfo, len(item), buf); err != nil {
+		itemLen = len(item)
+		// Set the value to null for supported protocols
+		if item == nil && mapInfo.proto > protoVersion2 {
+			itemLen = -1
+		}
+		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
@@ -1751,10 +1765,16 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 			return unmarshalErrorf("unmarshal map: unexpected eof")
 		}
 		key := reflect.New(t.Key())
-		if err := Unmarshal(mapInfo.Key, data[:m], key.Interface()); err != nil {
+
+		// In case m < 0, the key is null, and unmarshalData should be nil.
+		var unmarshalData []byte
+		if m >= 0 {
+			unmarshalData = data[:m]
+			data = data[m:]
+		}
+		if err := Unmarshal(mapInfo.Key, unmarshalData, key.Interface()); err != nil {
 			return err
 		}
-		data = data[m:]
 
 		m, p, err = readCollectionSize(mapInfo, data)
 		if err != nil {
@@ -1765,10 +1785,16 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 			return unmarshalErrorf("unmarshal map: unexpected eof")
 		}
 		val := reflect.New(t.Elem())
-		if err := Unmarshal(mapInfo.Elem, data[:m], val.Interface()); err != nil {
+
+		// In case m < 0, the value is null, and unmarshalData should be nil.
+		unmarshalData = nil
+		if m >= 0 {
+			unmarshalData = data[:m]
+			data = data[m:]
+		}
+		if err := Unmarshal(mapInfo.Elem, unmarshalData, val.Interface()); err != nil {
 			return err
 		}
-		data = data[m:]
 
 		rv.SetMapIndex(key.Elem(), val.Elem())
 	}


### PR DESCRIPTION
Handle `nil` values for supported protocol versions when (un)marshalling lists and maps according to the specs:
```
6.11 list

  A [int] n indicating the number of elements in the list, followed by n
  elements.  Each element is [bytes] representing the serialized value.

6.12 map

  A [int] n indicating the number of key/value pairs in the map, followed by
  n entries.  Each entry is composed of two [bytes] representing the key
  and value.
```
```
    [bytes]        A [int] n, followed by n bytes if n >= 0. If n < 0,
                   no byte should follow and the value represented is `null`.
```
