### PR TITLE
Marshal missing UDT fields as null instead of failing

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2210,13 +2210,15 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		var buf []byte
 		for _, e := range udt.Elements {
 			val, ok := v[e.Name]
-			if !ok {
-				return nil, marshalErrorf("marshal missing map key %q", e.Name)
-			}
 
-			data, err := Marshal(e.Type, val)
-			if err != nil {
-				return nil, err
+			var data []byte
+
+			if ok {
+				var err error
+				data, err = Marshal(e.Type, val)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			buf = appendBytes(buf, data)


### PR DESCRIPTION
We can't return an error in case a field is added to the UDT,
otherwise existing code would break by simply altering the UDT in the
database. For extra fields at the end of the UDT, we can either omit
them or put nulls.

The Java driver[1] and Python driver[2] serialize nulls when they
don't have a value for a field even for fields in the middle, so let's
do that. This behaviour matches even gocql when serializing structs.

[1] https://github.com/datastax/java-driver/blob/ef56d561d97adcae48e0e6e8807f334aedc0d783/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodec.java#L86
[2] https://github.com/datastax/python-driver/blob/15d715f4e686032b02ce785eca1d176d2b25e32b/cassandra/cqltypes.py#L1036