### PR TITLE
DialHost must connect to the requested host

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,3 +134,4 @@ Valerii Ponomarov <kiparis.kh@gmail.com>
 Neal Turett <neal.turett@datadoghq.com>
 Doug Schaapveld <djschaap@gmail.com>
 Steven Seidman <steven.seidman@datadoghq.com>
+Lauro Ramos Venancio <lauro.venancio@incognia.com>

--- a/dial.go
+++ b/dial.go
@@ -45,11 +45,12 @@ func (hd *defaultHostDialer) DialHost(ctx context.Context, host *HostInfo) (*Dia
 		return nil, fmt.Errorf("host missing port: %v", port)
 	}
 
-	addr := host.HostnameAndPort()
-	conn, err := hd.dialer.DialContext(ctx, "tcp", addr)
+	connAddr := host.ConnectAddressAndPort()
+	conn, err := hd.dialer.DialContext(ctx, "tcp", connAddr)
 	if err != nil {
 		return nil, err
 	}
+	addr := host.HostnameAndPort()
 	return WrapTLS(ctx, conn, addr, hd.tlsConfig)
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -401,6 +401,13 @@ func (h *HostInfo) HostnameAndPort() string {
 	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
 }
 
+func (h *HostInfo) ConnectAddressAndPort() string {
+        h.mu.Lock()
+        defer h.mu.Unlock()
+        addr, _ := h.connectAddressLocked()
+        return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
+}
+
 func (h *HostInfo) String() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()


### PR DESCRIPTION
When a hostname resolves to multiple hosts, multiple HostInfos are generated. DialHost must connect to the host received as parameter. If the hostname is used to establish the connection, the dns could resolve to another host.
The hostname should still be used to verify the TLS connection.