### PR TITLE
Use strings.Builder instead of bytes.Buffer to build strings

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2538,12 +2538,15 @@ type TupleTypeInfo struct {
 }
 
 func (t TupleTypeInfo) String() string {
-	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%s(", t.typ))
-	for _, elem := range t.Elems {
-		buf.WriteString(fmt.Sprintf("%s, ", elem))
+	var buf strings.Builder
+	buf.WriteString(t.typ.String())
+	buf.WriteString("(")
+	for i, elem := range t.Elems {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(fmt.Sprintf("%s", elem))
 	}
-	buf.Truncate(buf.Len() - 2)
 	buf.WriteByte(')')
 	return buf.String()
 }
@@ -2593,20 +2596,17 @@ func (u UDTTypeInfo) New() interface{} {
 }
 
 func (u UDTTypeInfo) String() string {
-	buf := &bytes.Buffer{}
+	var buf strings.Builder
 
-	fmt.Fprintf(buf, "%s.%s{", u.KeySpace, u.Name)
-	first := true
-	for _, e := range u.Elements {
-		if !first {
-			fmt.Fprint(buf, ",")
-		} else {
-			first = false
+	buf.WriteString(fmt.Sprintf("%s.%s{", u.KeySpace, u.Name))
+	for i, e := range u.Elements {
+		if i > 0 {
+			buf.WriteString(",")
 		}
 
-		fmt.Fprintf(buf, "%s=%v", e.Name, e.Type)
+		buf.WriteString(fmt.Sprintf("%s=%v", e.Name, e.Type))
 	}
-	fmt.Fprint(buf, "}")
+	buf.WriteString("}")
 
 	return buf.String()
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2519,3 +2519,98 @@ func bytesWithLength(data ...[]byte) []byte {
 	}
 	return ret
 }
+
+func TestTupleTypeInfo_String(t *testing.T) {
+	tests := map[string]struct {
+		input    TupleTypeInfo
+		expected string
+	}{
+		"empty elems": {
+			input: TupleTypeInfo{
+				NativeType: NewNativeType(4, TypeTuple, ""),
+				Elems:      nil,
+			},
+			expected: "tuple()",
+		},
+		"one elem": {
+			input: TupleTypeInfo{
+				NativeType: NewNativeType(4, TypeTuple, ""),
+				Elems: []TypeInfo{
+					NewNativeType(4, TypeVarchar, ""),
+				},
+			},
+			expected: "tuple(varchar)",
+		},
+		"two elems": {
+			input: TupleTypeInfo{
+				NativeType: NewNativeType(4, TypeTuple, ""),
+				Elems: []TypeInfo{
+					NewNativeType(4, TypeVarchar, ""),
+					NewNativeType(4, TypeSmallInt, ""),
+				},
+			},
+			expected: "tuple(varchar, smallint)",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.input.String()
+			assertEqual(t, "string value", test.expected, got)
+		})
+	}
+}
+
+func TestUDTTypeInfo_String(t *testing.T) {
+	tests := map[string]struct {
+		input    UDTTypeInfo
+		expected string
+	}{
+		"empty elems": {
+			input: UDTTypeInfo{
+				NativeType: NewNativeType(4, TypeUDT, ""),
+				Name:       "myudt",
+				KeySpace:   "mykeyspace",
+				Elements:   nil,
+			},
+			expected: "mykeyspace.myudt{}",
+		},
+		"one elem": {
+			input: UDTTypeInfo{
+				NativeType: NewNativeType(4, TypeUDT, ""),
+				Name:       "myudt",
+				KeySpace:   "mykeyspace",
+				Elements: []UDTField{
+					{
+						Name: "first",
+						Type: NewNativeType(4, TypeVarchar, ""),
+					},
+				},
+			},
+			expected: "mykeyspace.myudt{first=varchar}",
+		},
+		"two elems": {
+			input: UDTTypeInfo{
+				NativeType: NewNativeType(4, TypeUDT, ""),
+				Name:       "myudt",
+				KeySpace:   "mykeyspace",
+				Elements: []UDTField{
+					{
+						Name: "first",
+						Type: NewNativeType(4, TypeVarchar, ""),
+					},
+					{
+						Name: "second",
+						Type: NewNativeType(4, TypeSmallInt, ""),
+					},
+				},
+			},
+			expected: "mykeyspace.myudt{first=varchar,second=smallint}",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.input.String()
+			assertEqual(t, "string value", test.expected, got)
+		})
+	}
+}

--- a/token.go
+++ b/token.go
@@ -5,7 +5,6 @@
 package gocql
 
 import (
-	"bytes"
 	"crypto/md5"
 	"fmt"
 	"math/big"
@@ -181,7 +180,7 @@ func (t *tokenRing) Swap(i, j int) {
 }
 
 func (t *tokenRing) String() string {
-	buf := &bytes.Buffer{}
+	var buf strings.Builder
 	buf.WriteString("TokenRing(")
 	if t.partitioner != nil {
 		buf.WriteString(t.partitioner.Name())
@@ -199,7 +198,7 @@ func (t *tokenRing) String() string {
 		buf.WriteString(th.host.ConnectAddress().String())
 	}
 	buf.WriteString("\n}")
-	return string(buf.Bytes())
+	return buf.String()
 }
 
 func (t *tokenRing) GetHostForToken(token token) (host *HostInfo, endToken token) {


### PR DESCRIPTION
This removes a few allocations.
Also fixes an edge case in TupleTypeInfo.String when there are no elements.