### PR TITLE
Use Go 1.19 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        go: [ '1.17', '1.18' ]
+        go: [ '1.18', '1.19' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.17', '1.18' ]
+        go: [ '1.18', '1.19' ]
         cassandra_version: [ '3.0.27', '3.11.13' ]
         auth: [ "false" ]
         compressor: [ "snappy" ]
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ 1.17, 1.18 ]
+        go: [ 1.18, 1.19 ]
         cassandra_version: [ 3.11.13 ]
         compressor: [ "snappy" ]
         tags: [ "integration" ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Supported versions of Go that we test against are now Go 1.18 and Go 1.19.
+
 ### Fixed
 
 ## [1.2.1] - 2022-09-02

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The following matrix shows the versions of Go and Cassandra that are tested with
 
 Go/Cassandra | 2.1.x | 2.2.x | 3.x.x
 -------------| -------| ------| ---------
-1.17 | yes | yes | yes
 1.18 | yes | yes | yes
+1.19 | yes | yes | yes
 
 Gocql has been tested in production against many different versions of Cassandra. Due to limits in our CI setup we only test against the latest 3 major releases, which coincide with the official support from the Apache project.
 


### PR DESCRIPTION
We generally support the last two stable versions of Go,
updating the CI to test against them.