### PR TITLE
Support larger dates in TypeDate marshalling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -137,3 +137,4 @@ Steven Seidman <steven.seidman@datadoghq.com>
 Wojciech Przytuła <wojciech.przytula@scylladb.com>
 João Reis <joao.reis@datastax.com>
 Lauro Ramos Venancio <lauro.venancio@incognia.com>
+Oliver Boyle <pleasedontspamme4321+gocql@gmail.com>

--- a/marshal.go
+++ b/marshal.go
@@ -1326,7 +1326,7 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 	return unmarshalErrorf("can not unmarshal %s into %T", info, value)
 }
 
-const milliSecondsInADay int64 = 24 * 60 * 60 * 1000
+const millisecondsInADay int64 = 24 * 60 * 60 * 1000
 
 func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 	var timestamp int64
@@ -1337,21 +1337,21 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	case int64:
 		timestamp = v
-		x := timestamp/milliSecondsInADay + int64(1<<31)
+		x := timestamp/millisecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/milliSecondsInADay + int64(1<<31)
+		x := timestamp/millisecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case *time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/milliSecondsInADay + int64(1<<31)
+		x := timestamp/millisecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case string:
 		if v == "" {
@@ -1362,7 +1362,7 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("can not marshal %T into %s, date layout must be '2006-01-02'", value, info)
 		}
 		timestamp = int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
-		x := timestamp/milliSecondsInADay + int64(1<<31)
+		x := timestamp/millisecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	}
 
@@ -1383,7 +1383,7 @@ func unmarshalDate(info TypeInfo, data []byte, value interface{}) error {
 		}
 		var origin uint32 = 1 << 31
 		var current uint32 = binary.BigEndian.Uint32(data)
-		timestamp := (int64(current) - int64(origin)) * milliSecondsInADay
+		timestamp := (int64(current) - int64(origin)) * millisecondsInADay
 		*v = time.UnixMilli(timestamp).In(time.UTC)
 		return nil
 	case *string:
@@ -1393,7 +1393,7 @@ func unmarshalDate(info TypeInfo, data []byte, value interface{}) error {
 		}
 		var origin uint32 = 1 << 31
 		var current uint32 = binary.BigEndian.Uint32(data)
-		timestamp := (int64(current) - int64(origin)) * milliSecondsInADay
+		timestamp := (int64(current) - int64(origin)) * millisecondsInADay
 		*v = time.UnixMilli(timestamp).In(time.UTC).Format("2006-01-02")
 		return nil
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -1326,6 +1326,8 @@ func unmarshalTimestamp(info TypeInfo, data []byte, value interface{}) error {
 	return unmarshalErrorf("can not unmarshal %s into %T", info, value)
 }
 
+const milliSecondsInADay int64 = 24 * 60 * 60 * 1000
+
 func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 	var timestamp int64
 	switch v := value.(type) {
@@ -1335,21 +1337,21 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 		return nil, nil
 	case int64:
 		timestamp = v
-		x := timestamp/86400000 + int64(1<<31)
+		x := timestamp/milliSecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1<<31)
+		x := timestamp/milliSecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case *time.Time:
 		if v.IsZero() {
 			return []byte{}, nil
 		}
 		timestamp = int64(v.UTC().Unix()*1e3) + int64(v.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1<<31)
+		x := timestamp/milliSecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	case string:
 		if v == "" {
@@ -1360,7 +1362,7 @@ func marshalDate(info TypeInfo, value interface{}) ([]byte, error) {
 			return nil, marshalErrorf("can not marshal %T into %s, date layout must be '2006-01-02'", value, info)
 		}
 		timestamp = int64(t.UTC().Unix()*1e3) + int64(t.UTC().Nanosecond()/1e6)
-		x := timestamp/86400000 + int64(1<<31)
+		x := timestamp/milliSecondsInADay + int64(1<<31)
 		return encInt(int32(x)), nil
 	}
 
@@ -1381,8 +1383,8 @@ func unmarshalDate(info TypeInfo, data []byte, value interface{}) error {
 		}
 		var origin uint32 = 1 << 31
 		var current uint32 = binary.BigEndian.Uint32(data)
-		timestamp := (int64(current) - int64(origin)) * 86400000
-		*v = time.Unix(0, timestamp*int64(time.Millisecond)).In(time.UTC)
+		timestamp := (int64(current) - int64(origin)) * milliSecondsInADay
+		*v = time.UnixMilli(timestamp).In(time.UTC)
 		return nil
 	case *string:
 		if len(data) == 0 {
@@ -1391,8 +1393,8 @@ func unmarshalDate(info TypeInfo, data []byte, value interface{}) error {
 		}
 		var origin uint32 = 1 << 31
 		var current uint32 = binary.BigEndian.Uint32(data)
-		timestamp := (int64(current) - int64(origin)) * 86400000
-		*v = time.Unix(0, timestamp*int64(time.Millisecond)).In(time.UTC).Format("2006-01-02")
+		timestamp := (int64(current) - int64(origin)) * milliSecondsInADay
+		*v = time.UnixMilli(timestamp).In(time.UTC).Format("2006-01-02")
 		return nil
 	}
 	return unmarshalErrorf("can not unmarshal %s into %T", info, value)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2185,6 +2185,7 @@ func TestMarshalDate(t *testing.T) {
 	now := time.Now().UTC()
 	timestamp := now.UnixNano() / int64(time.Millisecond)
 	expectedData := encInt(int32(timestamp/86400000 + int64(1<<31)))
+
 	var marshalDateTests = []struct {
 		Info  TypeInfo
 		Data  []byte
@@ -2223,6 +2224,35 @@ func TestMarshalDate(t *testing.T) {
 			t.Errorf("marshalTest[%d]: expected %x (%v), got %x (%v) for time %s", i,
 				test.Data, decInt(test.Data), data, decInt(data), test.Value)
 		}
+	}
+}
+
+func TestLargeDate(t *testing.T) {
+	largeDate := time.Date(999999, time.December, 31, 0, 0, 0, 0, time.UTC)
+	largeTimeStamp := largeDate.UnixMilli()
+	largeExpectedData := encInt(int32(largeTimeStamp/86400000 + int64(1<<31)))
+
+	nativeType := NativeType{proto: 4, typ: TypeDate}
+
+	t.Log(largeDate)
+	data, err := Marshal(nativeType, largeDate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, largeExpectedData) {
+		t.Fatalf("marshalTest: expected %x (%v), got %x (%v) for time %s",
+			largeExpectedData, decInt(largeExpectedData), data, decInt(data), largeDate)
+	}
+
+	var date time.Time
+	if err := Unmarshal(nativeType, data, &date); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedDate := "999999-12-31"
+	formattedDate := date.Format("2006-01-02")
+	if expectedDate != formattedDate {
+		t.Fatalf("marshalTest: expected %v, got %v", expectedDate, formattedDate)
 	}
 }
 


### PR DESCRIPTION
We are using nanosecond precision when reading a `TypeDate` into a `time.Time` value, this limits the dates we can accurately read and write from cassandra to `[1677-09-22, 2262-04-11]` since outside of this range we end up with integer overflow. Dates outside of this range encode correctly and are persisted in Cassandra, but are then read as an incorrect value.

The new supported date range is `[-5877641-06-23, 5881580-07-11]` given that we are decoding the epoch day as a 32 bit int (`-2147483648` = minimum int = `-5877641-06-23`). I think it's possible to expand the range if ever needed by decoding a 64 bit int and using `time.Unix(seconds, 0)`, but I didn't think it was worth looking into that change.

Please let me know if I missed anything from the testing.