### PR TITLE
Add instaclustr password authenticator to default approved list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,3 +139,4 @@ João Reis <joao.reis@datastax.com>
 Lauro Ramos Venancio <lauro.venancio@incognia.com>
 Dmitry Kropachev <dmitry.kropachev@gmail.com>
 Oliver Boyle <pleasedontspamme4321+gocql@gmail.com>
+Jackson Fleming <jackson.fleming@instaclustr.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Added the InstaclustrPasswordAuthenticator to the list of default approved authenticators.
 ### Changed
 
 ### Fixed

--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,7 @@ var (
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator",
 		"com.amazon.helenus.auth.HelenusAuthenticator",
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator",
+		"com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator",
 	}
 )
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -39,6 +39,7 @@ func TestApprove(t *testing.T) {
 		approve("com.datastax.bdp.cassandra.auth.DseAuthenticator", []string{}):                                         true,
 		approve("io.aiven.cassandra.auth.AivenAuthenticator", []string{}):                                               true,
 		approve("com.amazon.helenus.auth.HelenusAuthenticator", []string{}):                                             true,
+		approve("com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator", []string{}):                               true,
 		approve("com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator", []string{}):                          true,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", []string{}):                                              false,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", nil):                                                     false,

--- a/conn_test.go
+++ b/conn_test.go
@@ -39,6 +39,7 @@ func TestApprove(t *testing.T) {
 		approve("com.datastax.bdp.cassandra.auth.DseAuthenticator", []string{}):                                         true,
 		approve("io.aiven.cassandra.auth.AivenAuthenticator", []string{}):                                               true,
 		approve("com.amazon.helenus.auth.HelenusAuthenticator", []string{}):                                             true,
+		approve("com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator", []string{}):                          true,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", []string{}):                                              false,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", nil):                                                     false,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", []string{"com.apache.cassandra.auth.FakeAuthenticator"}): true,


### PR DESCRIPTION
Hi,

Just adding opening a small PR to add the InstaclustrPasswordAuthenticator to the default approved list of authenticators in the gocql project.

This would be beneficial for us, as customers of ours using your driver have to do some additional configuration steps in-order to use an Instaclustr managed Apache Cassandra 4 cluster.

If you have any questions or concerns please let me know.