### PR TITLE
conn: Advertise driver's name & version in STARTUP

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -422,7 +422,9 @@ func (s *startupCoordinator) options(ctx context.Context) error {
 
 func (s *startupCoordinator) startup(ctx context.Context, supported map[string][]string) error {
 	m := map[string]string{
-		"CQL_VERSION": s.conn.cfg.CQLVersion,
+		"CQL_VERSION":    s.conn.cfg.CQLVersion,
+		"DRIVER_NAME":    driverName,
+		"DRIVER_VERSION": driverVersion,
 	}
 
 	if s.conn.compressor != nil {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,28 @@
+package gocql
+
+import "runtime/debug"
+
+const (
+	mainModule = "github.com/gocql/gocql"
+)
+
+var driverName string
+
+var driverVersion string
+
+func init() {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, d := range buildInfo.Deps {
+			if d.Path == mainModule {
+				driverName = mainModule
+				driverVersion = d.Version
+				if d.Replace != nil {
+					driverName = d.Replace.Path
+					driverVersion = d.Replace.Version
+				}
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Advertising driver's name in the system.clients table can be helpful when debugging issues, e.g. when a connection imbalance occurs and allows to narrow down the culprit application/driver better.

The main module name is stored in a const in version.go.
The replaced module name and the version are fetched from the binary runtime information, where it comes from GitHub metadata (release tag).
Credits to @zimnx for this idea!

I've tested this manually using my fork. The version has shown correctly in system.clients.