### PR TITLE
Add information about shard/thread to the tracing

### DIFF
--- a/session.go
+++ b/session.go
@@ -2088,6 +2088,7 @@ func (t *traceWriter) Trace(traceId []byte) {
 		activity  string
 		source    string
 		elapsed   int
+		thread    string
 	)
 
 	t.mu.Lock()
@@ -2096,13 +2097,13 @@ func (t *traceWriter) Trace(traceId []byte) {
 	fmt.Fprintf(t.w, "Tracing session %016x (coordinator: %s, duration: %v):\n",
 		traceId, coordinator, time.Duration(duration)*time.Microsecond)
 
-	iter = t.session.control.query(`SELECT event_id, activity, source, source_elapsed
+	iter = t.session.control.query(`SELECT event_id, activity, source, source_elapsed, thread
 			FROM system_traces.events
 			WHERE session_id = ?`, traceId)
 
-	for iter.Scan(&timestamp, &activity, &source, &elapsed) {
-		fmt.Fprintf(t.w, "%s: %s (source: %s, elapsed: %d)\n",
-			timestamp.Format("2006/01/02 15:04:05.999999"), activity, source, elapsed)
+	for iter.Scan(&timestamp, &activity, &source, &elapsed, &thread) {
+		fmt.Fprintf(t.w, "%s: %s [%s] (source: %s, elapsed: %d)\n",
+			timestamp.Format("2006/01/02 15:04:05.999999"), activity, thread, source, elapsed)
 	}
 
 	if err := iter.Close(); err != nil {


### PR DESCRIPTION
Previously there was no information about shards/threads in tracing. It could be problematic, if we want to test shard/thread related features. 

This PR introduces adding information about shard/thread to the tracing. This information could be needed for testing shard awareness. Also it is more in line with `cqlsh` tracing.

In Cassandra single tracing event looks like that:
```
session_id                           | event_id                             | activity                                    | source    | source_elapsed | source_port | thread
-------------------------------------+--------------------------------------+---------------------------------------------+-----------+----------------+-------------+-----------------------------
568f2370-26ed-11ee-8120-57607de2775b | 5690aa10-26ed-11ee-8120-57607de2775b |        Parsing SELECT * FROM system.local ; | 127.0.0.1 |           7107 |        null | Native-Transport-Requests-1
```
where thead could be for example: `Native-Transport-Requests-1`, `ReadStage-2`.

Accordingly, in Scylla single tracing event looks like that:
```
session_id                           | event_id                             | activity                                  | scylla_parent_id | scylla_span_id  | source    | source_elapsed | thread
-------------------------------------+--------------------------------------+-------------------------------------------+------------------+-----------------+-----------+----------------+----------
7b9f82c0-2604-11ee-ad99-17a0af160bf8 | 7b9f9b56-2604-11ee-ad99-17a0af160bf8 |                       Parsing a statement |                0 | 147842476120455 | 127.0.0.2 |              1 |  shard 4
```
with thread in the form: `shard x`, where x is a number.