### PR TITLE
Fallback to `system.peers` when `system.peers_v2` is not available

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -446,10 +446,3 @@ func LookupIP(host string) ([]net.IP, error) {
 	return net.LookupIP(host)
 
 }
-
-func peersTableName(version cassVersion) string {
-	if version.AtLeast(4, 0, 0) {
-		return "system.peers_v2"
-	}
-	return "system.peers"
-}

--- a/host_source.go
+++ b/host_source.go
@@ -561,8 +561,7 @@ func (r *ringDescriber) getClusterPeerInfo() ([]*HostInfo, error) {
 	var hosts []*HostInfo
 	iter := r.session.control.withConnHost(func(ch *connHost) *Iter {
 		hosts = append(hosts, ch.host)
-		return ch.conn.query(context.TODO(),
-			fmt.Sprintf("SELECT * FROM %s", peersTableName(ch.host.version)))
+		return ch.conn.querySystemPeers(context.TODO(), ch.host.version)
 	})
 
 	if iter == nil {
@@ -631,8 +630,7 @@ func (r *ringDescriber) getHostInfo(hostID UUID) (*HostInfo, error) {
 			}
 
 			if table == "system.peers" {
-				return ch.conn.query(context.TODO(),
-					fmt.Sprintf("SELECT * from %s", peersTableName(ch.host.version)))
+				return ch.conn.querySystemPeers(context.TODO(), ch.host.version)
 			} else {
 				return ch.conn.query(context.TODO(), fmt.Sprintf("SELECT * FROM %s", table))
 			}


### PR DESCRIPTION
As currently implemented `system.peers_v2` support doesn't work for DSE
clusters because it returns 4.0.x for the `release_version`. This
attempts to use the `system.peers_v2` table when `release_version` is >=
4.0.x, but falls back gracefully to `system.peers` when that table isn't
found.