### PR TITLE
Add Scylla authenticators to approved list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added the InstaclustrPasswordAuthenticator to the list of default approved authenticators.
+- Added the `com.scylladb.auth.SaslauthdAuthenticator` and `com.scylladb.auth.TransitionalAuthenticator`
+  to the list of default approved authenticators.
 ### Changed
 
 ### Fixed

--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,8 @@ var (
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator",
 		"com.amazon.helenus.auth.HelenusAuthenticator",
 		"com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator",
+		"com.scylladb.auth.SaslauthdAuthenticator",
+		"com.scylladb.auth.TransitionalAuthenticator",
 		"com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator",
 	}
 )

--- a/conn_test.go
+++ b/conn_test.go
@@ -40,6 +40,8 @@ func TestApprove(t *testing.T) {
 		approve("io.aiven.cassandra.auth.AivenAuthenticator", []string{}):                                               true,
 		approve("com.amazon.helenus.auth.HelenusAuthenticator", []string{}):                                             true,
 		approve("com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthenticator", []string{}):                               true,
+		approve("com.scylladb.auth.SaslauthdAuthenticator", []string{}):                                                 true,
+		approve("com.scylladb.auth.TransitionalAuthenticator", []string{}):                                              true,
 		approve("com.instaclustr.cassandra.auth.InstaclustrPasswordAuthenticator", []string{}):                          true,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", []string{}):                                              false,
 		approve("com.apache.cassandra.auth.FakeAuthenticator", nil):                                                     false,


### PR DESCRIPTION
These are already allowed in github.com/scylladb/gocql.

Closes https://github.com/gocql/gocql/issues/1703