### PR TITLE
refresh ring when node UP event received for missing host

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,3 +132,4 @@ Stefan Miklosovic <smiklosovic@apache.org>
 Adam Burk <amburk@gmail.com>
 Valerii Ponomarov <kiparis.kh@gmail.com>
 Neal Turett <neal.turett@datadoghq.com>
+Steven Seidman <steven.seidman@datadoghq.com>

--- a/events.go
+++ b/events.go
@@ -264,6 +264,9 @@ func (s *Session) handleNodeUp(eventIp net.IP, eventPort int) {
 
 	host, ok := s.ring.getHostByIP(eventIp.String())
 	if !ok {
+		if err := s.hostSource.refreshRing(); err != nil && gocqlDebug {
+			s.logger.Printf("gocql: Session.handleNodeUp: failed to refresh ring: %w\n", err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
The current issue is that there are no events dispatched for `NEW_NODE` changes. In a 3 node cassandra cluster deployed on cloud infrastructure, a cassandra instance was replaced using the `replace_address` flag so that it was moved to a new cloud instance (new IP, new host ID). The following debug logs are an example of how the client is currently handling this change in topology. 
```
2023/01/11 20:59:35 gocql: handling frame: [topology_change change=NEW_NODE host=10.128.191.122 port=9042]
2023/01/11 20:59:35 gocql: handling frame: [status_change change=UP host=10.128.191.122 port=9042]
2023/01/11 20:59:35 gocql: dispatching event: &{change:UP host:[10 128 191 122] port:9042}
2023/01/11 20:59:35 gocql: Session.handleNodeUp: 10.128.191.122:9042
```
There is no event dispatched for the `NEW_NODE` event and it jumps straight to processing the `UP` event, so the new node is never added to session ring. If all nodes in the cluster are replaced in this manner, the eventual outcome is that clients lose connection to the cluster and begin outputting `gocql: no hosts available in the pool`.

After bisecting recent commits, I found[ this PR](https://github.com/gocql/gocql/pull/1632/files#top) introduced the bug into the client. It looks like there was seemingly a [fail-safe](https://github.com/gocql/gocql/pull/1632/files#diff-6515f1a2f64d91949b3a8dbf406c260e24e551fb470fc9d520cf88d1b05c8090L271) for when the `NEW_NODE` event was missed, but this function was removed in the previously mentioned PR.

This change proposes to refresh the hostSource ring on `UP` events when the host cannot be found in the ring. This ensures that the hostMap stays up to date even if `NEW_NODE` events are not processed.

This should fix https://github.com/gocql/gocql/issues/1668, https://github.com/gocql/gocql/issues/1667, and https://github.com/gocql/gocql/issues/1582