### PR TITLE
Fix race condition in HostInfo.HostnameAndPort

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -367,8 +367,11 @@ func (h *HostInfo) IsUp() bool {
 }
 
 func (h *HostInfo) HostnameAndPort() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.hostname == "" {
-		h.hostname = h.ConnectAddress().String()
+		addr, _ := h.connectAddressLocked()
+		h.hostname = addr.String()
 	}
 	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
 }


### PR DESCRIPTION
Function changed HostInfo.hostname without holding write lock.
