### PR TITLE
Use Cassandra 4.0 in integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.17', '1.18' ]
-        cassandra_version: [ '3.0.27', '3.11.13' ]
+        cassandra_version: [ '3.11.13', '4.0.4' ]
         auth: [ "false" ]
         compressor: [ "snappy" ]
         tags: [ "cassandra", "integration", "ccm" ]
@@ -90,7 +90,7 @@ jobs:
           ccm node1 nodetool status
 
           proto=4
-          if [[ $version == 3.*.* ]]; then
+          if [[ $version == 4.*.* ]]; then
               proto=5
           fi
 
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ 1.17, 1.18 ]
-        cassandra_version: [ 3.11.13 ]
+        cassandra_version: [ 4.0.4 ]
         compressor: [ "snappy" ]
         tags: [ "integration" ]
 

--- a/integration.sh
+++ b/integration.sh
@@ -48,11 +48,11 @@ function run_tests() {
 		proto=2
 	elif [[ $version == 2.1.* ]]; then
 		proto=3
-	elif [[ $version == 2.2.* || $version == 3.0.* ]]; then
+	elif [[ $version == 2.2.* || $version == 3.*.* ]]; then
 		proto=4
 		ccm updateconf 'enable_user_defined_functions: true'
 		export JVM_EXTRA_OPTS=" -Dcassandra.test.fail_writes_ks=test -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"
-	elif [[ $version == 3.*.* ]]; then
+	elif [[ $version == 4.*.* ]]; then
 		proto=5
 		ccm updateconf 'enable_user_defined_functions: true'
 		export JVM_EXTRA_OPTS=" -Dcassandra.test.fail_writes_ks=test -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler"


### PR DESCRIPTION
Better to use the newest version than the old 3.0.
Keeping only 2 versions to conserve resources.