### PR TITLE
Ensure peer is up when waiting schema agreement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1694,6 +1694,12 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 				continue
 			}
 
+			peerInfo := c.session.ring.getHost(host.HostID())
+			if peerInfo == nil || !peerInfo.IsUp() {
+				c.logger.Printf("invalid or unreachable peer: peer=%q", host)
+				continue
+			}
+
 			versions[host.schemaVersion] = struct{}{}
 		}
 


### PR DESCRIPTION
Drivers written in other languages like Python or Java check if the peer is up when waiting for schema agreement to avoid complaining about schema versions coming from unreachable nodes.

This fixes #1736.