### PR TITLE
Reformat code using go fmt v 1.19

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -68,7 +68,7 @@ func TestInvalidPeerEntry(t *testing.T) {
 	}
 }
 
-//TestUseStatementError checks to make sure the correct error is returned when the user tries to execute a use statement.
+// TestUseStatementError checks to make sure the correct error is returned when the user tries to execute a use statement.
 func TestUseStatementError(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -82,7 +82,7 @@ func TestUseStatementError(t *testing.T) {
 	}
 }
 
-//TestInvalidKeyspace checks that an invalid keyspace will return promptly and without a flood of connections
+// TestInvalidKeyspace checks that an invalid keyspace will return promptly and without a flood of connections
 func TestInvalidKeyspace(t *testing.T) {
 	cluster := createCluster()
 	cluster.Keyspace = "invalidKeyspace"
@@ -1190,7 +1190,7 @@ func TestRebindQueryInfo(t *testing.T) {
 	}
 }
 
-//TestStaticQueryInfo makes sure that the application can manually bind query parameters using the simplest possible static binding strategy
+// TestStaticQueryInfo makes sure that the application can manually bind query parameters using the simplest possible static binding strategy
 func TestStaticQueryInfo(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1258,7 +1258,7 @@ func upcaseInitial(str string) string {
 	return ""
 }
 
-//TestBoundQueryInfo makes sure that the application can manually bind query parameters using the query meta data supplied at runtime
+// TestBoundQueryInfo makes sure that the application can manually bind query parameters using the query meta data supplied at runtime
 func TestBoundQueryInfo(t *testing.T) {
 
 	session := createSession(t)
@@ -1297,7 +1297,7 @@ func TestBoundQueryInfo(t *testing.T) {
 
 }
 
-//TestBatchQueryInfo makes sure that the application can manually bind query parameters when executing in a batch
+// TestBatchQueryInfo makes sure that the application can manually bind query parameters when executing in a batch
 func TestBatchQueryInfo(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1475,7 +1475,7 @@ func TestQueryInfo(t *testing.T) {
 	}
 }
 
-//TestPreparedCacheEviction will make sure that the cache size is maintained
+// TestPreparedCacheEviction will make sure that the cache size is maintained
 func TestPrepare_PreparedCacheEviction(t *testing.T) {
 	const maxPrepared = 4
 
@@ -1614,7 +1614,7 @@ func TestPrepare_PreparedCacheKey(t *testing.T) {
 	}
 }
 
-//TestMarshalFloat64Ptr tests to see that a pointer to a float64 is marshalled correctly.
+// TestMarshalFloat64Ptr tests to see that a pointer to a float64 is marshalled correctly.
 func TestMarshalFloat64Ptr(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1628,7 +1628,7 @@ func TestMarshalFloat64Ptr(t *testing.T) {
 	}
 }
 
-//TestMarshalInet tests to see that a pointer to a float64 is marshalled correctly.
+// TestMarshalInet tests to see that a pointer to a float64 is marshalled correctly.
 func TestMarshalInet(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1788,7 +1788,7 @@ func TestVarint(t *testing.T) {
 	}
 }
 
-//TestQueryStats confirms that the stats are returning valid data. Accuracy may be questionable.
+// TestQueryStats confirms that the stats are returning valid data. Accuracy may be questionable.
 func TestQueryStats(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1817,7 +1817,7 @@ func TestIterHost(t *testing.T) {
 	}
 }
 
-//TestBatchStats confirms that the stats are returning valid data. Accuracy may be questionable.
+// TestBatchStats confirms that the stats are returning valid data. Accuracy may be questionable.
 func TestBatchStats(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
@@ -1915,8 +1915,8 @@ func TestBatchObserve(t *testing.T) {
 	}
 }
 
-//TestNilInQuery tests to see that a nil value passed to a query is handled by Cassandra
-//TODO validate the nil value by reading back the nil. Need to fix Unmarshalling.
+// TestNilInQuery tests to see that a nil value passed to a query is handled by Cassandra
+// TODO validate the nil value by reading back the nil. Need to fix Unmarshalling.
 func TestNilInQuery(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()

--- a/conn.go
+++ b/conn.go
@@ -91,13 +91,13 @@ func (p PasswordAuthenticator) Success(data []byte) error {
 // to true if no Config is set. Most users should set SslOptions.Config to a *tls.Config.
 // SslOptions and Config.InsecureSkipVerify interact as follows:
 //
-//  Config.InsecureSkipVerify | EnableHostVerification | Result
-//  Config is nil             | false                  | do not verify host
-//  Config is nil             | true                   | verify host
-//  false                     | false                  | verify host
-//  true                      | false                  | do not verify host
-//  false                     | true                   | verify host
-//  true                      | true                   | verify host
+//	Config.InsecureSkipVerify | EnableHostVerification | Result
+//	Config is nil             | false                  | do not verify host
+//	Config is nil             | true                   | verify host
+//	false                     | false                  | verify host
+//	true                      | false                  | do not verify host
+//	false                     | true                   | verify host
+//	true                      | true                   | verify host
 type SslOptions struct {
 	*tls.Config
 

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -350,7 +350,7 @@ func (pool *hostConnPool) Pick() *Conn {
 	return leastBusyConn
 }
 
-//Size returns the number of connections currently active in the pool
+// Size returns the number of connections currently active in the pool
 func (pool *hostConnPool) Size() int {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
@@ -358,7 +358,7 @@ func (pool *hostConnPool) Size() int {
 	return len(pool.conns)
 }
 
-//Close the connection pool
+// Close the connection pool
 func (pool *hostConnPool) Close() {
 	pool.mu.Lock()
 

--- a/connectionpool_test.go
+++ b/connectionpool_test.go
@@ -1,3 +1,4 @@
+//go:build all || unit
 // +build all unit
 
 package gocql
@@ -9,8 +10,8 @@ import (
 
 func TestSetupTLSConfig(t *testing.T) {
 	tests := []struct {
-		name string
-		opts *SslOptions
+		name                       string
+		opts                       *SslOptions
 		expectedInsecureSkipVerify bool
 	}{
 		{
@@ -82,4 +83,3 @@ func TestSetupTLSConfig(t *testing.T) {
 		})
 	}
 }
-

--- a/debug_off.go
+++ b/debug_off.go
@@ -1,3 +1,4 @@
+//go:build !gocql_debug
 // +build !gocql_debug
 
 package gocql

--- a/debug_on.go
+++ b/debug_on.go
@@ -1,3 +1,4 @@
+//go:build gocql_debug
 // +build gocql_debug
 
 package gocql

--- a/doc.go
+++ b/doc.go
@@ -5,15 +5,15 @@
 // Package gocql implements a fast and robust Cassandra driver for the
 // Go programming language.
 //
-// Connecting to the cluster
+// # Connecting to the cluster
 //
 // Pass a list of initial node IP addresses to NewCluster to create a new cluster configuration:
 //
-//  cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
+//	cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
 //
 // Port can be specified as part of the address, the above is equivalent to:
 //
-//  cluster := gocql.NewCluster("192.168.1.1:9042", "192.168.1.2:9042", "192.168.1.3:9042")
+//	cluster := gocql.NewCluster("192.168.1.1:9042", "192.168.1.2:9042", "192.168.1.3:9042")
 //
 // It is recommended to use the value set in the Cassandra config for broadcast_address or listen_address,
 // an IP address not a domain name. This is because events from Cassandra will use the configured IP
@@ -22,9 +22,9 @@
 //
 // Then you can customize more options (see ClusterConfig):
 //
-//  cluster.Keyspace = "example"
-//  cluster.Consistency = gocql.Quorum
-//  cluster.ProtoVersion = 4
+//	cluster.Keyspace = "example"
+//	cluster.Consistency = gocql.Quorum
+//	cluster.ProtoVersion = 4
 //
 // The driver tries to automatically detect the protocol version to use if not set, but you might want to set the
 // protocol version explicitly, as it's not defined which version will be used in certain situations (for example
@@ -32,13 +32,13 @@
 //
 // When ready, create a session from the configuration. Don't forget to Close the session once you are done with it:
 //
-//  session, err := cluster.CreateSession()
-//  if err != nil {
-//  	return err
-//  }
-//  defer session.Close()
+//	session, err := cluster.CreateSession()
+//	if err != nil {
+//		return err
+//	}
+//	defer session.Close()
 //
-// Authentication
+// # Authentication
 //
 // CQL protocol uses a SASL-based authentication mechanism and so consists of an exchange of server challenges and
 // client response pairs. The details of the exchanged messages depend on the authenticator used.
@@ -47,18 +47,18 @@
 //
 // PasswordAuthenticator is provided to use for username/password authentication:
 //
-//  cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
-//  cluster.Authenticator = gocql.PasswordAuthenticator{
-//		Username: "user",
-//		Password: "password"
-//  }
-//  session, err := cluster.CreateSession()
-//  if err != nil {
-//  	return err
-//  }
-//  defer session.Close()
+//	 cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
+//	 cluster.Authenticator = gocql.PasswordAuthenticator{
+//			Username: "user",
+//			Password: "password"
+//	 }
+//	 session, err := cluster.CreateSession()
+//	 if err != nil {
+//	 	return err
+//	 }
+//	 defer session.Close()
 //
-// Transport layer security
+// # Transport layer security
 //
 // It is possible to secure traffic between the client and server with TLS.
 //
@@ -69,38 +69,38 @@
 // to true if no Config is set. Most users should set SslOptions.Config to a *tls.Config.
 // SslOptions and Config.InsecureSkipVerify interact as follows:
 //
-//  Config.InsecureSkipVerify | EnableHostVerification | Result
-//  Config is nil             | false                  | do not verify host
-//  Config is nil             | true                   | verify host
-//  false                     | false                  | verify host
-//  true                      | false                  | do not verify host
-//  false                     | true                   | verify host
-//  true                      | true                   | verify host
+//	Config.InsecureSkipVerify | EnableHostVerification | Result
+//	Config is nil             | false                  | do not verify host
+//	Config is nil             | true                   | verify host
+//	false                     | false                  | verify host
+//	true                      | false                  | do not verify host
+//	false                     | true                   | verify host
+//	true                      | true                   | verify host
 //
 // For example:
 //
-//  cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
-//  cluster.SslOpts = &gocql.SslOptions{
-//  	EnableHostVerification: true,
-//  }
-//  session, err := cluster.CreateSession()
-//  if err != nil {
-//  	return err
-//  }
-//  defer session.Close()
+//	cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
+//	cluster.SslOpts = &gocql.SslOptions{
+//		EnableHostVerification: true,
+//	}
+//	session, err := cluster.CreateSession()
+//	if err != nil {
+//		return err
+//	}
+//	defer session.Close()
 //
-// Data-center awareness and query routing
+// # Data-center awareness and query routing
 //
 // To route queries to local DC first, use DCAwareRoundRobinPolicy. For example, if the datacenter you
 // want to primarily connect is called dc1 (as configured in the database):
 //
-//  cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
-//  cluster.PoolConfig.HostSelectionPolicy = gocql.DCAwareRoundRobinPolicy("dc1")
+//	cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
+//	cluster.PoolConfig.HostSelectionPolicy = gocql.DCAwareRoundRobinPolicy("dc1")
 //
 // The driver can route queries to nodes that hold data replicas based on partition key (preferring local DC).
 //
-//  cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
-//  cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.DCAwareRoundRobinPolicy("dc1"))
+//	cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
+//	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.DCAwareRoundRobinPolicy("dc1"))
 //
 // Note that TokenAwareHostPolicy can take options such as gocql.ShuffleReplicas and gocql.NonLocalReplicasFallback.
 //
@@ -109,50 +109,50 @@
 // The driver can only use token-aware routing for queries where all partition key columns are query parameters.
 // For example, instead of
 //
-//  session.Query("select value from mytable where pk1 = 'abc' AND pk2 = ?", "def")
+//	session.Query("select value from mytable where pk1 = 'abc' AND pk2 = ?", "def")
 //
 // use
 //
-//  session.Query("select value from mytable where pk1 = ? AND pk2 = ?", "abc", "def")
+//	session.Query("select value from mytable where pk1 = ? AND pk2 = ?", "abc", "def")
 //
-// Executing queries
+// # Executing queries
 //
 // Create queries with Session.Query. Query values must not be reused between different executions and must not be
 // modified after starting execution of the query.
 //
 // To execute a query without reading results, use Query.Exec:
 //
-//  err := session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
-//		"me", gocql.TimeUUID(), "hello world").WithContext(ctx).Exec()
+//	 err := session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
+//			"me", gocql.TimeUUID(), "hello world").WithContext(ctx).Exec()
 //
 // Single row can be read by calling Query.Scan:
 //
-//  err := session.Query(`SELECT id, text FROM tweet WHERE timeline = ? LIMIT 1`,
-//		"me").WithContext(ctx).Consistency(gocql.One).Scan(&id, &text)
+//	 err := session.Query(`SELECT id, text FROM tweet WHERE timeline = ? LIMIT 1`,
+//			"me").WithContext(ctx).Consistency(gocql.One).Scan(&id, &text)
 //
 // Multiple rows can be read using Iter.Scanner:
 //
-//  scanner := session.Query(`SELECT id, text FROM tweet WHERE timeline = ?`,
-//  	"me").WithContext(ctx).Iter().Scanner()
-//  for scanner.Next() {
-//  	var (
-//  		id gocql.UUID
-//		text string
-//  	)
-//  	err = scanner.Scan(&id, &text)
-//  	if err != nil {
-//  		log.Fatal(err)
-//  	}
-//  	fmt.Println("Tweet:", id, text)
-//  }
-//  // scanner.Err() closes the iterator, so scanner nor iter should be used afterwards.
-//  if err := scanner.Err(); err != nil {
-//  	log.Fatal(err)
-//  }
+//	 scanner := session.Query(`SELECT id, text FROM tweet WHERE timeline = ?`,
+//	 	"me").WithContext(ctx).Iter().Scanner()
+//	 for scanner.Next() {
+//	 	var (
+//	 		id gocql.UUID
+//			text string
+//	 	)
+//	 	err = scanner.Scan(&id, &text)
+//	 	if err != nil {
+//	 		log.Fatal(err)
+//	 	}
+//	 	fmt.Println("Tweet:", id, text)
+//	 }
+//	 // scanner.Err() closes the iterator, so scanner nor iter should be used afterwards.
+//	 if err := scanner.Err(); err != nil {
+//	 	log.Fatal(err)
+//	 }
 //
 // See Example for complete example.
 //
-// Prepared statements
+// # Prepared statements
 //
 // The driver automatically prepares DML queries (SELECT/INSERT/UPDATE/DELETE/BATCH statements) and maintains a cache
 // of prepared statements.
@@ -163,71 +163,71 @@
 // The main advantage is the ability to keep the same prepared statement even when you don't
 // want to update some fields, where before you needed to make another prepared statement.
 //
-// Executing multiple queries concurrently
+// # Executing multiple queries concurrently
 //
 // Session is safe to use from multiple goroutines, so to execute multiple concurrent queries, just execute them
 // from several worker goroutines. Gocql provides synchronously-looking API (as recommended for Go APIs) and the queries
 // are executed asynchronously at the protocol level.
 //
-//  results := make(chan error, 2)
-//  go func() {
-//  	results <- session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
-//  		"me", gocql.TimeUUID(), "hello world 1").Exec()
-//  }()
-//  go func() {
-//  	results <- session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
-//  		"me", gocql.TimeUUID(), "hello world 2").Exec()
-//  }()
+//	results := make(chan error, 2)
+//	go func() {
+//		results <- session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
+//			"me", gocql.TimeUUID(), "hello world 1").Exec()
+//	}()
+//	go func() {
+//		results <- session.Query(`INSERT INTO tweet (timeline, id, text) VALUES (?, ?, ?)`,
+//			"me", gocql.TimeUUID(), "hello world 2").Exec()
+//	}()
 //
-// Nulls
+// # Nulls
 //
 // Null values are are unmarshalled as zero value of the type. If you need to distinguish for example between text
 // column being null and empty string, you can unmarshal into *string variable instead of string.
 //
-//  var text *string
-//  err := scanner.Scan(&text)
-//  if err != nil {
-//  	// handle error
-//  }
-//  if text != nil {
-//  	// not null
-//  }
-//  else {
-//  	// null
-//  }
+//	var text *string
+//	err := scanner.Scan(&text)
+//	if err != nil {
+//		// handle error
+//	}
+//	if text != nil {
+//		// not null
+//	}
+//	else {
+//		// null
+//	}
 //
 // See Example_nulls for full example.
 //
-// Reusing slices
+// # Reusing slices
 //
 // The driver reuses backing memory of slices when unmarshalling. This is an optimization so that a buffer does not
 // need to be allocated for every processed row. However, you need to be careful when storing the slices to other
 // memory structures.
 //
-//  scanner := session.Query(`SELECT myints FROM table WHERE pk = ?`, "key").WithContext(ctx).Iter().Scanner()
-//  var myInts []int
-//  for scanner.Next() {
-//  	// This scan reuses backing store of myInts for each row.
-//  	err = scanner.Scan(&myInts)
-//  	if err != nil {
-//  		log.Fatal(err)
-//  	}
-//  }
+//	scanner := session.Query(`SELECT myints FROM table WHERE pk = ?`, "key").WithContext(ctx).Iter().Scanner()
+//	var myInts []int
+//	for scanner.Next() {
+//		// This scan reuses backing store of myInts for each row.
+//		err = scanner.Scan(&myInts)
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//	}
 //
 // When you want to save the data for later use, pass a new slice every time. A common pattern is to declare the
 // slice variable within the scanner loop:
 //
-//  scanner := session.Query(`SELECT myints FROM table WHERE pk = ?`, "key").WithContext(ctx).Iter().Scanner()
-//  for scanner.Next() {
-//  	var myInts []int
-//  	// This scan always gets pointer to fresh myInts slice, so does not reuse memory.
-//  	err = scanner.Scan(&myInts)
-//  	if err != nil {
-//  		log.Fatal(err)
-//  	}
-//  }
+//	scanner := session.Query(`SELECT myints FROM table WHERE pk = ?`, "key").WithContext(ctx).Iter().Scanner()
+//	for scanner.Next() {
+//		var myInts []int
+//		// This scan always gets pointer to fresh myInts slice, so does not reuse memory.
+//		err = scanner.Scan(&myInts)
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//	}
 //
-// Paging
+// # Paging
 //
 // The driver supports paging of results with automatic prefetch, see ClusterConfig.PageSize, Session.SetPrefetch,
 // Query.PageSize, and Query.Prefetch.
@@ -258,14 +258,14 @@
 //
 // See Example_paging for an example of manual paging.
 //
-// Dynamic list of columns
+// # Dynamic list of columns
 //
 // There are certain situations when you don't know the list of columns in advance, mainly when the query is supplied
 // by the user. Iter.Columns, Iter.RowData, Iter.MapScan and Iter.SliceMap can be used to handle this case.
 //
 // See Example_dynamicColumns.
 //
-// Batches
+// # Batches
 //
 // The CQL protocol supports sending batches of DML statements (INSERT/UPDATE/DELETE) and so does gocql.
 // Use Session.NewBatch to create a new batch and then fill-in details of individual queries.
@@ -292,7 +292,7 @@
 //
 // See Example_batch for an example.
 //
-// Lightweight transactions
+// # Lightweight transactions
 //
 // Query.ScanCAS or Query.MapScanCAS can be used to execute a single-statement lightweight transaction (an
 // INSERT/UPDATE .. IF statement) and reading its result. See example for Query.MapScanCAS.
@@ -302,7 +302,7 @@
 // Session.MapExecuteBatchCAS when executing the batch to learn about the result of the LWT. See example for
 // Session.MapExecuteBatchCAS.
 //
-// Retries and speculative execution
+// # Retries and speculative execution
 //
 // Queries can be marked as idempotent. Marking the query as idempotent tells the driver that the query can be executed
 // multiple times without affecting its result. Non-idempotent queries are not eligible for retrying nor speculative
@@ -316,21 +316,21 @@
 // is still executing. The two parallel executions of the query race to return a result, the first received result will
 // be returned.
 //
-// User-defined types
+// # User-defined types
 //
 // UDTs can be mapped (un)marshaled from/to map[string]interface{} a Go struct (or a type implementing
 // UDTUnmarshaler, UDTMarshaler, Unmarshaler or Marshaler interfaces).
 //
 // For structs, cql tag can be used to specify the CQL field name to be mapped to a struct field:
 //
-//  type MyUDT struct {
-//  	FieldA int32 `cql:"a"`
-//  	FieldB string `cql:"b"`
-//  }
+//	type MyUDT struct {
+//		FieldA int32 `cql:"a"`
+//		FieldB string `cql:"b"`
+//	}
 //
 // See Example_userDefinedTypesMap, Example_userDefinedTypesStruct, ExampleUDTMarshaler, ExampleUDTUnmarshaler.
 //
-// Metrics and tracing
+// # Metrics and tracing
 //
 // It is possible to provide observer implementations that could be used to gather metrics:
 //

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -1,4 +1,5 @@
-// +build ccm, ignore
+//go:build (ccm && ignore) || ignore
+// +build ccm,ignore ignore
 
 package gocql
 

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -39,12 +39,12 @@ func ExampleSession_MapExecuteBatchCAS() {
 	executeBatch := func(ck2Version int) {
 		b := session.NewBatch(gocql.LoggedBatch)
 		b.Entries = append(b.Entries, gocql.BatchEntry{
-			Stmt:       "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
-			Args:       []interface{}{"b", "pk1", "ck1", 1},
+			Stmt: "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
+			Args: []interface{}{"b", "pk1", "ck1", 1},
 		})
 		b.Entries = append(b.Entries, gocql.BatchEntry{
-			Stmt:       "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
-			Args:       []interface{}{"B", "pk1", "ck2", ck2Version},
+			Stmt: "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
+			Args: []interface{}{"B", "pk1", "ck2", ck2Version},
 		})
 		m := make(map[string]interface{})
 		applied, iter, err := session.MapExecuteBatchCAS(b.WithContext(ctx), m)

--- a/example_nulls_test.go
+++ b/example_nulls_test.go
@@ -28,7 +28,7 @@ func Example_nulls() {
 	scanner := session.Query(`SELECT id, value FROM stringvals`).Iter().Scanner()
 	for scanner.Next() {
 		var (
-			id int32
+			id  int32
 			val *string
 		)
 		err := scanner.Scan(&id, &val)

--- a/example_paging_test.go
+++ b/example_paging_test.go
@@ -38,7 +38,7 @@ func Example_paging() {
 		scanner := iter.Scanner()
 		for scanner.Next() {
 			var (
-				id int
+				id          int
 				description string
 			)
 			err = scanner.Scan(&id, &description)

--- a/example_set_test.go
+++ b/example_set_test.go
@@ -45,7 +45,7 @@ func Example_set() {
 	scanner := session.Query(`SELECT id, value FROM sets`).Iter().Scanner()
 	for scanner.Next() {
 		var (
-			id int32
+			id  int32
 			val []string
 		)
 		err := scanner.Scan(&id, &val)

--- a/example_udt_struct_test.go
+++ b/example_udt_struct_test.go
@@ -9,7 +9,7 @@ import (
 
 type MyUDT struct {
 	FieldA string `cql:"field_a"`
-	FieldB int32 `cql:"field_b"`
+	FieldB int32  `cql:"field_b"`
 }
 
 // Example_userDefinedTypesStruct demonstrates how to work with user-defined types as structs.

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package gocql

--- a/host_source_gen.go
+++ b/host_source_gen.go
@@ -1,3 +1,4 @@
+//go:build genhostinfo
 // +build genhostinfo
 
 package main

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,3 +1,4 @@
+//go:build all || integration
 // +build all integration
 
 package gocql

--- a/marshal.go
+++ b/marshal.go
@@ -51,45 +51,45 @@ type Unmarshaler interface {
 //
 // Supported conversions are as follows, other type combinations may be added in the future:
 //
-//  CQL type                    | Go type (value)    | Note
-//  varchar, ascii, blob, text  | string, []byte     |
-//  boolean                     | bool               |
-//  tinyint, smallint, int      | integer types      |
-//  tinyint, smallint, int      | string             | formatted as base 10 number
-//  bigint, counter             | integer types      |
-//  bigint, counter             | big.Int            |
-//  bigint, counter             | string             | formatted as base 10 number
-//  float                       | float32            |
-//  double                      | float64            |
-//  decimal                     | inf.Dec            |
-//  time                        | int64              | nanoseconds since start of day
-//  time                        | time.Duration      | duration since start of day
-//  timestamp                   | int64              | milliseconds since Unix epoch
-//  timestamp                   | time.Time          |
-//  list, set                   | slice, array       |
-//  list, set                   | map[X]struct{}     |
-//  map                         | map[X]Y            |
-//  uuid, timeuuid              | gocql.UUID         |
-//  uuid, timeuuid              | [16]byte           | raw UUID bytes
-//  uuid, timeuuid              | []byte             | raw UUID bytes, length must be 16 bytes
-//  uuid, timeuuid              | string             | hex representation, see ParseUUID
-//  varint                      | integer types      |
-//  varint                      | big.Int            |
-//  varint                      | string             | value of number in decimal notation
-//  inet                        | net.IP             |
-//  inet                        | string             | IPv4 or IPv6 address string
-//  tuple                       | slice, array       |
-//  tuple                       | struct             | fields are marshaled in order of declaration
-//  user-defined type           | gocql.UDTMarshaler | MarshalUDT is called
-//  user-defined type           | map[string]interface{} |
-//  user-defined type           | struct             | struct fields' cql tags are used for column names
-//  date                        | int64              | milliseconds since Unix epoch to start of day (in UTC)
-//  date                        | time.Time          | start of day (in UTC)
-//  date                        | string             | parsed using "2006-01-02" format
-//  duration                    | int64              | duration in nanoseconds
-//  duration                    | time.Duration      |
-//  duration                    | gocql.Duration     |
-//  duration                    | string             | parsed with time.ParseDuration
+//	CQL type                    | Go type (value)    | Note
+//	varchar, ascii, blob, text  | string, []byte     |
+//	boolean                     | bool               |
+//	tinyint, smallint, int      | integer types      |
+//	tinyint, smallint, int      | string             | formatted as base 10 number
+//	bigint, counter             | integer types      |
+//	bigint, counter             | big.Int            |
+//	bigint, counter             | string             | formatted as base 10 number
+//	float                       | float32            |
+//	double                      | float64            |
+//	decimal                     | inf.Dec            |
+//	time                        | int64              | nanoseconds since start of day
+//	time                        | time.Duration      | duration since start of day
+//	timestamp                   | int64              | milliseconds since Unix epoch
+//	timestamp                   | time.Time          |
+//	list, set                   | slice, array       |
+//	list, set                   | map[X]struct{}     |
+//	map                         | map[X]Y            |
+//	uuid, timeuuid              | gocql.UUID         |
+//	uuid, timeuuid              | [16]byte           | raw UUID bytes
+//	uuid, timeuuid              | []byte             | raw UUID bytes, length must be 16 bytes
+//	uuid, timeuuid              | string             | hex representation, see ParseUUID
+//	varint                      | integer types      |
+//	varint                      | big.Int            |
+//	varint                      | string             | value of number in decimal notation
+//	inet                        | net.IP             |
+//	inet                        | string             | IPv4 or IPv6 address string
+//	tuple                       | slice, array       |
+//	tuple                       | struct             | fields are marshaled in order of declaration
+//	user-defined type           | gocql.UDTMarshaler | MarshalUDT is called
+//	user-defined type           | map[string]interface{} |
+//	user-defined type           | struct             | struct fields' cql tags are used for column names
+//	date                        | int64              | milliseconds since Unix epoch to start of day (in UTC)
+//	date                        | time.Time          | start of day (in UTC)
+//	date                        | string             | parsed using "2006-01-02" format
+//	duration                    | int64              | duration in nanoseconds
+//	duration                    | time.Duration      |
+//	duration                    | gocql.Duration     |
+//	duration                    | string             | parsed with time.ParseDuration
 func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 	if info.Version() < protoVersion1 {
 		panic("protocol version not set")
@@ -172,36 +172,36 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 //
 // Supported conversions are as follows, other type combinations may be added in the future:
 //
-//  CQL type                                | Go type (value)         | Note
-//  varchar, ascii, blob, text              | *string                 |
-//  varchar, ascii, blob, text              | *[]byte                 | non-nil buffer is reused
-//  bool                                    | *bool                   |
-//  tinyint, smallint, int, bigint, counter | *integer types          |
-//  tinyint, smallint, int, bigint, counter | *big.Int                |
-//  tinyint, smallint, int, bigint, counter | *string                 | formatted as base 10 number
-//  float                                   | *float32                |
-//  double                                  | *float64                |
-//  decimal                                 | *inf.Dec                |
-//  time                                    | *int64                  | nanoseconds since start of day
-//  time                                    | *time.Duration          |
-//  timestamp                               | *int64                  | milliseconds since Unix epoch
-//  timestamp                               | *time.Time              |
-//  list, set                               | *slice, *array          |
-//  map                                     | *map[X]Y                |
-//  uuid, timeuuid                          | *string                 | see UUID.String
-//  uuid, timeuuid                          | *[]byte                 | raw UUID bytes
-//  uuid, timeuuid                          | *gocql.UUID             |
-//  timeuuid                                | *time.Time              | timestamp of the UUID
-//  inet                                    | *net.IP                 |
-//  inet                                    | *string                 | IPv4 or IPv6 address string
-//  tuple                                   | *slice, *array          |
-//  tuple                                   | *struct                 | struct fields are set in order of declaration
-//  user-defined types                      | gocql.UDTUnmarshaler    | UnmarshalUDT is called
-//  user-defined types                      | *map[string]interface{} |
-//  user-defined types                      | *struct                 | cql tag is used to determine field name
-//  date                                    | *time.Time              | time of beginning of the day (in UTC)
-//  date                                    | *string                 | formatted with 2006-01-02 format
-//  duration                                | *gocql.Duration         |
+//	CQL type                                | Go type (value)         | Note
+//	varchar, ascii, blob, text              | *string                 |
+//	varchar, ascii, blob, text              | *[]byte                 | non-nil buffer is reused
+//	bool                                    | *bool                   |
+//	tinyint, smallint, int, bigint, counter | *integer types          |
+//	tinyint, smallint, int, bigint, counter | *big.Int                |
+//	tinyint, smallint, int, bigint, counter | *string                 | formatted as base 10 number
+//	float                                   | *float32                |
+//	double                                  | *float64                |
+//	decimal                                 | *inf.Dec                |
+//	time                                    | *int64                  | nanoseconds since start of day
+//	time                                    | *time.Duration          |
+//	timestamp                               | *int64                  | milliseconds since Unix epoch
+//	timestamp                               | *time.Time              |
+//	list, set                               | *slice, *array          |
+//	map                                     | *map[X]Y                |
+//	uuid, timeuuid                          | *string                 | see UUID.String
+//	uuid, timeuuid                          | *[]byte                 | raw UUID bytes
+//	uuid, timeuuid                          | *gocql.UUID             |
+//	timeuuid                                | *time.Time              | timestamp of the UUID
+//	inet                                    | *net.IP                 |
+//	inet                                    | *string                 | IPv4 or IPv6 address string
+//	tuple                                   | *slice, *array          |
+//	tuple                                   | *struct                 | struct fields are set in order of declaration
+//	user-defined types                      | gocql.UDTUnmarshaler    | UnmarshalUDT is called
+//	user-defined types                      | *map[string]interface{} |
+//	user-defined types                      | *struct                 | cql tag is used to determine field name
+//	date                                    | *time.Time              | time of beginning of the day (in UTC)
+//	date                                    | *string                 | formatted with 2006-01-02 format
+//	duration                                | *gocql.Duration         |
 func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 	if v, ok := value.(Unmarshaler); ok {
 		return v.UnmarshalCQL(info, data)

--- a/policies.go
+++ b/policies.go
@@ -133,12 +133,11 @@ type RetryPolicy interface {
 //
 // See below for examples of usage:
 //
-//     //Assign to the cluster
-//     cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 3}
+//	//Assign to the cluster
+//	cluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 3}
 //
-//     //Assign to a query
-//     query.RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 1})
-//
+//	//Assign to a query
+//	query.RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 1})
 type SimpleRetryPolicy struct {
 	NumRetries int //Number of times to retry a query
 }
@@ -634,14 +633,13 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 // use an empty slice of hosts as the hostpool will be populated later by gocql.
 // See below for examples of usage:
 //
-//     // Create host selection policy using a simple host pool
-//     cluster.PoolConfig.HostSelectionPolicy = HostPoolHostPolicy(hostpool.New(nil))
+//	// Create host selection policy using a simple host pool
+//	cluster.PoolConfig.HostSelectionPolicy = HostPoolHostPolicy(hostpool.New(nil))
 //
-//     // Create host selection policy using an epsilon greedy pool
-//     cluster.PoolConfig.HostSelectionPolicy = HostPoolHostPolicy(
-//         hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
-//     )
-//
+//	// Create host selection policy using an epsilon greedy pool
+//	cluster.PoolConfig.HostSelectionPolicy = HostPoolHostPolicy(
+//	    hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+//	)
 func HostPoolHostPolicy(hp hostpool.HostPool) HostSelectionPolicy {
 	return &hostPoolHostPolicy{hostMap: map[string]*HostInfo{}, hp: hp}
 }
@@ -926,7 +924,6 @@ func (e *SimpleConvictionPolicy) Reset(host *HostInfo) {}
 // ReconnectionPolicy interface is used by gocql to determine if reconnection
 // can be attempted after connection error. The interface allows gocql users
 // to implement their own logic to determine how to attempt reconnection.
-//
 type ReconnectionPolicy interface {
 	GetInterval(currentRetry int) time.Duration
 	GetMaxRetries() int
@@ -936,8 +933,7 @@ type ReconnectionPolicy interface {
 //
 // Examples of usage:
 //
-//     cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{MaxRetries: 10, Interval: 8 * time.Second}
-//
+//	cluster.ReconnectionPolicy = &gocql.ConstantReconnectionPolicy{MaxRetries: 10, Interval: 8 * time.Second}
 type ConstantReconnectionPolicy struct {
 	MaxRetries int
 	Interval   time.Duration

--- a/session.go
+++ b/session.go
@@ -926,7 +926,7 @@ func (q Query) String() string {
 	return fmt.Sprintf("[query statement=%q values=%+v consistency=%s]", q.stmt, q.values, q.cons)
 }
 
-//Attempts returns the number of times the query was executed.
+// Attempts returns the number of times the query was executed.
 func (q *Query) Attempts() int {
 	return q.metrics.attempts()
 }
@@ -935,7 +935,7 @@ func (q *Query) AddAttempts(i int, host *HostInfo) {
 	q.metrics.attempt(i, 0, host, false)
 }
 
-//Latency returns the average amount of nanoseconds per attempt of the query.
+// Latency returns the average amount of nanoseconds per attempt of the query.
 func (q *Query) Latency() int64 {
 	return q.metrics.latency()
 }
@@ -1319,9 +1319,10 @@ func (q *Query) MapScanCAS(dest map[string]interface{}) (applied bool, err error
 // cannot be reused.
 //
 // Example:
-// 		qry := session.Query("SELECT * FROM my_table")
-// 		qry.Exec()
-// 		qry.Release()
+//
+//	qry := session.Query("SELECT * FROM my_table")
+//	qry.Exec()
+//	qry.Release()
 func (q *Query) Release() {
 	q.reset()
 	queryPool.Put(q)
@@ -1712,7 +1713,7 @@ func (b *Batch) AddAttempts(i int, host *HostInfo) {
 	b.metrics.attempt(i, 0, host, false)
 }
 
-//Latency returns the average number of nanoseconds to execute a single attempt of the batch.
+// Latency returns the average number of nanoseconds to execute a single attempt of the batch.
 func (b *Batch) Latency() int64 {
 	return b.metrics.latency()
 }
@@ -1978,8 +1979,8 @@ func (r *routingKeyInfoLRU) Remove(key string) {
 	r.mu.Unlock()
 }
 
-//Max adjusts the maximum size of the cache and cleans up the oldest records if
-//the new max is lower than the previous value. Not concurrency safe.
+// Max adjusts the maximum size of the cache and cleans up the oldest records if
+// the new max is lower than the previous value. Not concurrency safe.
 func (r *routingKeyInfoLRU) Max(max int) {
 	r.mu.Lock()
 	for r.lru.Len() > max {

--- a/session_test.go
+++ b/session_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -1,3 +1,4 @@
+//go:build all || unit
 // +build all unit
 
 package gocql

--- a/stress_test.go
+++ b/stress_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/topology_test.go
+++ b/topology_test.go
@@ -55,7 +55,7 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 		hostsPerDC = 5
 	)
 
-	tests := []struct{
+	tests := []struct {
 		name                   string
 		strat                  *networkTopology
 		expectedReplicaMapSize int
@@ -69,7 +69,7 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 					"dc3": 3,
 				},
 			},
-			expectedReplicaMapSize: hostsPerDC*totalDCs,
+			expectedReplicaMapSize: hostsPerDC * totalDCs,
 		},
 		{
 			name: "missing",
@@ -79,7 +79,7 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 					"dc3": 3,
 				},
 			},
-			expectedReplicaMapSize: hostsPerDC*2,
+			expectedReplicaMapSize: hostsPerDC * 2,
 		},
 		{
 			name: "zero",
@@ -90,7 +90,7 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 					"dc3": 3,
 				},
 			},
-			expectedReplicaMapSize: hostsPerDC*2,
+			expectedReplicaMapSize: hostsPerDC * 2,
 		},
 	}
 

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -1,3 +1,4 @@
+//go:build all || integration
 // +build all integration
 
 package gocql

--- a/udt_test.go
+++ b/udt_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,3 +1,4 @@
+//go:build all || unit
 // +build all unit
 
 package gocql

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -1,3 +1,4 @@
+//go:build all || cassandra
 // +build all cassandra
 
 package gocql


### PR DESCRIPTION
There are different format rules for Go 1.19, reformat the comments
with the new version so that the formatting changes do not show up in
unrelated merge requests.