### PR TITLE
Change default port if provided in new cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strconv"
 	"time"
 )
 
@@ -241,12 +242,25 @@ type Dialer interface {
 // resolves to more than 1 IP address then the driver may connect multiple times to
 // the same host, and will not mark the node being down or up from events.
 func NewCluster(hosts ...string) *ClusterConfig {
+
+	port := 9042
+
+	for _, hostPort := range hosts {
+		_, portStr, err := net.SplitHostPort(hostPort)
+		if err == nil {
+			port, err = strconv.Atoi(portStr)
+			if err == nil {
+				break
+			}
+		}
+	}
+
 	cfg := &ClusterConfig{
 		Hosts:                  hosts,
 		CQLVersion:             "3.0.0",
 		Timeout:                600 * time.Millisecond,
 		ConnectTimeout:         600 * time.Millisecond,
-		Port:                   9042,
+		Port:                   port,
 		NumConns:               2,
 		Consistency:            Quorum,
 		MaxPreparedStmts:       defaultMaxPreparedStmts,

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -32,6 +32,13 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
 	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
 }
+func TestNewCluster_WithHostPortString(t *testing.T) {
+	cfg := NewCluster("addr1:9142", "addr2:9142")
+	assertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
+	assertEqual(t, "cluster config host 0", "addr1:9142", cfg.Hosts[0])
+	assertEqual(t, "cluster config host 1", "addr2:9142", cfg.Hosts[1])
+	assertEqual(t, "cluster port", 9142, cfg.Port)
+}
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	cfg := NewCluster()


### PR DESCRIPTION
Currently, when creating a cluster, the contact points can contain the port as well.  Currently this does not change the port when a new cluster is configured, causing timeout issues to peers.  This especially impacting when using TLS which is using 9142 instead of 9042.  If user does not set Cluster.Port connection to peers failed. Traditionally, cassandra drivers do not support connecting to nodes on different ports. All nodes must have the same cql port.  The result is users may end up connected only to provided seeds initial host without connecting to peers.  This pull request adds port assignment to NewCluster by extracting it from the host string if provided.  