### PR TITLE
Synchronize access to pools in TestControlConn_ReconnectRefreshesRing

### DIFF
--- a/control_ccm_test.go
+++ b/control_ccm_test.go
@@ -117,9 +117,11 @@ func TestControlConn_ReconnectRefreshesRing(t *testing.T) {
 			}
 		}
 
-		pools := session.pool.hostConnPools
-		if len(pools) != 0 {
-			return fmt.Errorf("expected 0 connection pool but there were %v", len(pools))
+		session.pool.mu.RLock()
+		poolsLen := len(session.pool.hostConnPools)
+		session.pool.mu.RUnlock()
+		if poolsLen != 0 {
+			return fmt.Errorf("expected 0 connection pool but there were %v", poolsLen)
 		}
 		return nil
 	}
@@ -152,9 +154,11 @@ func TestControlConn_ReconnectRefreshesRing(t *testing.T) {
 				return fmt.Errorf("expected all hosts to be UP but %v isn't", host.String())
 			}
 		}
-		pools := session.pool.hostConnPools
-		if len(pools) != len(allCcmHosts) {
-			return fmt.Errorf("expected %v connection pool but there were %v", len(allCcmHosts), len(pools))
+		session.pool.mu.RLock()
+		poolsLen := len(session.pool.hostConnPools)
+		session.pool.mu.RUnlock()
+		if poolsLen != len(allCcmHosts) {
+			return fmt.Errorf("expected %v connection pool but there were %v", len(allCcmHosts), poolsLen)
 		}
 		return nil
 	}


### PR DESCRIPTION
This should fix the following data race:

```
Read at 0x00c000202090 by goroutine 15:
  github.com/gocql/gocql.TestControlConn_ReconnectRefreshesRing.func3()
      /home/runner/work/gocql/gocql/control_ccm_test.go:121 +0x249
  github.com/gocql/gocql.TestControlConn_ReconnectRefreshesRing()
      /home/runner/work/gocql/gocql/control_ccm_test.go:129 +0x942
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x47

Previous write at 0x00c000202090 by goroutine 83:
  runtime.mapdelete_faststr()
      /opt/hostedtoolcache/go/1.20.3/x64/src/runtime/map_faststr.go:301 +0x0
  github.com/gocql/gocql.(*policyConnPool).removeHost()
      /home/runner/work/gocql/gocql/connectionpool.go:265 +0xd5
  github.com/gocql/gocql.(*Session).handleNodeDown()
      /home/runner/work/gocql/gocql/events.go:244 +0x2b8
  github.com/gocql/gocql.(*hostConnPool).fillingStopped()
      /home/runner/work/gocql/gocql/connectionpool.go:504 +0x4a8
  github.com/gocql/gocql.(*hostConnPool).fill.func1()
      /home/runner/work/gocql/gocql/connectionpool.go:456 +0x64

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:157 +0x2e9

Goroutine 83 (finished) created at:
  github.com/gocql/gocql.(*hostConnPool).fill()
      /home/runner/work/gocql/gocql/connectionpool.go:452 +0x411
  github.com/gocql/gocql.(*hostConnPool).HandleError.func2()
      /home/runner/work/gocql/gocql/connectionpool.go:618 +0x39
```