### PR TITLE
Fix k8s reconnect

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,3 +132,4 @@ Stefan Miklosovic <smiklosovic@apache.org>
 Adam Burk <amburk@gmail.com>
 Valerii Ponomarov <kiparis.kh@gmail.com>
 Neal Turett <neal.turett@datadoghq.com>
+Doug Schaapveld <djschaap@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Learning a new IP address for an existing node (identified by host ID) now triggers replacement of that host.
+  This fixes some Kubernetes reconnection failures. (#1682)
+
 ## [1.3.1] - 2022-12-13
 
 ### Fixed

--- a/events.go
+++ b/events.go
@@ -129,6 +129,14 @@ func (s *Session) handleKeyspaceChange(keyspace, change string) {
 	s.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: keyspace, Change: change})
 }
 
+// handleNodeEvent handles inbound status and topology change events.
+//
+// Within each category (topology vs status), events are debounced by
+// host IP; only the latest event is processed.
+//
+// Processing topology change events before status change events ensures
+// that a NEW_NODE event is not dropped in favor of a newer UP event (which
+// would itself be dropped/ignored, as the node is not yet known).
 func (s *Session) handleNodeEvent(frames []frame) {
 	type nodeEvent struct {
 		change string
@@ -136,32 +144,35 @@ func (s *Session) handleNodeEvent(frames []frame) {
 		port   int
 	}
 
-	events := make(map[string]*nodeEvent)
+	// topology change events
+	tEvents := make(map[string]*nodeEvent)
+	// status change events
+	sEvents := make(map[string]*nodeEvent)
 
 	for _, frame := range frames {
 		// TODO: can we be sure the order of events in the buffer is correct?
 		switch f := frame.(type) {
 		case *topologyChangeEventFrame:
-			event, ok := events[f.host.String()]
+			event, ok := tEvents[f.host.String()]
 			if !ok {
 				event = &nodeEvent{change: f.change, host: f.host, port: f.port}
-				events[f.host.String()] = event
+				tEvents[f.host.String()] = event
 			}
 			event.change = f.change
 
 		case *statusChangeEventFrame:
-			event, ok := events[f.host.String()]
+			event, ok := sEvents[f.host.String()]
 			if !ok {
 				event = &nodeEvent{change: f.change, host: f.host, port: f.port}
-				events[f.host.String()] = event
+				sEvents[f.host.String()] = event
 			}
 			event.change = f.change
 		}
 	}
 
-	for _, f := range events {
+	for _, f := range tEvents {
 		if gocqlDebug {
-			s.logger.Printf("gocql: dispatching event: %+v\n", f)
+			s.logger.Printf("gocql: dispatching topology change event: %+v\n", f)
 		}
 
 		// ignore events we received if they were disabled
@@ -176,8 +187,19 @@ func (s *Session) handleNodeEvent(frames []frame) {
 				s.handleRemovedNode(f.host, f.port)
 			}
 		case "MOVED_NODE":
-		// java-driver handles this, not mentioned in the spec
-		// TODO(zariel): refresh token map
+			// java-driver handles this, not mentioned in the spec
+			// TODO(zariel): refresh token map
+		}
+	}
+
+	for _, f := range sEvents {
+		if gocqlDebug {
+			s.logger.Printf("gocql: dispatching status change event: %+v\n", f)
+		}
+
+		// ignore events we received if they were disabled
+		// see https://github.com/gocql/gocql/issues/1591
+		switch f.change {
 		case "UP":
 			if !s.cfg.Events.DisableNodeStatusEvents {
 				s.handleNodeUp(f.host, f.port)


### PR DESCRIPTION
With existing behavior, when a Cassandra node changes its IP address (while keeping the same host ID), the gocql client never utilizes that new IP address.  In the event ALL nodes change their IP addresses (over the lifetime of the gocql client), the cluster connection will become unusable.  Attempts to query Cassandra will be met with `gocql: no hosts available in the pool` errors.

I am experiencing this behavior connecting to a Cassandra cluster running on Kubernetes.  When a rolling restart occurs (StatefulSet change or otherwise), many of my long-lived gocql clients will become unresponsive.  Restarting the affected processes is required to restore Cassandra connectivity.

With these changes in place, when a `NEW_NODE` message is received for an existing host (host ID) with a new IP address, 1) the existing host (`HostInfo` struct) is removed and 2) the new host (`HostInfo` struct) is added.

Personal testing has shown this fix to work (i.e., the client learns the each new node IP address and maintains connectivity to the Cassandra cluster); more thorough testing would be welcome.

This may address #915 and/or #1582.