### PR TITLE
Always refresh ring on topology changes and reconnections

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,3 +134,4 @@ Valerii Ponomarov <kiparis.kh@gmail.com>
 Neal Turett <neal.turett@datadoghq.com>
 Doug Schaapveld <djschaap@gmail.com>
 Steven Seidman <steven.seidman@datadoghq.com>
+João Reis <joao.reis@datastax.com>

--- a/conn.go
+++ b/conn.go
@@ -1651,6 +1651,10 @@ func (c *Conn) querySystemPeers(ctx context.Context, version cassVersion) *Iter 
 	}
 }
 
+func (c *Conn) querySystemLocal(ctx context.Context) *Iter {
+	return c.query(ctx, "SELECT * FROM system.local WHERE key='local'")
+}
+
 func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 	const localSchemas = "SELECT schema_version FROM system.local WHERE key='local'"
 
@@ -1719,23 +1723,6 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 
 	// not exported
 	return fmt.Errorf("gocql: cluster schema versions not consistent: %+v", schemas)
-}
-
-func (c *Conn) localHostInfo(ctx context.Context) (*HostInfo, error) {
-	row, err := c.query(ctx, "SELECT * FROM system.local WHERE key='local'").rowMap()
-	if err != nil {
-		return nil, err
-	}
-
-	port := c.conn.RemoteAddr().(*net.TCPAddr).Port
-
-	// TODO(zariel): avoid doing this here
-	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.connectAddress, port: port})
-	if err != nil {
-		return nil, err
-	}
-
-	return c.session.ring.addOrUpdate(host), nil
 }
 
 var (

--- a/control.go
+++ b/control.go
@@ -98,7 +98,7 @@ func (c *controlConn) heartBeat() {
 	reconn:
 		// try to connect a bit faster
 		sleepTime = 1 * time.Second
-		c.reconnect(true)
+		c.reconnect()
 		continue
 	}
 }
@@ -335,7 +335,7 @@ func (c *controlConn) registerEvents(conn *Conn) error {
 	return nil
 }
 
-func (c *controlConn) reconnect(refreshring bool) {
+func (c *controlConn) reconnect() {
 	if atomic.LoadInt32(&c.state) == controlConnClosing {
 		return
 	}
@@ -381,9 +381,7 @@ func (c *controlConn) reconnect(refreshring bool) {
 		return
 	}
 
-	if refreshring {
-		c.session.hostSource.refreshRing()
-	}
+	c.session.hostSource.refreshRing()
 }
 
 func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
@@ -399,7 +397,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 
-	c.reconnect(false)
+	c.reconnect()
 }
 
 func (c *controlConn) getConn() *connHost {
@@ -433,7 +431,7 @@ func (c *controlConn) withConnHost(fn func(*connHost) *Iter) *Iter {
 
 			connectAttempts++
 
-			c.reconnect(false)
+			c.reconnect()
 			continue
 		}
 

--- a/control.go
+++ b/control.go
@@ -384,7 +384,10 @@ func (c *controlConn) reconnect() {
 		return
 	}
 
-	c.session.hostSource.refreshRing()
+	err = c.session.refreshRing()
+	if err != nil {
+		c.session.logger.Printf("gocql: unable to refresh ring: %v\n", err)
+	}
 }
 
 func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {

--- a/control.go
+++ b/control.go
@@ -269,10 +269,13 @@ type connHost struct {
 
 func (c *controlConn) setupConn(conn *Conn) error {
 	// we need up-to-date host info for the filterHost call below
-	host, err := conn.localHostInfo(context.TODO())
+	iter := conn.querySystemLocal(context.TODO())
+	host, err := c.session.hostInfoFromIter(iter, conn.host.connectAddress, conn.conn.RemoteAddr().(*net.TCPAddr).Port)
 	if err != nil {
 		return err
 	}
+
+	host = c.session.ring.addOrUpdate(host)
 
 	if c.session.cfg.filterHost(host) {
 		return fmt.Errorf("host was filtered: %v", host.ConnectAddress())

--- a/control_ccm_test.go
+++ b/control_ccm_test.go
@@ -1,0 +1,173 @@
+//go:build ccm
+// +build ccm
+
+package gocql
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql/internal/ccm"
+)
+
+type TestHostFilter struct {
+	mu           sync.Mutex
+	allowedHosts map[string]ccm.Host
+}
+
+func (f *TestHostFilter) Accept(h *HostInfo) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.allowedHosts[h.ConnectAddress().String()]
+	return ok
+}
+
+func (f *TestHostFilter) SetAllowedHosts(hosts map[string]ccm.Host) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.allowedHosts = hosts
+}
+
+func TestControlConn_ReconnectRefreshesRing(t *testing.T) {
+	if err := ccm.AllUp(); err != nil {
+		t.Fatal(err)
+	}
+
+	allCcmHosts, err := ccm.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(allCcmHosts) < 2 {
+		t.Skip("this test requires at least 2 nodes")
+	}
+
+	allAllowedHosts := map[string]ccm.Host{}
+	var firstNode *ccm.Host
+	for _, node := range allCcmHosts {
+		if firstNode == nil {
+			firstNode = &node
+		}
+		allAllowedHosts[node.Addr] = node
+	}
+
+	allowedHosts := map[string]ccm.Host{
+		firstNode.Addr: *firstNode,
+	}
+
+	testFilter := &TestHostFilter{allowedHosts: allowedHosts}
+
+	session := createSession(t, func(config *ClusterConfig) {
+		config.Hosts = []string{firstNode.Addr}
+		config.Events.DisableTopologyEvents = true
+		config.Events.DisableNodeStatusEvents = true
+		config.HostFilter = testFilter
+	})
+	defer session.Close()
+
+	if session.control == nil || session.control.conn.Load() == nil {
+		t.Fatal("control conn is nil")
+	}
+
+	controlConnection := session.control.getConn()
+	ccHost := controlConnection.host
+
+	var ccHostName string
+	for _, node := range allCcmHosts {
+		if node.Addr == ccHost.ConnectAddress().String() {
+			ccHostName = node.Name
+			break
+		}
+	}
+
+	if ccHostName == "" {
+		t.Fatal("could not find name of control host")
+	}
+
+	if err := ccm.NodeDown(ccHostName); err != nil {
+		t.Fatal()
+	}
+
+	defer func() {
+		ccmStatus, err := ccm.Status()
+		if err != nil {
+			t.Logf("could not bring nodes back up after test: %v", err)
+			return
+		}
+		for _, node := range ccmStatus {
+			if node.State == ccm.NodeStateDown {
+				err = ccm.NodeUp(node.Name)
+				if err != nil {
+					t.Logf("could not bring node %v back up after test: %v", node.Name, err)
+				}
+			}
+		}
+	}()
+
+	assertNodeDown := func() error {
+		hosts := session.ring.currentHosts()
+		if len(hosts) != 1 {
+			return fmt.Errorf("expected 1 host in ring but there were %v", len(hosts))
+		}
+		for _, host := range hosts {
+			if host.IsUp() {
+				return fmt.Errorf("expected host to be DOWN but %v isn't", host.String())
+			}
+		}
+
+		pools := session.pool.hostConnPools
+		if len(pools) != 0 {
+			return fmt.Errorf("expected 0 connection pool but there were %v", len(pools))
+		}
+		return nil
+	}
+
+	maxAttempts := 5
+	delayPerAttempt := 1 * time.Second
+	assertErr := assertNodeDown()
+	for i := 0; i < maxAttempts && assertErr != nil; i++ {
+		time.Sleep(delayPerAttempt)
+		assertErr = assertNodeDown()
+	}
+
+	if assertErr != nil {
+		t.Fatal(err)
+	}
+
+	testFilter.SetAllowedHosts(allAllowedHosts)
+
+	if err = ccm.NodeUp(ccHostName); err != nil {
+		t.Fatal(err)
+	}
+
+	assertNodeUp := func() error {
+		hosts := session.ring.currentHosts()
+		if len(hosts) != len(allCcmHosts) {
+			return fmt.Errorf("expected %v hosts in ring but there were %v", len(allCcmHosts), len(hosts))
+		}
+		for _, host := range hosts {
+			if !host.IsUp() {
+				return fmt.Errorf("expected all hosts to be UP but %v isn't", host.String())
+			}
+		}
+		pools := session.pool.hostConnPools
+		if len(pools) != len(allCcmHosts) {
+			return fmt.Errorf("expected %v connection pool but there were %v", len(allCcmHosts), len(pools))
+		}
+		return nil
+	}
+
+	maxAttempts = 30
+	delayPerAttempt = 1 * time.Second
+	assertErr = assertNodeUp()
+	for i := 0; i < maxAttempts && assertErr != nil; i++ {
+		time.Sleep(delayPerAttempt)
+		assertErr = assertNodeUp()
+	}
+
+	if assertErr != nil {
+		t.Fatal(err)
+	}
+}

--- a/events.go
+++ b/events.go
@@ -194,34 +194,6 @@ func (s *Session) handleNodeEvent(frames []frame) {
 	}
 }
 
-func (s *Session) addNewNode(hostID UUID) {
-	// Get host info and apply any filters to the host
-	hostInfo, err := s.hostSource.getHostInfo(hostID)
-	if err != nil {
-		s.logger.Printf("gocql: events: unable to fetch host info for hostID: %q: %v\n", hostID, err)
-		return
-	} else if hostInfo == nil {
-		// ignore if it's null because we couldn't find it
-		return
-	}
-
-	if t := hostInfo.Version().nodeUpDelay(); t > 0 {
-		time.Sleep(t)
-	}
-
-	// should this handle token moving?
-	hostInfo = s.ring.addOrUpdate(hostInfo)
-
-	if !s.cfg.filterHost(hostInfo) {
-		s.startPoolFill(hostInfo)
-	}
-
-	if s.control != nil && !s.cfg.IgnorePeerAddr {
-		// TODO(zariel): debounce ring refresh
-		s.hostSource.refreshRing()
-	}
-}
-
 func (s *Session) handleNodeUp(eventIp net.IP, eventPort int) {
 	if gocqlDebug {
 		s.logger.Printf("gocql: Session.handleNodeUp: %s:%d\n", eventIp.String(), eventPort)

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -1,11 +1,15 @@
-//go:build all || cassandra
-// +build all cassandra
+//go:build all || unit
+// +build all unit
 
 package gocql
 
 import (
+	"errors"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestUnmarshalCassVersion(t *testing.T) {
@@ -97,5 +101,247 @@ func TestHostInfo_ConnectAddress(t *testing.T) {
 				t.Fatalf("expected ConnectAddress to be %s got %s", localhost, addr)
 			}
 		})
+	}
+}
+
+// This test sends debounce requests and waits until the refresh function is called (which should happen when the timer elapses).
+func TestRefreshDebouncer_MultipleEvents(t *testing.T) {
+	const numberOfEvents = 10
+	channel := make(chan int, numberOfEvents) // should never use more than 1 but allow for more to possibly detect bugs
+	fn := func() error {
+		channel <- 0
+		return nil
+	}
+	beforeEvents := time.Now()
+	wg := sync.WaitGroup{}
+	d := newRefreshDebouncer(2*time.Second, fn)
+	defer d.stop()
+	for i := 0; i < numberOfEvents; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.debounce()
+		}()
+	}
+	wg.Wait()
+	timeoutCh := time.After(2500 * time.Millisecond) // extra time to avoid flakiness
+	select {
+	case <-channel:
+	case <-timeoutCh:
+		t.Fatalf("timeout elapsed without flush function being called")
+	}
+	afterFunctionCall := time.Now()
+
+	// use 1.5 seconds instead of 2 seconds to avoid timer precision issues
+	if afterFunctionCall.Sub(beforeEvents) < 1500*time.Millisecond {
+		t.Fatalf("function was called after %v ms instead of ~2 seconds", afterFunctionCall.Sub(beforeEvents).Milliseconds())
+	}
+
+	// wait another 2 seconds and check if function was called again
+	time.Sleep(2500 * time.Millisecond)
+	if len(channel) > 0 {
+		t.Fatalf("function was called more than once")
+	}
+}
+
+// This test:
+//
+//	1 - Sends debounce requests when test starts
+//	2 - Calls refreshNow() before the timer elapsed (which stops the timer) about 1.5 seconds after test starts
+//
+// The end result should be 1 refresh function call when refreshNow() is called.
+func TestRefreshDebouncer_RefreshNow(t *testing.T) {
+	const numberOfEvents = 10
+	channel := make(chan int, numberOfEvents) // should never use more than 1 but allow for more to possibly detect bugs
+	fn := func() error {
+		channel <- 0
+		return nil
+	}
+	beforeEvents := time.Now()
+	eventsWg := sync.WaitGroup{}
+	d := newRefreshDebouncer(2*time.Second, fn)
+	defer d.stop()
+	for i := 0; i < numberOfEvents; i++ {
+		eventsWg.Add(1)
+		go func() {
+			defer eventsWg.Done()
+			d.debounce()
+		}()
+	}
+
+	refreshNowWg := sync.WaitGroup{}
+	refreshNowWg.Add(1)
+	go func() {
+		defer refreshNowWg.Done()
+		time.Sleep(1500 * time.Millisecond)
+		d.refreshNow()
+	}()
+
+	eventsWg.Wait()
+	select {
+	case <-channel:
+		t.Fatalf("function was called before the expected time")
+	default:
+	}
+
+	refreshNowWg.Wait()
+
+	timeoutCh := time.After(200 * time.Millisecond) // allow for 200ms of delay to prevent flakiness
+	select {
+	case <-channel:
+	case <-timeoutCh:
+		t.Fatalf("timeout elapsed without flush function being called")
+	}
+	afterFunctionCall := time.Now()
+
+	// use 1 second instead of 1.5s to avoid timer precision issues
+	if afterFunctionCall.Sub(beforeEvents) < 1000*time.Millisecond {
+		t.Fatalf("function was called after %v ms instead of ~1.5 seconds", afterFunctionCall.Sub(beforeEvents).Milliseconds())
+	}
+
+	// wait some time and check if function was called again
+	time.Sleep(2500 * time.Millisecond)
+	if len(channel) > 0 {
+		t.Fatalf("function was called more than once")
+	}
+}
+
+// This test:
+//
+//	1 - Sends debounce requests when test starts
+//	2 - Calls refreshNow() before the timer elapsed (which stops the timer) about 1 second after test starts
+//	3 - Sends more debounce requests (which resets the timer with a 3-second interval) about 2 seconds after test starts
+//
+// The end result should be 2 refresh function calls:
+//
+//	1 - When refreshNow() is called (1 second after the test starts)
+//	2 - When the timer elapses after the second "wave" of debounce requests (5 seconds after the test starts)
+func TestRefreshDebouncer_EventsAfterRefreshNow(t *testing.T) {
+	const numberOfEvents = 10
+	channel := make(chan int, numberOfEvents) // should never use more than 2 but allow for more to possibly detect bugs
+	fn := func() error {
+		channel <- 0
+		return nil
+	}
+	beforeEvents := time.Now()
+	wg := sync.WaitGroup{}
+	d := newRefreshDebouncer(3*time.Second, fn)
+	defer d.stop()
+	for i := 0; i < numberOfEvents; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.debounce()
+			time.Sleep(2000 * time.Millisecond)
+			d.debounce()
+		}()
+	}
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		d.refreshNow()
+	}()
+
+	wg.Wait()
+	timeoutCh := time.After(1500 * time.Millisecond) // extra 500ms to prevent flakiness
+	select {
+	case <-channel:
+	case <-timeoutCh:
+		t.Fatalf("timeout elapsed without flush function being called after refreshNow()")
+	}
+	afterFunctionCall := time.Now()
+
+	// use 500ms instead of 1s to avoid timer precision issues
+	if afterFunctionCall.Sub(beforeEvents) < 500*time.Millisecond {
+		t.Fatalf("function was called after %v ms instead of ~1 second", afterFunctionCall.Sub(beforeEvents).Milliseconds())
+	}
+
+	timeoutCh = time.After(4 * time.Second) // extra 1s to prevent flakiness
+	select {
+	case <-channel:
+	case <-timeoutCh:
+		t.Fatalf("timeout elapsed without flush function being called after debounce requests")
+	}
+	afterSecondFunctionCall := time.Now()
+
+	// use 2.5s instead of 3s to avoid timer precision issues
+	if afterSecondFunctionCall.Sub(afterFunctionCall) < 2500*time.Millisecond {
+		t.Fatalf("function was called after %v ms instead of ~3 seconds", afterSecondFunctionCall.Sub(afterFunctionCall).Milliseconds())
+	}
+
+	if len(channel) > 0 {
+		t.Fatalf("function was called more than twice")
+	}
+}
+
+func TestErrorBroadcaster_MultipleListeners(t *testing.T) {
+	b := newErrorBroadcaster()
+	defer b.stop()
+	const numberOfListeners = 10
+	var listeners []<-chan error
+	for i := 0; i < numberOfListeners; i++ {
+		listeners = append(listeners, b.newListener())
+	}
+
+	err := errors.New("expected error")
+	wg := sync.WaitGroup{}
+	result := atomic.Value{}
+	for _, listener := range listeners {
+		currentListener := listener
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			receivedErr, ok := <-currentListener
+			if !ok {
+				result.Store(errors.New("listener was closed"))
+			} else if receivedErr != err {
+				result.Store(errors.New("expected received error to be the same as the one that was broadcasted"))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		b.broadcast(err)
+		b.stop()
+	}()
+	wg.Wait()
+	if loadedVal := result.Load(); loadedVal != nil {
+		t.Errorf(loadedVal.(error).Error())
+	}
+}
+
+func TestErrorBroadcaster_StopWithoutBroadcast(t *testing.T) {
+	var b = newErrorBroadcaster()
+	defer b.stop()
+	const numberOfListeners = 10
+	var listeners []<-chan error
+	for i := 0; i < numberOfListeners; i++ {
+		listeners = append(listeners, b.newListener())
+	}
+
+	wg := sync.WaitGroup{}
+	result := atomic.Value{}
+	for _, listener := range listeners {
+		currentListener := listener
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// broadcaster stopped, expect listener to be closed
+			_, ok := <-currentListener
+			if ok {
+				result.Store(errors.New("expected listener to be closed"))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// call stop without broadcasting anything to current listeners
+		b.stop()
+	}()
+	wg.Wait()
+	if loadedVal := result.Load(); loadedVal != nil {
+		t.Errorf(loadedVal.(error).Error())
 	}
 }

--- a/internal/ccm/ccm.go
+++ b/internal/ccm/ccm.go
@@ -1,3 +1,4 @@
+//go:build ccm
 // +build ccm
 
 package ccm
@@ -8,11 +9,17 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
 func execCmd(args ...string) (*bytes.Buffer, error) {
-	cmd := exec.Command("ccm", args...)
+	execName := "ccm"
+	if runtime.GOOS == "windows" {
+		args = append([]string{"/c", execName}, args...)
+		execName = "cmd.exe"
+	}
+	cmd := exec.Command(execName, args...)
 	stdout := &bytes.Buffer{}
 	cmd.Stdout = stdout
 	cmd.Stderr = &bytes.Buffer{}
@@ -41,7 +48,11 @@ func AllUp() error {
 }
 
 func NodeUp(node string) error {
-	_, err := execCmd(node, "start", "--wait-for-binary-proto", "--wait-other-notice")
+	args := []string{node, "start", "--wait-for-binary-proto"}
+	if runtime.GOOS == "windows" {
+		args = append(args, "--quiet-windows")
+	}
+	_, err := execCmd(args...)
 	return err
 }
 


### PR DESCRIPTION
Currently, there are some cases where gocql does not refresh the ring during a control connection reconnection. If topology changes are happening on the cluster during the reconnection, some `NEW_NODE` and `REMOVED_NODE` protocol events might be missed. 

To fix this, every successful reconnection on the control connection should trigger a ring refresh operation. This PR adds that.

Also, this PR fixes an issue where `NEW_NODE` events can be overwritten by `UP` events and cause certain nodes to not be added to the ring. This is an issue already described in #1669 but the fix proposed by this PR is a bit different than one outlined on that PR. This PR causes any topology event to trigger a ring refresh regardless of how many nodes were removed or added. This eliminates the need to have duplicated logic around adding and removing nodes in both `ringDescriber` and `Session`.

**Note**: this is not an implementation of #1681.