### PR TITLE
query_executor: Fixed race between Query.Release() and speculative executions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,3 +134,4 @@ Valerii Ponomarov <kiparis.kh@gmail.com>
 Neal Turett <neal.turett@datadoghq.com>
 Doug Schaapveld <djschaap@gmail.com>
 Steven Seidman <steven.seidman@datadoghq.com>
+Wojciech Przytuła <wojciech.przytula@scylladb.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Deadlock in Session.Close(). (#1688)
+- Race between Query.Release() and speculative executions (#1684)
 
 ## [1.3.2] - 2023-03-27
 
@@ -33,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Panic in RackAwareRoundRobinPolicy caused by wrong alignment on 32-bit platforms. (#1666) 
+- Panic in RackAwareRoundRobinPolicy caused by wrong alignment on 32-bit platforms. (#1666)
 
 ## [1.3.0] - 2022-11-29
 
@@ -100,7 +101,7 @@ This release improves support for connecting through proxies and some improvemen
 - Fixed panic when trying to unmarshal unknown/custom CQL type.
 
 ## Deprecated
-- TypeInfo.New, please use TypeInfo.NewWithError instead. 
+- TypeInfo.New, please use TypeInfo.NewWithError instead.
 
 ## [1.0.0] - 2022-03-04
 ### Changed

--- a/query_executor.go
+++ b/query_executor.go
@@ -7,6 +7,8 @@ import (
 )
 
 type ExecutableQuery interface {
+	borrowForExecution()    // Used to ensure that the query stays alive for lifetime of a particular execution goroutine.
+	releaseAfterExecution() // Used when a goroutine finishes its execution attempts, either with ok result or an error.
 	execute(ctx context.Context, conn *Conn) *Iter
 	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
@@ -43,6 +45,7 @@ func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp S
 	for i := 0; i < sp.Attempts(); i++ {
 		select {
 		case <-ticker.C:
+			qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
 			go q.run(ctx, qry, hostIter, results)
 		case <-ctx.Done():
 			return &Iter{err: ctx.Err()}
@@ -80,6 +83,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	results := make(chan *Iter, 1)
 
 	// Launch the main execution
+	qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
 	go q.run(ctx, qry, hostIter, results)
 
 	// The speculative executions are launched _in addition_ to the main
@@ -171,4 +175,5 @@ func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, hostIter N
 	case results <- q.do(ctx, qry, hostIter):
 	case <-ctx.Done():
 	}
+	qry.releaseAfterExecution()
 }


### PR DESCRIPTION
As described in #1315, there is a race condition when there is more than one concurrent execution (by means of speculative execution) and `Query.Release()` is called after one of them completes. `Query.Release()` calls `Query.reset()`, which in turns zeroes the whole `Query`. Then, after another execution completes, it tries to access metrics, but they are already set to nil by the call to `Release()`, so a segfault is triggered.

The solution is quite simple: a ref counter is introduced into the `Query`. It is obviously initially set to 1. Every execution fiber (i.e. every execution goroutine) has the refcount atomically incremented before it is started, and decrements the refcount on completion. `Query.Release()` merely decrements the refcount. `Query.reset()` is called by whichever goroutine that decrements the refcount to 0.

Fixes: #1315