### PR TITLE
fix: null data unmarshal to the pointer of point should be nil

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -271,7 +271,7 @@ func isNullableValue(value interface{}) bool {
 }
 
 func isNullData(info TypeInfo, data []byte) bool {
-	return data == nil
+	return len(data) == 0
 }
 
 func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {


### PR DESCRIPTION
When passing the pointer of the pointer. The pointer of the pointer will still be initialized if a null value is returned. According to the document, it should be nil. And this change include `data == nil` and `data == []byte{}` condition.

My test type
```go
type NullTime struct {
	Time  time.Time
	Valid bool
}

func (v *NullTime) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
	var t *time.Time
	err := gocql.Unmarshal(info, data, &t)
	fmt.Println(info, "data", string(data), "time", t)
	if t == nil {
		v.Valid = false
		return nil
	} else {
		v.Time = *t
	}
	if err == nil {
		v.Time = v.Time.In(time.UTC).Truncate(time.Millisecond)
		v.Valid = true
	}
	return err
}
```

before the change, output:
```
timestamp data  time 0001-01-01 00:00:00 +0000 UTC
```

after change, output: 
```
timestamp data  time <nil>
```