### PR TITLE
Add more logging, a Structured Logger interface and log levels

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -237,6 +237,14 @@ type ClusterConfig struct {
 	// If not specified, defaults to the global gocql.Logger.
 	Logger StdLogger
 
+	// StructuredLogger for this ClusterConfig.
+	// If not specified, Logger will be used instead.
+	StructuredLogger AdvancedLogger
+
+	// MinimumLogLevel for this ClusterConfig.
+	// If not specified, LogLevelWarn will be used as the default.
+	MinimumLogLevel LogLevel
+
 	// internal config for testing
 	disableControlConn bool
 }
@@ -272,15 +280,19 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
+		MinimumLogLevel:        LogLevelWarn,
 	}
 	return cfg
 }
 
-func (cfg *ClusterConfig) logger() StdLogger {
-	if cfg.Logger == nil {
-		return Logger
+func (cfg *ClusterConfig) newLogger() loggerAdapter {
+	if cfg.StructuredLogger != nil {
+		return newInternalLoggerFromAdvancedLogger(cfg.StructuredLogger, cfg.MinimumLogLevel)
 	}
-	return cfg.Logger
+	if cfg.Logger == nil {
+		return newInternalLoggerFromStdLogger(Logger, cfg.MinimumLogLevel)
+	}
+	return newInternalLoggerFromStdLogger(cfg.Logger, cfg.MinimumLogLevel)
 }
 
 // CreateSession initializes the cluster based on this config and returns a
@@ -293,14 +305,14 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 // if defined, to translate the given address and port into a possibly new address
 // and port, If no AddressTranslator or if an error occurs, the given address and
 // port will be returned.
-func (cfg *ClusterConfig) translateAddressPort(addr net.IP, port int) (net.IP, int) {
+func (cfg *ClusterConfig) translateAddressPort(addr net.IP, port int, logger internalLogger) (net.IP, int) {
 	if cfg.AddressTranslator == nil || len(addr) == 0 {
 		return addr, port
 	}
 	newAddr, newPort := cfg.AddressTranslator.Translate(addr, port)
-	if gocqlDebug {
-		cfg.logger().Printf("gocql: translating address '%v:%d' to '%v:%d'", addr, port, newAddr, newPort)
-	}
+	logger.Debug("gocql: translating address '%v:%d' to '%v:%d'",
+		NewLogField("old_addr", addr), NewLogField("old_port", port),
+		NewLogField("new_addr", newAddr), NewLogField("new_port", newPort))
 	return newAddr, newPort
 }
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -36,7 +36,7 @@ func TestNewCluster_WithHosts(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	cfg := NewCluster()
 	assertNil(t, "cluster config address translator", cfg.AddressTranslator)
-	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234, nilInternalLogger)
 	assertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
 	assertEqual(t, "translated host and port", 1234, newPort)
 }
@@ -44,7 +44,7 @@ func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0)
+	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0, nilInternalLogger)
 	assertTrue(t, "translated address is still empty", len(newAddr) == 0)
 	assertEqual(t, "translated port", 0, newPort)
 }
@@ -52,7 +52,7 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
+	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345, nilInternalLogger)
 	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
 	assertEqual(t, "translated port", 5432, newPort)
 }

--- a/conn.go
+++ b/conn.go
@@ -120,28 +120,23 @@ type SslOptions struct {
 }
 
 type ConnConfig struct {
-	ProtoVersion   int
-	CQLVersion     string
-	Timeout        time.Duration
-	WriteTimeout   time.Duration
-	ConnectTimeout time.Duration
-	Dialer         Dialer
-	HostDialer     HostDialer
-	Compressor     Compressor
-	Authenticator  Authenticator
-	AuthProvider   func(h *HostInfo) (Authenticator, error)
-	Keepalive      time.Duration
-	Logger         StdLogger
+	ProtoVersion     int
+	CQLVersion       string
+	Timeout          time.Duration
+	WriteTimeout     time.Duration
+	ConnectTimeout   time.Duration
+	Dialer           Dialer
+	HostDialer       HostDialer
+	Compressor       Compressor
+	Authenticator    Authenticator
+	AuthProvider     func(h *HostInfo) (Authenticator, error)
+	Keepalive        time.Duration
+	Logger           StdLogger
+	StructuredLogger AdvancedLogger
+	MinimumLogLevel  LogLevel
 
 	tlsConfig       *tls.Config
 	disableCoalesce bool
-}
-
-func (c *ConnConfig) logger() StdLogger {
-	if c.Logger == nil {
-		return Logger
-	}
-	return c.Logger
 }
 
 type ConnErrorHandler interface {
@@ -205,7 +200,7 @@ type Conn struct {
 
 	timeouts int64
 
-	logger StdLogger
+	logger internalLogger
 }
 
 // connect establishes a connection to a Cassandra node using session's connection config.
@@ -269,7 +264,7 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		},
 		ctx:            ctx,
 		cancel:         cancel,
-		logger:         cfg.logger(),
+		logger:         s.logger,
 		streamObserver: s.streamObserver,
 		writeTimeout:   writeTimeout,
 	}
@@ -706,7 +701,7 @@ func (c *Conn) recv(ctx context.Context) error {
 	delete(c.calls, head.stream)
 	c.mu.Unlock()
 	if call == nil || !ok {
-		c.logger.Printf("gocql: received response for stream which has no handler: header=%v\n", head)
+		c.logger.Warning("gocql: received response for stream which has no handler: header=%v\n", NewLogField("header", head))
 		return c.discardFrame(head)
 	} else if head.stream != call.streamID {
 		panic(fmt.Sprintf("call has incorrect streamID: got %d expected %d", call.streamID, head.stream))
@@ -1450,7 +1445,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		iter := &Iter{framer: framer}
 		if err := c.awaitSchemaAgreement(ctx); err != nil {
 			// TODO: should have this behind a flag
-			c.logger.Println(err)
+			c.logger.Warning("gocql: error while awaiting for schema agreement after a schema change event: %v", NewLogField("err", err.Error()))
 		}
 		// dont return an error from this, might be a good idea to give a warning
 		// though. The impact of this returning an error would be that the cluster
@@ -1690,7 +1685,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 				goto cont
 			}
 			if !isValidPeer(host) || host.schemaVersion == "" {
-				c.logger.Printf("invalid peer or peer with empty schema_version: peer=%q", host)
+				c.logger.Warning("gocql: invalid peer or peer with empty schema_version: peer=%s", NewLogField("peer", host.ConnectAddress()))
 				continue
 			}
 

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -123,18 +123,20 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 	}
 
 	return &ConnConfig{
-		ProtoVersion:   cfg.ProtoVersion,
-		CQLVersion:     cfg.CQLVersion,
-		Timeout:        cfg.Timeout,
-		WriteTimeout:   cfg.WriteTimeout,
-		ConnectTimeout: cfg.ConnectTimeout,
-		Dialer:         cfg.Dialer,
-		HostDialer:     hostDialer,
-		Compressor:     cfg.Compressor,
-		Authenticator:  cfg.Authenticator,
-		AuthProvider:   cfg.AuthProvider,
-		Keepalive:      cfg.SocketKeepalive,
-		Logger:         cfg.logger(),
+		ProtoVersion:     cfg.ProtoVersion,
+		CQLVersion:       cfg.CQLVersion,
+		Timeout:          cfg.Timeout,
+		WriteTimeout:     cfg.WriteTimeout,
+		ConnectTimeout:   cfg.ConnectTimeout,
+		Dialer:           cfg.Dialer,
+		HostDialer:       hostDialer,
+		Compressor:       cfg.Compressor,
+		Authenticator:    cfg.Authenticator,
+		AuthProvider:     cfg.AuthProvider,
+		Keepalive:        cfg.SocketKeepalive,
+		Logger:           cfg.Logger,
+		StructuredLogger: cfg.StructuredLogger,
+		MinimumLogLevel:  cfg.MinimumLogLevel,
 	}, nil
 }
 
@@ -283,7 +285,7 @@ type hostConnPool struct {
 	filling bool
 
 	pos    uint32
-	logger StdLogger
+	logger internalLogger
 }
 
 func (h *hostConnPool) String() string {
@@ -466,21 +468,20 @@ func (pool *hostConnPool) logConnectErr(err error) {
 	if opErr, ok := err.(*net.OpError); ok && (opErr.Op == "dial" || opErr.Op == "read") {
 		// connection refused
 		// these are typical during a node outage so avoid log spam.
-		if gocqlDebug {
-			pool.logger.Printf("gocql: unable to dial %q: %v\n", pool.host, err)
-		}
+		pool.logger.Debug("gocql: unable to dial %s (%s): %v\n",
+			NewLogField("host_addr", pool.host.ConnectAddress()), NewLogField("host_id", pool.host.HostID()), NewLogField("err", err.Error()))
 	} else if err != nil {
 		// unexpected error
-		pool.logger.Printf("error: failed to connect to %q due to error: %v", pool.host, err)
+		pool.logger.Debug("gocql: failed to connect to %s (%s) due to error: %v",
+			NewLogField("host_addr", pool.host.ConnectAddress()), NewLogField("host_id", pool.host.HostID()), NewLogField("err", err.Error()))
 	}
 }
 
 // transition back to a not-filling state.
 func (pool *hostConnPool) fillingStopped(err error) {
 	if err != nil {
-		if gocqlDebug {
-			pool.logger.Printf("gocql: filling stopped %q: %v\n", pool.host.ConnectAddress(), err)
-		}
+		pool.logger.Warning("gocql: connection pool filling failed %s (%s): %v\n",
+			NewLogField("host_addr", pool.host.ConnectAddress()), NewLogField("host_id", pool.host.HostID()), NewLogField("err", err.Error()))
 		// wait for some time to avoid back-to-back filling
 		// this provides some time between failed attempts
 		// to fill the pool for the host to recover
@@ -496,9 +497,8 @@ func (pool *hostConnPool) fillingStopped(err error) {
 
 	// if we errored and the size is now zero, make sure the host is marked as down
 	// see https://github.com/gocql/gocql/issues/1614
-	if gocqlDebug {
-		pool.logger.Printf("gocql: conns of pool after stopped %q: %v\n", host.ConnectAddress(), count)
-	}
+	pool.logger.Debug("gocql: conns of pool after stopped %s (%s): %v\n",
+		NewLogField("host_addr", host.ConnectAddress()), NewLogField("host_id", host.HostID()), NewLogField("count", count))
 	if err != nil && count == 0 {
 		if pool.session.cfg.ConvictionPolicy.AddFailure(err, host) {
 			pool.session.handleNodeDown(host.ConnectAddress(), port)
@@ -554,10 +554,11 @@ func (pool *hostConnPool) connect() (err error) {
 				break
 			}
 		}
-		if gocqlDebug {
-			pool.logger.Printf("gocql: connection failed %q: %v, reconnecting with %T\n",
-				pool.host.ConnectAddress(), err, reconnectionPolicy)
-		}
+		pool.logger.Warning("gocql: connection failed %s (%s): %v, reconnecting with %v\n",
+			NewLogField("host", pool.host.ConnectAddress()),
+			NewLogField("host_id", pool.host.HostID()),
+			NewLogField("err", err.Error()),
+			NewLogField("reconnectionPolicy", fmt.Sprintf("%T", reconnectionPolicy)))
 		time.Sleep(reconnectionPolicy.GetInterval(i))
 	}
 
@@ -604,9 +605,8 @@ func (pool *hostConnPool) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 
-	if gocqlDebug {
-		pool.logger.Printf("gocql: pool connection error %q: %v\n", conn.addr, err)
-	}
+	pool.logger.Info("gocql: pool connection error %v: %v\n",
+		NewLogField("addr", conn.addr), NewLogField("err", err.Error()))
 
 	// find the connection index
 	for i, candidate := range pool.conns {

--- a/control.go
+++ b/control.go
@@ -314,6 +314,10 @@ func (c *controlConn) setupConn(conn *Conn) error {
 	}
 
 	c.conn.Store(ch)
+
+	c.session.logger.Info("gocql: control connection connected to %v (%s).",
+		NewLogField("host_addr", host.ConnectAddress().String()), NewLogField("host_id", host.HostID()))
+
 	if c.session.initialized() {
 		// We connected to control conn, so add the connect the host in pool as well.
 		// Notify session we can start trying to connect to the node.
@@ -462,6 +466,11 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 	if oldConn != nil && oldConn.conn != conn {
 		return
 	}
+
+	c.session.logger.Info("gocql: control connection error %v (%s): %v\n",
+		NewLogField("host_addr", conn.host.ConnectAddress().String()),
+		NewLogField("host_id", conn.host.HostID()),
+		NewLogField("err", err.Error()))
 
 	c.reconnect()
 }

--- a/control.go
+++ b/control.go
@@ -92,7 +92,7 @@ func (c *controlConn) heartBeat() {
 		case error:
 			goto reconn
 		default:
-			panic(fmt.Sprintf("gocql: unknown frame in response to options: %T", resp))
+			c.session.logger.Error("gocql: unknown frame in response to options: %v", NewLogField("frame_type", fmt.Sprintf("%T", resp)))
 		}
 
 	reconn:
@@ -239,14 +239,22 @@ func (c *controlConn) connect(hosts []*HostInfo) error {
 	for _, host := range hosts {
 		conn, err = c.session.dial(c.session.ctx, host, &cfg, c)
 		if err != nil {
-			c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
+			c.session.logger.Info("gocql: unable to dial control conn %s:%v (%s): %v\n",
+				NewLogField("host_addr", host.ConnectAddress()),
+				NewLogField("port", host.Port()),
+				NewLogField("host_id", host.HostID()),
+				NewLogField("err", err.Error()))
 			continue
 		}
 		err = c.setupConn(conn)
 		if err == nil {
 			break
 		}
-		c.session.logger.Printf("gocql: unable setup control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
+		c.session.logger.Info("gocql: unable setup control conn %v:%v (%s): %v\n",
+			NewLogField("host_addr", host.ConnectAddress()),
+			NewLogField("port", host.Port()),
+			NewLogField("host_id", host.HostID()),
+			NewLogField("err", err.Error()))
 		conn.Close()
 		conn = nil
 	}
@@ -347,16 +355,18 @@ func (c *controlConn) reconnect() {
 	}
 	defer atomic.StoreInt32(&c.reconnecting, 0)
 
-	conn, err := c.attemptReconnect()
+	_, err := c.attemptReconnect()
 
-	if conn == nil {
-		c.session.logger.Printf("gocql: unable to reconnect control connection: %v\n", err)
+	if err != nil {
+		c.session.logger.Error("gocql: unable to reconnect control connection: %v\n",
+			NewLogField("err", err.Error()))
 		return
 	}
 
 	err = c.session.refreshRing()
 	if err != nil {
-		c.session.logger.Printf("gocql: unable to refresh ring: %v\n", err)
+		c.session.logger.Warning("gocql: unable to refresh ring: %v\n",
+			NewLogField("err", err.Error()))
 	}
 }
 
@@ -383,8 +393,7 @@ func (c *controlConn) attemptReconnect() (*Conn, error) {
 		return conn, err
 	}
 
-	c.session.logger.Printf("gocql: unable to connect to any ring node: %v\n", err)
-	c.session.logger.Printf("gocql: control falling back to initial contact points.\n")
+	c.session.logger.Error("gocql: unable to connect to any ring node, control connection falling back to initial contact points: %v", NewLogField("err", err.Error()))
 	// Fallback to initial contact points, as it may be the case that all known initialHosts
 	// changed their IPs while keeping the same hostname(s).
 	initialHosts, resolvErr := addrsToHosts(c.session.cfg.Hosts, c.session.cfg.Port, c.session.logger)
@@ -401,14 +410,22 @@ func (c *controlConn) attemptReconnectToAnyOfHosts(hosts []*HostInfo) (*Conn, er
 	for _, host := range hosts {
 		conn, err = c.session.connect(c.session.ctx, host, c)
 		if err != nil {
-			c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
+			c.session.logger.Info("gocql: unable to dial control conn %s:%v (%s): %v\n",
+				NewLogField("host_addr", host.ConnectAddress()),
+				NewLogField("port", host.Port()),
+				NewLogField("host_id", host.HostID()),
+				NewLogField("err", err.Error()))
 			continue
 		}
 		err = c.setupConn(conn)
 		if err == nil {
 			break
 		}
-		c.session.logger.Printf("gocql: unable setup control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
+		c.session.logger.Info("gocql: unable setup control conn %v:%v (%s): %v\n",
+			NewLogField("host_addr", host.ConnectAddress()),
+			NewLogField("port", host.Port()),
+			NewLogField("host_id", host.HostID()),
+			NewLogField("err", err.Error()))
 		conn.Close()
 		conn = nil
 	}
@@ -489,8 +506,9 @@ func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter
 			return conn.executeQuery(context.TODO(), q)
 		})
 
-		if gocqlDebug && iter.err != nil {
-			c.session.logger.Printf("control: error executing %q: %v\n", statement, iter.err)
+		if iter.err != nil {
+			c.session.logger.Warning("control: error executing %v: %v\n",
+				NewLogField("statement", statement), NewLogField("err", iter.err.Error()))
 		}
 
 		q.AddAttempts(1, c.getConn().host)

--- a/control.go
+++ b/control.go
@@ -81,15 +81,17 @@ func (c *controlConn) heartBeat() {
 
 		resp, err := c.writeFrame(&writeOptionsFrame{})
 		if err != nil {
+			c.session.logger.Debug("gocql: control connection heartbeat failed: %v.", NewLogField("err", err.Error()))
 			goto reconn
 		}
 
-		switch resp.(type) {
+		switch actualResp := resp.(type) {
 		case *supportedFrame:
 			// Everything ok
 			sleepTime = 5 * time.Second
 			continue
 		case error:
+			c.session.logger.Debug("gocql: control connection heartbeat failed: %v.", NewLogField("err", actualResp.Error()))
 			goto reconn
 		default:
 			c.session.logger.Error("gocql: unknown frame in response to options: %v", NewLogField("frame_type", fmt.Sprintf("%T", resp)))
@@ -211,12 +213,19 @@ func (c *controlConn) discoverProtocol(hosts []*HostInfo) (int, error) {
 		}
 
 		if err == nil {
+			c.session.logger.Debug("gocql: discovered protocol version %v using host %v (%s).",
+				NewLogField("protocol_version", connCfg.ProtoVersion), NewLogField("host_addr", host.ConnectAddress()), NewLogField("host_id", host.HostID()))
 			return connCfg.ProtoVersion, nil
 		}
 
 		if proto := parseProtocolFromError(err); proto > 0 {
+			c.session.logger.Debug("gocql: discovered protocol version %v using host %v (%s).",
+				NewLogField("protocol_version", proto), NewLogField("host_addr", host.ConnectAddress()), NewLogField("host_id", host.HostID()))
 			return proto, nil
 		}
+
+		c.session.logger.Debug("gocql: failed to discover protocol version using host %v (%v): %v.",
+			NewLogField("host_addr", host.ConnectAddress()), NewLogField("host_id", host.HostID()), NewLogField("err", err.Error()))
 	}
 
 	return 0, err
@@ -283,10 +292,16 @@ func (c *controlConn) setupConn(conn *Conn) error {
 		return err
 	}
 
-	host = c.session.ring.addOrUpdate(host)
+	var exists bool
+	host, exists = c.session.ring.addOrUpdate(host)
 
 	if c.session.cfg.filterHost(host) {
-		return fmt.Errorf("host was filtered: %v", host.ConnectAddress())
+		return fmt.Errorf("host was filtered: %v (%s)", host.ConnectAddress(), host.HostID())
+	}
+
+	if !exists {
+		c.session.logger.Info("gocql: adding host %v (%v).",
+			NewLogField("host_addr", host.ConnectAddress().String()), NewLogField("host_id", host.HostID()))
 	}
 
 	if err := c.registerEvents(conn); err != nil {
@@ -371,6 +386,9 @@ func (c *controlConn) reconnect() {
 }
 
 func (c *controlConn) attemptReconnect() (*Conn, error) {
+
+	c.session.logger.Info("gocql: reconnecting the control connection.")
+
 	hosts := c.session.ring.allHosts()
 	hosts = shuffleHosts(hosts)
 

--- a/debug_off.go
+++ b/debug_off.go
@@ -1,6 +1,0 @@
-//go:build !gocql_debug
-// +build !gocql_debug
-
-package gocql
-
-const gocqlDebug = false

--- a/debug_on.go
+++ b/debug_on.go
@@ -1,6 +1,0 @@
-//go:build gocql_debug
-// +build gocql_debug
-
-package gocql
-
-const gocqlDebug = true

--- a/events.go
+++ b/events.go
@@ -1,7 +1,10 @@
 package gocql
 
 import (
+	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -15,10 +18,10 @@ type eventDebouncer struct {
 	callback func([]frame)
 	quit     chan struct{}
 
-	logger StdLogger
+	logger internalLogger
 }
 
-func newEventDebouncer(name string, eventHandler func([]frame), logger StdLogger) *eventDebouncer {
+func newEventDebouncer(name string, eventHandler func([]frame), logger internalLogger) *eventDebouncer {
 	e := &eventDebouncer{
 		name:     name,
 		quit:     make(chan struct{}),
@@ -76,7 +79,8 @@ func (e *eventDebouncer) debounce(frame frame) {
 	if len(e.events) < eventBufferSize {
 		e.events = append(e.events, frame)
 	} else {
-		e.logger.Printf("%s: buffer full, dropping event frame: %s", e.name, frame)
+		e.logger.Warning("gocql: %s: buffer full, dropping event frame: %s",
+			NewLogField("event_name", e.name), NewLogField("frame", frame))
 	}
 
 	e.mu.Unlock()
@@ -85,13 +89,11 @@ func (e *eventDebouncer) debounce(frame frame) {
 func (s *Session) handleEvent(framer *framer) {
 	frame, err := framer.parseFrame()
 	if err != nil {
-		s.logger.Printf("gocql: unable to parse event frame: %v\n", err)
+		s.logger.Error("gocql: unable to parse event frame: %v\n", NewLogField("err", err.Error()))
 		return
 	}
 
-	if gocqlDebug {
-		s.logger.Printf("gocql: handling frame: %v\n", frame)
-	}
+	s.logger.Debug("gocql: handling event frame: %v\n", NewLogField("frame", frame.String()))
 
 	switch f := frame.(type) {
 	case *schemaChangeKeyspace, *schemaChangeFunction,
@@ -101,7 +103,8 @@ func (s *Session) handleEvent(framer *framer) {
 	case *topologyChangeEventFrame, *statusChangeEventFrame:
 		s.nodeEvents.debounce(frame)
 	default:
-		s.logger.Printf("gocql: invalid event frame (%T): %v\n", f, f)
+		s.logger.Error("gocql: invalid event frame (%v): %v\n",
+			NewLogField("frame_type", fmt.Sprintf("%T", f)), NewLogField("frame", f.String()))
 	}
 }
 
@@ -169,9 +172,8 @@ func (s *Session) handleNodeEvent(frames []frame) {
 	}
 
 	for _, f := range sEvents {
-		if gocqlDebug {
-			s.logger.Printf("gocql: dispatching status change event: %+v\n", f)
-		}
+		s.logger.Info("gocql: dispatching status change event: %v\n",
+			NewLogField("frame", strings.Join([]string{f.change, "->", f.host.String(), ":", strconv.Itoa(f.port)}, "")))
 
 		// ignore events we received if they were disabled
 		// see https://github.com/gocql/gocql/issues/1591
@@ -189,9 +191,8 @@ func (s *Session) handleNodeEvent(frames []frame) {
 }
 
 func (s *Session) handleNodeUp(eventIp net.IP, eventPort int) {
-	if gocqlDebug {
-		s.logger.Printf("gocql: Session.handleNodeUp: %s:%d\n", eventIp.String(), eventPort)
-	}
+	s.logger.Info("gocql: node is UP: %s:%d\n",
+		NewLogField("event_ip", eventIp.String()), NewLogField("event_port", eventPort))
 
 	host, ok := s.ring.getHostByIP(eventIp.String())
 	if !ok {
@@ -216,9 +217,8 @@ func (s *Session) startPoolFill(host *HostInfo) {
 }
 
 func (s *Session) handleNodeConnected(host *HostInfo) {
-	if gocqlDebug {
-		s.logger.Printf("gocql: Session.handleNodeConnected: %s:%d\n", host.ConnectAddress(), host.Port())
-	}
+	s.logger.Debug("gocql: connected to node: %s:%d (%s)\n",
+		NewLogField("host_addr", host.ConnectAddress()), NewLogField("port", host.Port()), NewLogField("host_id", host.HostID()))
 
 	host.setState(NodeUp)
 
@@ -228,9 +228,8 @@ func (s *Session) handleNodeConnected(host *HostInfo) {
 }
 
 func (s *Session) handleNodeDown(ip net.IP, port int) {
-	if gocqlDebug {
-		s.logger.Printf("gocql: Session.handleNodeDown: %s:%d\n", ip.String(), port)
-	}
+	s.logger.Warning("gocql: node is DOWN: %s:%d\n",
+		NewLogField("host_addr", ip.String()), NewLogField("port", port))
 
 	host, ok := s.ring.getHostByIP(ip.String())
 	if ok {

--- a/events.go
+++ b/events.go
@@ -156,6 +156,8 @@ func (s *Session) handleNodeEvent(frames []frame) {
 	for _, frame := range frames {
 		switch f := frame.(type) {
 		case *topologyChangeEventFrame:
+			s.logger.Warning("gocql: received topology change event: %v",
+				NewLogField("frame", strings.Join([]string{f.change, "->", f.host.String(), ":", strconv.Itoa(f.port)}, "")))
 			topologyEventReceived = true
 		case *statusChangeEventFrame:
 			event, ok := sEvents[f.host.String()]

--- a/events_test.go
+++ b/events_test.go
@@ -15,7 +15,7 @@ func TestEventDebounce(t *testing.T) {
 	debouncer := newEventDebouncer("testDebouncer", func(events []frame) {
 		defer wg.Done()
 		eventsSeen += len(events)
-	}, &defaultLogger{})
+	}, newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone))
 	defer debouncer.stop()
 
 	for i := 0; i < eventCount; i++ {

--- a/filters.go
+++ b/filters.go
@@ -40,7 +40,7 @@ func DataCentreHostFilter(dataCentre string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(hosts, 9042, nopLogger{})
+	hostInfos, err := addrsToHosts(hosts, 9042, nilInternalLogger)
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/frame.go
+++ b/frame.go
@@ -418,6 +418,7 @@ func newFramer(compressor Compressor, version byte) *framer {
 
 type frame interface {
 	Header() frameHeader
+	String() string
 }
 
 func readHeader(r io.Reader, p []byte) (head frameHeader, err error) {

--- a/helpers.go
+++ b/helpers.go
@@ -5,6 +5,7 @@
 package gocql
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"net"
@@ -446,4 +447,12 @@ func LookupIP(host string) ([]net.IP, error) {
 	}
 	return net.LookupIP(host)
 
+}
+
+func ringString(hosts []*HostInfo) string {
+	buf := new(bytes.Buffer)
+	for _, h := range hosts {
+		buf.WriteString("[" + h.ConnectAddress().String() + "-" + h.HostID() + ":" + h.State().String() + "]")
+	}
+	return buf.String()
 }

--- a/helpers.go
+++ b/helpers.go
@@ -142,7 +142,7 @@ func getCassandraBaseType(name string) Type {
 	}
 }
 
-func getCassandraType(name string, logger StdLogger) TypeInfo {
+func getCassandraType(name string, logger internalLogger) TypeInfo {
 	if strings.HasPrefix(name, "frozen<") {
 		return getCassandraType(strings.TrimPrefix(name[:len(name)-1], "frozen<"), logger)
 	} else if strings.HasPrefix(name, "set<") {
@@ -158,7 +158,8 @@ func getCassandraType(name string, logger StdLogger) TypeInfo {
 	} else if strings.HasPrefix(name, "map<") {
 		names := splitCompositeTypes(strings.TrimPrefix(name[:len(name)-1], "map<"))
 		if len(names) != 2 {
-			logger.Printf("Error parsing map type, it has %d subelements, expecting 2\n", len(names))
+			logger.Warning("gocql: error parsing map type, it has %d subelements, expecting 2\n",
+				NewLogField("subelements_number", len(names)))
 			return NativeType{
 				typ: TypeCustom,
 			}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetCassandraType_Set(t *testing.T) {
-	typ := getCassandraType("set<text>", &defaultLogger{})
+	typ := getCassandraType("set<text>", newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone))
 	set, ok := typ.(CollectionType)
 	if !ok {
 		t.Fatalf("expected CollectionType got %T", typ)
@@ -203,7 +203,7 @@ func TestGetCassandraType(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			got := getCassandraType(test.input, &defaultLogger{})
+			got := getCassandraType(test.input, newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone))
 
 			// TODO(zariel): define an equal method on the types?
 			if !reflect.DeepEqual(got, test.exp) {

--- a/host_source.go
+++ b/host_source.go
@@ -706,6 +706,7 @@ func refreshRing(r *ringDescriber) error {
 		}
 
 		if host, ok := r.session.ring.addHostIfMissing(h); !ok {
+			r.session.logger.Info("gocql: adding host %v (%v).", NewLogField("host_addr", h.ConnectAddress().String()), NewLogField("host_id", h.HostID()))
 			r.session.startPoolFill(h)
 		} else {
 			// host (by hostID) already exists; determine if IP has changed
@@ -724,6 +725,7 @@ func refreshRing(r *ringDescriber) error {
 				if _, alreadyExists := r.session.ring.addHostIfMissing(h); alreadyExists {
 					return fmt.Errorf("add new host=%s after removal: %w", h, ErrHostAlreadyExists)
 				}
+				r.session.logger.Info("gocql: adding host %v (%v).", NewLogField("host_addr", h.ConnectAddress().String()), NewLogField("host_id", h.HostID()))
 				// add new HostInfo (same hostID, new IP)
 				r.session.startPoolFill(h)
 			}
@@ -737,6 +739,7 @@ func refreshRing(r *ringDescriber) error {
 
 	r.session.metadata.setPartitioner(partitioner)
 	r.session.policy.SetPartitioner(partitioner)
+	r.session.logger.Info("gocql: refreshed ring: %v.", NewLogField("ring", ringString(r.session.ring.allHosts())))
 	return nil
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -402,10 +402,10 @@ func (h *HostInfo) HostnameAndPort() string {
 }
 
 func (h *HostInfo) ConnectAddressAndPort() string {
-        h.mu.Lock()
-        defer h.mu.Unlock()
-        addr, _ := h.connectAddressLocked()
-        return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	addr, _ := h.connectAddressLocked()
+	return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
 }
 
 func (h *HostInfo) String() string {
@@ -559,7 +559,7 @@ func (s *Session) hostInfoFromMap(row map[string]interface{}, host *HostInfo) (*
 		// Not sure what the port field will be called until the JIRA issue is complete
 	}
 
-	ip, port := s.cfg.translateAddressPort(host.ConnectAddress(), host.port)
+	ip, port := s.cfg.translateAddressPort(host.ConnectAddress(), host.port, s.logger)
 	host.connectAddress = ip
 	host.port = port
 
@@ -633,8 +633,8 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo) ([]*HostInfo, er
 			return nil, err
 		} else if !isValidPeer(host) {
 			// If it's not a valid peer
-			r.session.logger.Printf("Found invalid peer '%s' "+
-				"Likely due to a gossip or snitch issue, this host will be ignored", host)
+			r.session.logger.Warning("gocql: found invalid peer '%s' "+
+				"Likely due to a gossip or snitch issue, this host will be ignored", NewLogField("host", host))
 			continue
 		}
 

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 )
 
 type StdLogger interface {
@@ -19,6 +21,14 @@ func (n nopLogger) Print(_ ...interface{}) {}
 func (n nopLogger) Printf(_ string, _ ...interface{}) {}
 
 func (n nopLogger) Println(_ ...interface{}) {}
+
+func (n nopLogger) Error(_ string, _ ...LogField) {}
+
+func (n nopLogger) Warning(_ string, _ ...LogField) {}
+
+func (n nopLogger) Info(_ string, _ ...LogField) {}
+
+func (n nopLogger) Debug(_ string, _ ...LogField) {}
 
 type testLogger struct {
 	capture bytes.Buffer
@@ -38,3 +48,145 @@ func (l *defaultLogger) Println(v ...interface{})               { log.Println(v.
 // Logger for logging messages.
 // Deprecated: Use ClusterConfig.Logger instead.
 var Logger StdLogger = &defaultLogger{}
+
+var nilInternalLogger internalLogger = loggerAdapter{
+	minimumLogLevel: LogLevelNone,
+	advLogger:       nopLogger{},
+	legacyLogger:    nil,
+}
+
+type LogLevel int
+
+const (
+	LogLevelDebug = LogLevel(5)
+	LogLevelInfo  = LogLevel(4)
+	LogLevelWarn  = LogLevel(3)
+	LogLevelError = LogLevel(2)
+	LogLevelNone  = LogLevel(0)
+)
+
+func (recv LogLevel) String() string {
+	switch recv {
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelInfo:
+		return "info"
+	case LogLevelWarn:
+		return "warn"
+	case LogLevelError:
+		return "error"
+	case LogLevelNone:
+		return "none"
+	default:
+		// fmt.sprintf allocates so use strings.Join instead
+		temp := [2]string{"invalid level ", strconv.Itoa(int(recv))}
+		return strings.Join(temp[:], "")
+	}
+}
+
+type LogField struct {
+	Name  string
+	Value interface{}
+}
+
+func NewLogField(name string, value interface{}) LogField {
+	return LogField{
+		Name:  name,
+		Value: value,
+	}
+}
+
+type AdvancedLogger interface {
+	Error(msg string, fields ...LogField)
+	Warning(msg string, fields ...LogField)
+	Info(msg string, fields ...LogField)
+	Debug(msg string, fields ...LogField)
+}
+
+type internalLogger interface {
+	AdvancedLogger
+	MinimumLogLevel() LogLevel
+}
+
+type loggerAdapter struct {
+	minimumLogLevel LogLevel
+	advLogger       AdvancedLogger
+	legacyLogger    StdLogger
+}
+
+func (recv loggerAdapter) logLegacy(msg string, fields ...LogField) {
+	var values []interface{}
+	var small [5]interface{}
+	l := len(fields)
+	if l <= 5 { // small stack array optimization
+		values = small[:l]
+	} else {
+		values = make([]interface{}, l)
+	}
+	var i int
+	for _, v := range fields {
+		values[i] = v.Value
+		i++
+	}
+	recv.legacyLogger.Printf(msg, values...)
+}
+
+func (recv loggerAdapter) Error(msg string, fields ...LogField) {
+	if LogLevelError <= recv.minimumLogLevel {
+		if recv.advLogger != nil {
+			recv.advLogger.Error(msg, fields...)
+		} else {
+			recv.logLegacy(msg, fields...)
+		}
+	}
+}
+
+func (recv loggerAdapter) Warning(msg string, fields ...LogField) {
+	if LogLevelWarn <= recv.minimumLogLevel {
+		if recv.advLogger != nil {
+			recv.advLogger.Warning(msg, fields...)
+		} else {
+			recv.logLegacy(msg, fields...)
+		}
+	}
+}
+
+func (recv loggerAdapter) Info(msg string, fields ...LogField) {
+	if LogLevelInfo <= recv.minimumLogLevel {
+		if recv.advLogger != nil {
+			recv.advLogger.Info(msg, fields...)
+		} else {
+			recv.logLegacy(msg, fields...)
+		}
+	}
+}
+
+func (recv loggerAdapter) Debug(msg string, fields ...LogField) {
+	if LogLevelDebug <= recv.minimumLogLevel {
+		if recv.advLogger != nil {
+			recv.advLogger.Debug(msg, fields...)
+		} else {
+			recv.logLegacy(msg, fields...)
+		}
+	}
+}
+
+func (recv loggerAdapter) MinimumLogLevel() LogLevel {
+	return recv.minimumLogLevel
+}
+
+func newInternalLoggerFromAdvancedLogger(logger AdvancedLogger, level LogLevel) loggerAdapter {
+	return loggerAdapter{
+		minimumLogLevel: level,
+		advLogger:       logger,
+		legacyLogger:    nil,
+	}
+}
+
+func newInternalLoggerFromStdLogger(logger StdLogger, level LogLevel) loggerAdapter {
+	return loggerAdapter{
+		minimumLogLevel: level,
+		advLogger:       nil,
+		legacyLogger:    logger,
+	}
+}

--- a/metadata.go
+++ b/metadata.go
@@ -313,7 +313,7 @@ func compileMetadata(
 	aggregates []AggregateMetadata,
 	views []ViewMetadata,
 	materializedViews []MaterializedViewMetadata,
-	logger StdLogger,
+	logger internalLogger,
 ) {
 	keyspace.Tables = make(map[string]*TableMetadata)
 	for i := range tables {
@@ -398,7 +398,7 @@ func compileMetadata(
 // column metadata as V2+ (because V1 doesn't support the "type" column in the
 // system.schema_columns table) so determining PartitionKey and ClusterColumns
 // is more complex.
-func compileV1Metadata(tables []TableMetadata, logger StdLogger) {
+func compileV1Metadata(tables []TableMetadata, logger internalLogger) {
 	for i := range tables {
 		table := &tables[i]
 
@@ -505,7 +505,7 @@ func compileV1Metadata(tables []TableMetadata, logger StdLogger) {
 }
 
 // The simpler compile case for V2+ protocol
-func compileV2Metadata(tables []TableMetadata, logger StdLogger) {
+func compileV2Metadata(tables []TableMetadata, logger internalLogger) {
 	for i := range tables {
 		table := &tables[i]
 
@@ -923,7 +923,7 @@ func getColumnMetadata(session *Session, keyspaceName string) ([]ColumnMetadata,
 	return columns, nil
 }
 
-func getTypeInfo(t string, logger StdLogger) TypeInfo {
+func getTypeInfo(t string, logger internalLogger) TypeInfo {
 	if strings.HasPrefix(t, apacheCassandraTypePrefix) {
 		t = apacheToCassandraType(t)
 	}
@@ -1161,7 +1161,7 @@ func getAggregatesMetadata(session *Session, keyspaceName string) ([]AggregateMe
 type typeParser struct {
 	input  string
 	index  int
-	logger StdLogger
+	logger internalLogger
 }
 
 // the type definition parser result
@@ -1173,7 +1173,7 @@ type typeParserResult struct {
 }
 
 // Parse the type definition used for validator and comparator schema data
-func parseType(def string, logger StdLogger) typeParserResult {
+func parseType(def string, logger internalLogger) typeParserResult {
 	parser := &typeParser{input: def, logger: logger}
 	return parser.parse()
 }
@@ -1234,11 +1234,11 @@ func (t *typeParser) parse() typeParserResult {
 				var name string
 				decoded, err := hex.DecodeString(*param.name)
 				if err != nil {
-					t.logger.Printf(
-						"Error parsing type '%s', contains collection name '%s' with an invalid format: %v",
-						t.input,
-						*param.name,
-						err,
+					t.logger.Warning(
+						"gocql: error parsing type '%s', contains collection name '%s' with an invalid format: %v",
+						NewLogField("type", t.input),
+						NewLogField("collection_name", *param.name),
+						NewLogField("err", err.Error()),
 					)
 					// just use the provided name
 					name = *param.name

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -13,7 +13,7 @@ import (
 // from metadata schema queries (see getKeyspaceMetadata, getTableMetadata, and getColumnMetadata)
 func TestCompileMetadata(t *testing.T) {
 	// V1 tests - these are all based on real examples from the integration test ccm cluster
-	log := &defaultLogger{}
+	log := newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone)
 	keyspace := &KeyspaceMetadata{
 		Name: "V1Keyspace",
 	}
@@ -675,7 +675,7 @@ func assertParseNonCompositeType(
 	typeExpected assertTypeInfo,
 ) {
 
-	log := &defaultLogger{}
+	log := newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone)
 	result := parseType(def, log)
 	if len(result.reversed) != 1 {
 		t.Errorf("%s expected %d reversed values but there were %d", def, 1, len(result.reversed))
@@ -706,7 +706,7 @@ func assertParseCompositeType(
 	collectionsExpected map[string]assertTypeInfo,
 ) {
 
-	log := &defaultLogger{}
+	log := newInternalLoggerFromStdLogger(&defaultLogger{}, LogLevelNone)
 	result := parseType(def, log)
 	if len(result.reversed) != len(typesExpected) {
 		t.Errorf("%s expected %d reversed values but there were %d", def, len(typesExpected), len(result.reversed))

--- a/policies.go
+++ b/policies.go
@@ -398,7 +398,7 @@ type tokenAwareHostPolicy struct {
 	partitioner string
 	metadata    atomic.Value // *clusterMeta
 
-	logger StdLogger
+	logger internalLogger
 }
 
 func (t *tokenAwareHostPolicy) Init(s *Session) {
@@ -541,7 +541,7 @@ func (t *tokenAwareHostPolicy) getMetadataForUpdate() *clusterMeta {
 
 // resetTokenRing creates a new tokenRing.
 // It must be called with t.mu locked.
-func (m *clusterMeta) resetTokenRing(partitioner string, hosts []*HostInfo, logger StdLogger) {
+func (m *clusterMeta) resetTokenRing(partitioner string, hosts []*HostInfo, logger internalLogger) {
 	if partitioner == "" {
 		// partitioner not yet set
 		return
@@ -550,7 +550,7 @@ func (m *clusterMeta) resetTokenRing(partitioner string, hosts []*HostInfo, logg
 	// create a new token ring
 	tokenRing, err := newTokenRing(partitioner, hosts)
 	if err != nil {
-		logger.Printf("Unable to update the token ring due to error: %s", err)
+		logger.Warning("gocql: unable to update the token ring due to error: %s", NewLogField("err", err.Error()))
 		return
 	}
 

--- a/ring.go
+++ b/ring.go
@@ -70,12 +70,12 @@ func (r *ring) currentHosts() map[string]*HostInfo {
 	return hosts
 }
 
-func (r *ring) addOrUpdate(host *HostInfo) *HostInfo {
-	if existingHost, ok := r.addHostIfMissing(host); ok {
+func (r *ring) addOrUpdate(host *HostInfo) (*HostInfo, bool) {
+	existingHost, ok := r.addHostIfMissing(host)
+	if ok {
 		existingHost.update(host)
-		host = existingHost
 	}
-	return host
+	return existingHost, ok
 }
 
 func (r *ring) addHostIfMissing(host *HostInfo) (*HostInfo, bool) {

--- a/session.go
+++ b/session.go
@@ -211,11 +211,25 @@ func (s *Session) init() error {
 			// TODO(zariel): we really only need this in 1 place
 			s.cfg.ProtoVersion = proto
 			s.connCfg.ProtoVersion = proto
+			s.logger.Info("gocql: discovered protocol version %v.", NewLogField("protocol_version", proto))
 		}
 
 		if err := s.control.connect(hosts); err != nil {
 			return err
 		}
+
+		controlHostConn := s.control.getConn()
+		var controlHost *HostInfo
+		var controlHostAddr string
+		var controlHostId string
+		if controlHostConn != nil {
+			controlHost = controlHostConn.host
+			controlHostAddr = controlHost.ConnectAddress().String()
+			controlHostId = controlHost.HostID()
+		}
+
+		s.logger.Info("gocql: control connection successfully connected to host %v (%v).",
+			NewLogField("host_addr", controlHostAddr), NewLogField("host_id", controlHostId))
 
 		if !s.cfg.DisableInitialHostLookup {
 			var partitioner string
@@ -232,6 +246,9 @@ func (s *Session) init() error {
 			}
 
 			hosts = filteredHosts
+			s.logger.Info("gocql: refreshed ring: %v.", NewLogField("ring", ringString(hosts)))
+		} else {
+			s.logger.Info("gocql: not performing a ring refresh because DisableInitialHostLookup is true.")
 		}
 	}
 
@@ -262,9 +279,13 @@ func (s *Session) init() error {
 	// again
 	atomic.AddInt64(&left, 1)
 	for _, host := range hostMap {
-		host := s.ring.addOrUpdate(host)
+		host, exists := s.ring.addOrUpdate(host)
 		if s.cfg.filterHost(host) {
 			continue
+		}
+		if !exists {
+			s.logger.Info("gocql: adding host %v (%v).",
+				NewLogField("host_addr", host.ConnectAddress().String()), NewLogField("host_id", host.HostID()))
 		}
 
 		atomic.AddInt64(&left, 1)
@@ -343,6 +364,7 @@ func (s *Session) init() error {
 	s.isInitialized = true
 	s.sessionStateMu.Unlock()
 
+	s.logger.Info("gocql: Session initialized successfully.")
 	return nil
 }
 
@@ -368,6 +390,7 @@ func (s *Session) reconnectDownedHosts(intv time.Duration) {
 	for {
 		select {
 		case <-reconnectTicker.C:
+			s.logger.Debug("gocql: connecting to downed hosts if there is any.")
 			hosts := s.ring.allHosts()
 
 			// Print session.ring for debug.
@@ -377,6 +400,10 @@ func (s *Session) reconnectDownedHosts(intv time.Duration) {
 				if h.IsUp() {
 					continue
 				}
+				s.logger.Info("gocql: reconnecting to downed host %v:%d (%v).",
+					NewLogField("host_addr", h.ConnectAddress().String()),
+					NewLogField("host_port", h.Port()),
+					NewLogField("host_id", h.HostID()))
 				// we let the pool call handleNodeConnected to change the host state
 				s.pool.addHost(h)
 			}
@@ -529,6 +556,7 @@ func (s *Session) executeQuery(qry *Query) (it *Iter) {
 }
 
 func (s *Session) removeHost(h *HostInfo) {
+	s.logger.Warning("gocql: removing host %v (%v).", NewLogField("host_addr", h.ConnectAddress().String()), NewLogField("host_id", h.HostID()))
 	s.policy.RemoveHost(h)
 	hostID := h.HostID()
 	s.pool.removeHost(hostID)

--- a/session.go
+++ b/session.go
@@ -218,19 +218,6 @@ func (s *Session) init() error {
 			return err
 		}
 
-		controlHostConn := s.control.getConn()
-		var controlHost *HostInfo
-		var controlHostAddr string
-		var controlHostId string
-		if controlHostConn != nil {
-			controlHost = controlHostConn.host
-			controlHostAddr = controlHost.ConnectAddress().String()
-			controlHostId = controlHost.HostID()
-		}
-
-		s.logger.Info("gocql: control connection successfully connected to host %v (%v).",
-			NewLogField("host_addr", controlHostAddr), NewLogField("host_id", controlHostId))
-
 		if !s.cfg.DisableInitialHostLookup {
 			var partitioner string
 			newHosts, partitioner, err := s.hostSource.GetHosts()

--- a/session.go
+++ b/session.go
@@ -82,7 +82,7 @@ type Session struct {
 	// you can use initialized() to read the value.
 	isInitialized bool
 
-	logger StdLogger
+	logger internalLogger
 }
 
 var queryPool = &sync.Pool{
@@ -91,14 +91,14 @@ var queryPool = &sync.Pool{
 	},
 }
 
-func addrsToHosts(addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
+func addrsToHosts(addrs []string, defaultPort int, logger internalLogger) ([]*HostInfo, error) {
 	var hosts []*HostInfo
 	for _, hostaddr := range addrs {
 		resolvedHosts, err := hostInfo(hostaddr, defaultPort)
 		if err != nil {
 			// Try other hosts if unable to resolve DNS name
 			if _, ok := err.(*net.DNSError); ok {
-				logger.Printf("gocql: dns error: %v\n", err)
+				logger.Error("gocql: dns error: %v\n", NewLogField("err", err.Error()))
 				continue
 			}
 			return nil, err
@@ -136,7 +136,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		connectObserver: cfg.ConnectObserver,
 		ctx:             ctx,
 		cancel:          cancel,
-		logger:          cfg.logger(),
+		logger:          cfg.newLogger(),
 	}
 
 	s.schemaDescriber = newSchemaDescriber(s)
@@ -371,13 +371,7 @@ func (s *Session) reconnectDownedHosts(intv time.Duration) {
 			hosts := s.ring.allHosts()
 
 			// Print session.ring for debug.
-			if gocqlDebug {
-				buf := bytes.NewBufferString("Session.ring:")
-				for _, h := range hosts {
-					buf.WriteString("[" + h.ConnectAddress().String() + ":" + h.State().String() + "]")
-				}
-				s.logger.Println(buf.String())
-			}
+			s.logger.Debug("gocql: current ring: %v.", NewLogField("ring", ringString(hosts)))
 
 			for _, h := range hosts {
 				if h.IsUp() {

--- a/session_test.go
+++ b/session_test.go
@@ -17,7 +17,7 @@ func TestSessionAPI(t *testing.T) {
 		cfg:    *cfg,
 		cons:   Quorum,
 		policy: RoundRobinHostPolicy(),
-		logger: cfg.logger(),
+		logger: cfg.newLogger(),
 	}
 
 	s.pool = cfg.PoolConfig.buildPool(s)
@@ -188,7 +188,7 @@ func TestBatchBasicAPI(t *testing.T) {
 	s := &Session{
 		cfg:    *cfg,
 		cons:   Quorum,
-		logger: cfg.logger(),
+		logger: cfg.newLogger(),
 	}
 	defer s.Close()
 

--- a/topology.go
+++ b/topology.go
@@ -66,12 +66,13 @@ func getReplicationFactorFromOpts(val interface{}) (int, error) {
 	}
 }
 
-func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
+func getStrategy(ks *KeyspaceMetadata, logger internalLogger) placementStrategy {
 	switch {
 	case strings.Contains(ks.StrategyClass, "SimpleStrategy"):
 		rf, err := getReplicationFactorFromOpts(ks.StrategyOptions["replication_factor"])
 		if err != nil {
-			logger.Printf("parse rf for keyspace %q: %v", ks.Name, err)
+			logger.Warning("gocql: parse rf for keyspace %v: %v",
+				NewLogField("keyspace", ks.Name), NewLogField("err", err.Error()))
 			return nil
 		}
 		return &simpleStrategy{rf: rf}
@@ -84,7 +85,8 @@ func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
 
 			rf, err := getReplicationFactorFromOpts(rf)
 			if err != nil {
-				logger.Println("parse rf for keyspace %q, dc %q: %v", err)
+				logger.Warning("gocql: parse rf for keyspace %v, dc %v: %v",
+					NewLogField("keyspace", ks.Name), NewLogField("dc", dc), NewLogField("err", err.Error()))
 				// skip DC if the rf is invalid/unsupported, so that we can at least work with other working DCs.
 				continue
 			}
@@ -95,7 +97,8 @@ func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
 	case strings.Contains(ks.StrategyClass, "LocalStrategy"):
 		return nil
 	default:
-		logger.Printf("parse rf for keyspace %q: unsupported strategy class: %v", ks.StrategyClass)
+		logger.Warning("gocql: parse rf for keyspace %v: unsupported strategy class: %v",
+			NewLogField("keyspace", ks.Name), NewLogField("strategy_class", ks.StrategyClass))
 		return nil
 	}
 }


### PR DESCRIPTION
### Motivation

In my experience troubleshooting connection issues in gocql is quite complicated because there's not enough logging information available to understand what is going on under the hood (control connection reconnections, nodes being considered UP/DOWN, nodes being added or removed, connection pool errors, etc.). There is already some logging for this in place at the moment but it requires a build flag to be set which is far from ideal.

Adding logging for all of this by default would make the default gocql experience a bit frustrating for users that do not care about all of this extra information so log levels are also needed. With log levels, one can make the logging more verbose if they are trying to troubleshoot a particular issue. Other C* drivers already provide this kind of functionality out of the box.

### Proposal

As mentioned in the prior section, with this PR I'm adding logging for a lot of the scenarios that were described above and I'm also adding log levels so that log verbosity can be tuned by users.

On top of the additional logging and log levels, I'm also adding better support for structured logging (new `StructuredLogger` interface and field in the cluster config). Note that the current "printf" way needs to be supported at the very least until gocql v2 to maintain the same behavior that exists today in apps that are leveraging the `StdLogger` interface.

I'm proposing to set the default log level as `WARNING` because it looks like `WARNING` is the most appropriate default level taking into account what logging there is today in gocql by default (prior to this proposal).

It would be great if other community members could chime in on this proposal to improve any weak points that it might have and to make sure it addresses the needs of our users.

### Usage/Examples

#### Example application side code with [zerolog](https://github.com/rs/zerolog):

```go
// write a new logger that implements gocql's StructuredLogger interface using zerolog
type Zerologlogger struct {
	L *zerolog.Logger
}

func (rec *Zerologlogger) log(event *zerolog.Event, fields ...gocql.LogField) *zerolog.Event {
	for _, field := range fields {
		event = event.Any(field.Name, field.Value)
	}
	return event
}

func (rec *Zerologlogger) Error(msg string, fields ...gocql.LogField) {
	rec.log(rec.L.Error(), fields...).Msg(msg)
}

func (rec *Zerologlogger) Warning(msg string, fields ...gocql.LogField) {
	rec.log(rec.L.Warn(), fields...).Msg(msg)
}

func (rec *Zerologlogger) Info(msg string, fields ...gocql.LogField) {
	rec.log(rec.L.Info(), fields...).Msg(msg)
}

func (rec *Zerologlogger) Debug(msg string, fields ...gocql.LogField) {
	rec.log(rec.L.Debug(), fields...).Msg(msg)
}

// example of building a session with this new logger
func buildCqlSession(logger *zerolog.Logger) (*gocql.Session, error) {
	cluster := gocql.NewCluster("127.0.0.1")
	cluster.StructuredLogger = &Zerologlogger{L: logger}
	return cluster.CreateSession()
}
```

### Alternatives

I considered `log/slog` instead of creating a new Structured Logger interface from scratch but `log/slog` was only introduced in `go 1.21` so I discarded this option for now. Maybe it would be a good idea to move to `log/slog` down the line when a new major version of gocql is being worked on?

### Drawbacks

The biggest drawback in this solution is that in order for a user to take full advantage of the new StructuredLogger interface, they have to implement a new type while this wasn't needed in the case of `StdLogger` for some logging libraries.

### Log output examples

The following examples were collected following one simple procedure with CCM where:

1. node1 (127.0.0.1) is brought DOWN
2. node1 (127.0.0.1) is brought UP
3. node3 (127.0.0.3) is brought DOWN
4. node3 (127.0.0.3) is REMOVED
5. node3 (127.0.0.1) is ADDED and brought UP

Each log sample was collected on a unique run of this procedure so these log samples might not be fully comparable with each other.

#### Zerolog with gocql minimum log level set to WARN

```
{"level":"warn","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"read tcp 127.0.0.1:61968->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:57:43+01:00"
,"message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.1","port":9042,"time":"2024-05-29T10:57:43+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"warn","host_addr":"127.0.0.1","port":9042,"time":"2024-05-29T10:58:03+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","err":"read tcp 127.0.0.1:62078->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:58:40+01:00"
,"message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:58:41+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:59:00+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","err":"dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.","time":"2024-05-29T10:59:35+01:00","
message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:59:35+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"warn","frame":"REMOVED_NODE->127.0.0.3:9042","time":"2024-05-29T10:59:43+01:00","message":"gocql: received topology change event: %v"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","time":"2024-05-29T10:59:44+01:00","message":"gocql: removing host %v (%v)."}
{"level":"warn","frame":"NEW_NODE->127.0.0.3:9042","time":"2024-05-29T11:01:56+01:00","message":"gocql: received topology change event: %v"}
```

#### Default logger with gocql minimum log level set to WARN

```
2024/05/29 11:04:59 gocql: connection pool filling failed 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): dial tcp 127.0.0.1:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 11:04:59 gocql: node is DOWN: 127.0.0.1:9042
2024/05/29 11:05:16 gocql: node is DOWN: 127.0.0.1:9042
2024/05/29 11:06:12 gocql: connection pool filling failed 127.0.0.3 (789de5e6-fc79-4066-aba9-0fb8f4cea344): read tcp 127.0.0.1:62444->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 11:06:13 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 11:06:32 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 11:06:43 gocql: connection pool filling failed 127.0.0.3 (789de5e6-fc79-4066-aba9-0fb8f4cea344): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 11:06:43 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 11:07:23 gocql: received topology change event: REMOVED_NODE->127.0.0.3:9042
2024/05/29 11:07:24 gocql: removing host 127.0.0.3 (789de5e6-fc79-4066-aba9-0fb8f4cea344).
2024/05/29 11:09:26 gocql: received topology change event: NEW_NODE->127.0.0.3:9042
```

#### Zerolog with gocql minimum log level set to DEBUG

```
{"level":"debug","protocol_version":4,"host_addr":"127.0.0.1","host_id":"","time":"2024-05-29T10:48:10+01:00","message":"gocql: discovered protocol version %v using host %v (%s)."}
{"level":"info","protocol_version":4,"time":"2024-05-29T10:48:10+01:00","message":"gocql: discovered protocol version %v."}                                                             
{"level":"info","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","time":"2024-05-29T10:48:10+01:00","message":"gocql: adding host %v (%v)."}                    
{"level":"info","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","time":"2024-05-29T10:48:10+01:00","message":"gocql: control connection connected to %v (%s)."}
{"level":"info","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:48:10+01:00","message":"gocql: refreshed rin
g: %v."}
{"level":"info","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","time":"2024-05-29T10:48:10+01:00","message":"gocql: adding host %v (%v)."}
{"level":"info","host_addr":"127.0.0.2","host_id":"b1d368d0-d545-4213-843f-1e0229be11c4","time":"2024-05-29T10:48:10+01:00","message":"gocql: adding host %v (%v)."}
{"level":"debug","host_addr":"127.0.0.2","port":9042,"host_id":"b1d368d0-d545-4213-843f-1e0229be11c4","time":"2024-05-29T10:48:10+01:00","message":"gocql: connected to node: %s:%d (%s)\n"}
{"level":"debug","host_addr":"127.0.0.1","port":9042,"host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","time":"2024-05-29T10:48:10+01:00","message":"gocql: connected to node: %s:%d (%s)\n"}
{"level":"info","time":"2024-05-29T10:48:10+01:00","message":"gocql: Session initialized successfully."}
{"level":"debug","host_addr":"127.0.0.3","port":9042,"host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","time":"2024-05-29T10:48:10+01:00","message":"gocql: connected to node: %s:%d (%s)\n"}
{"level":"debug","host_addr":"127.0.0.2","host_id":"b1d368d0-d545-4213-843f-1e0229be11c4","count":2,"time":"2024-05-29T10:48:10+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","count":2,"time":"2024-05-29T10:48:10+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","count":2,"time":"2024-05-29T10:48:10+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"info","host_addr":"127.0.0.1","host_id":"","err":"read tcp 127.0.0.1:61292->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:48:48+01:00","message":"gocql: control connectio
n error %v (%s): %v\n"}
{"level":"info","time":"2024-05-29T10:48:48+01:00","message":"gocql: reconnecting the control connection."}
{"level":"info","addr":"127.0.0.1:9042","err":"read tcp 127.0.0.1:61297->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:48:48+01:00","message":"gocql: pool connection error %v: %v\n
"}
{"level":"info","addr":"127.0.0.1:9042","err":"read tcp 127.0.0.1:61293->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:48:48+01:00","message":"gocql: pool connection error %v: %v\n
"}
{"level":"info","host_addr":"127.0.0.1","port":9042,"host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"read tcp 127.0.0.1:61305->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:
48:48+01:00","message":"gocql: unable to dial control conn %s:%v (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"read tcp 127.0.0.1:61306->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:48:48+01:00
","message":"gocql: unable to dial %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"read tcp 127.0.0.1:61306->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:48:48+01:00"
,"message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"info","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","time":"2024-05-29T10:48:48+01:00","message":"gocql: control connection connected to %v (%s)."}
{"level":"info","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:48:48+01:00","message":"gocql: refreshed rin
g: %v."}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","count":0,"time":"2024-05-29T10:48:48+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.1","port":9042,"time":"2024-05-29T10:48:48+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","frame":"[status_change change=DOWN host=127.0.0.1 port=9042]","time":"2024-05-29T10:49:07+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"info","frame":"DOWN->127.0.0.1:9042","time":"2024-05-29T10:49:08+01:00","message":"gocql: dispatching status change event: %v\n"}
{"level":"warn","host_addr":"127.0.0.1","port":9042,"time":"2024-05-29T10:49:08+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","time":"2024-05-29T10:49:10+01:00","message":"gocql: connecting to downed hosts if there is any."}
{"level":"debug","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:DOWN][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:49:10+01:00","message":"gocql: current ri
ng: %v."}
{"level":"info","host_addr":"127.0.0.1","host_port":9042,"host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","time":"2024-05-29T10:49:10+01:00","message":"gocql: reconnecting to downed host %v:%d (%v)."}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"dial tcp 127.0.0.1:9042: connectex: No connection could be made because the target machine actively refused it.","time":"2024-05-29T10:49:12+01:00",
"message":"gocql: unable to dial %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","err":"dial tcp 127.0.0.1:9042: connectex: No connection could be made because the target machine actively refused it.","time":"2024-05-29T10:49:12+01:00","
message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","count":0,"time":"2024-05-29T10:49:12+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.1","port":9042,"time":"2024-05-29T10:49:12+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","frame":"[status_change change=UP host=127.0.0.1 port=9042]","time":"2024-05-29T10:49:37+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"info","frame":"UP->127.0.0.1:9042","time":"2024-05-29T10:49:38+01:00","message":"gocql: dispatching status change event: %v\n"}
{"level":"info","event_ip":"127.0.0.1","event_port":9042,"time":"2024-05-29T10:49:38+01:00","message":"gocql: node is UP: %s:%d\n"}
{"level":"debug","host_addr":"127.0.0.1","port":9042,"host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","time":"2024-05-29T10:49:38+01:00","message":"gocql: connected to node: %s:%d (%s)\n"}
{"level":"debug","host_addr":"127.0.0.1","host_id":"d0586c1b-9546-429a-81a6-278a6ffe903f","count":2,"time":"2024-05-29T10:49:38+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"info","addr":"127.0.0.3:9042","err":"read tcp 127.0.0.1:61298->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:50:02+01:00","message":"gocql: pool connection error %v: %v\n
"}
{"level":"info","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"read tcp 127.0.0.1:61307->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:50:02+01:00"
,"message":"gocql: control connection error %v (%s): %v\n"}
{"level":"info","time":"2024-05-29T10:50:02+01:00","message":"gocql: reconnecting the control connection."}
{"level":"info","addr":"127.0.0.3:9042","err":"read tcp 127.0.0.1:61295->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:50:02+01:00","message":"gocql: pool connection error %v: %v\n
"}
{"level":"info","host_addr":"127.0.0.3","port":9042,"host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"read tcp 127.0.0.1:61464->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:
50:02+01:00","message":"gocql: unable to dial control conn %s:%v (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"read tcp 127.0.0.1:61465->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:50:02+01:00
","message":"gocql: unable to dial %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"read tcp 127.0.0.1:61465->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.","time":"2024-05-29T10:50:02+01:00"
,"message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"info","host_addr":"127.0.0.2","host_id":"b1d368d0-d545-4213-843f-1e0229be11c4","time":"2024-05-29T10:50:02+01:00","message":"gocql: control connection connected to %v (%s)."}
{"level":"info","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:50:02+01:00","message":"gocql: refreshed rin
g: %v."}
{"level":"debug","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","count":0,"time":"2024-05-29T10:50:02+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:50:02+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","time":"2024-05-29T10:50:10+01:00","message":"gocql: connecting to downed hosts if there is any."}
{"level":"debug","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:DOWN][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:50:10+01:00","message":"gocql: current ri
ng: %v."}
{"level":"info","host_addr":"127.0.0.3","host_port":9042,"host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","time":"2024-05-29T10:50:10+01:00","message":"gocql: reconnecting to downed host %v:%d (%v)."}
{"level":"debug","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.","time":"2024-05-29T10:50:12+01:00",
"message":"gocql: unable to dial %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","err":"dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.","time":"2024-05-29T10:50:12+01:00","
message":"gocql: connection pool filling failed %s (%s): %v\n"}
{"level":"debug","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","count":0,"time":"2024-05-29T10:50:12+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:50:12+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","frame":"[status_change change=DOWN host=127.0.0.3 port=9042]","time":"2024-05-29T10:50:20+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"info","frame":"DOWN->127.0.0.3:9042","time":"2024-05-29T10:50:21+01:00","message":"gocql: dispatching status change event: %v\n"}
{"level":"warn","host_addr":"127.0.0.3","port":9042,"time":"2024-05-29T10:50:21+01:00","message":"gocql: node is DOWN: %s:%d\n"}
{"level":"debug","frame":"[topology_change change=REMOVED_NODE host=127.0.0.3 port=9042]","time":"2024-05-29T10:51:03+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"warn","frame":"REMOVED_NODE->127.0.0.3:9042","time":"2024-05-29T10:51:04+01:00","message":"gocql: received topology change event: %v"}
{"level":"warn","host_addr":"127.0.0.3","host_id":"60f32865-2f22-47fa-b3f4-034aea1b2bcc","time":"2024-05-29T10:51:05+01:00","message":"gocql: removing host %v (%v)."}
{"level":"info","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:51:05+01:00","message":"gocql: refreshed ring: %v."}
{"level":"debug","time":"2024-05-29T10:51:10+01:00","message":"gocql: connecting to downed hosts if there is any."}
{"level":"debug","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:51:10+01:00","message":"gocql: current ring: %v."}
{"level":"debug","time":"2024-05-29T10:52:10+01:00","message":"gocql: connecting to downed hosts if there is any."}
{"level":"debug","ring":"[127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP][127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP]","time":"2024-05-29T10:52:10+01:00","message":"gocql: current ring: %v."}
{"level":"debug","frame":"[topology_change change=NEW_NODE host=127.0.0.3 port=9042]","time":"2024-05-29T10:52:54+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"debug","frame":"[status_change change=UP host=127.0.0.3 port=9042]","time":"2024-05-29T10:52:54+01:00","message":"gocql: handling event frame: %v\n"}
{"level":"warn","frame":"NEW_NODE->127.0.0.3:9042","time":"2024-05-29T10:52:55+01:00","message":"gocql: received topology change event: %v"}
{"level":"info","frame":"UP->127.0.0.3:9042","time":"2024-05-29T10:52:55+01:00","message":"gocql: dispatching status change event: %v\n"}
{"level":"info","event_ip":"127.0.0.3","event_port":9042,"time":"2024-05-29T10:52:55+01:00","message":"gocql: node is UP: %s:%d\n"}
{"level":"info","host_addr":"127.0.0.3","host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","time":"2024-05-29T10:52:56+01:00","message":"gocql: adding host %v (%v)."}
{"level":"info","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-83389975-1aef-4727-a2e1-9451691dd9bb:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:52:56+01:00","message":"gocql: refreshed rin
g: %v."}
{"level":"debug","host_addr":"127.0.0.3","port":9042,"host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","time":"2024-05-29T10:52:56+01:00","message":"gocql: connected to node: %s:%d (%s)\n"}
{"level":"debug","host_addr":"127.0.0.3","host_id":"83389975-1aef-4727-a2e1-9451691dd9bb","count":2,"time":"2024-05-29T10:52:56+01:00","message":"gocql: conns of pool after stopped %s (%s): %v\n"}
{"level":"debug","time":"2024-05-29T10:53:10+01:00","message":"gocql: connecting to downed hosts if there is any."}
{"level":"debug","ring":"[127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-83389975-1aef-4727-a2e1-9451691dd9bb:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP]","time":"2024-05-29T10:53:10+01:00","message":"gocql: current ring
: %v."}
```

#### Default logger with gocql minimum log level set to DEBUG

```
2024/05/29 10:40:16 gocql: discovered protocol version 4 using host 127.0.0.2 ().
2024/05/29 10:40:16 gocql: discovered protocol version 4.                                                                                                                                            
2024/05/29 10:40:16 gocql: adding host 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f).                                                                                                             
2024/05/29 10:40:16 gocql: control connection connected to 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f).                                                                                         
2024/05/29 10:40:16 gocql: refreshed ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:40:16 gocql: adding host 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24).                                                                                                             
2024/05/29 10:40:16 gocql: adding host 127.0.0.2 (b1d368d0-d545-4213-843f-1e0229be11c4).                                                                                                             
2024/05/29 10:40:16 gocql: connected to node: 127.0.0.1:9042 (d0586c1b-9546-429a-81a6-278a6ffe903f)       
2024/05/29 10:40:16 gocql: connected to node: 127.0.0.2:9042 (b1d368d0-d545-4213-843f-1e0229be11c4)       
2024/05/29 10:40:16 gocql: Session initialized successfully.                                              
2024/05/29 10:40:16 gocql: connected to node: 127.0.0.3:9042 (921d79a6-4791-4cc3-9426-d5a85cd1cb24)       
2024/05/29 10:40:16 gocql: conns of pool after stopped 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): 2
2024/05/29 10:40:16 gocql: conns of pool after stopped 127.0.0.2 (b1d368d0-d545-4213-843f-1e0229be11c4): 2
2024/05/29 10:40:16 gocql: conns of pool after stopped 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): 2
2024/05/29 10:40:44 gocql: pool connection error 127.0.0.1:9042: read tcp 127.0.0.1:60927->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:40:44 gocql: unable to dial 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): read tcp 127.0.0.1:60935->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:40:44 gocql: connection pool filling failed 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): read tcp 127.0.0.1:60935->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:40:44 gocql: pool connection error 127.0.0.1:9042: read tcp 127.0.0.1:60930->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:40:44 gocql: control connection error 127.0.0.1 (): read tcp 127.0.0.1:60925->127.0.0.1:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:40:44 gocql: reconnecting the control connection.
2024/05/29 10:40:44 gocql: conns of pool after stopped 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): 0
2024/05/29 10:40:44 gocql: node is DOWN: 127.0.0.1:9042
2024/05/29 10:40:46 gocql: unable to dial control conn 127.0.0.1:9042 (d0586c1b-9546-429a-81a6-278a6ffe903f): dial tcp 127.0.0.1:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:40:46 gocql: control connection connected to 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24).
2024/05/29 10:40:46 gocql: refreshed ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:DOWN][127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:41:02 gocql: handling event frame: [status_change change=DOWN host=127.0.0.1 port=9042]
2024/05/29 10:41:03 gocql: dispatching status change event: DOWN->127.0.0.1:9042
2024/05/29 10:41:03 gocql: node is DOWN: 127.0.0.1:9042
2024/05/29 10:41:06 gocql: handling event frame: [status_change change=UP host=127.0.0.1 port=9042]
2024/05/29 10:41:07 gocql: dispatching status change event: UP->127.0.0.1:9042
2024/05/29 10:41:07 gocql: node is UP: 127.0.0.1:9042
2024/05/29 10:41:07 gocql: connected to node: 127.0.0.1:9042 (d0586c1b-9546-429a-81a6-278a6ffe903f)
2024/05/29 10:41:07 gocql: conns of pool after stopped 127.0.0.1 (d0586c1b-9546-429a-81a6-278a6ffe903f): 2
2024/05/29 10:41:16 gocql: connecting to downed hosts if there is any.
2024/05/29 10:41:16 gocql: current ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:41:21 gocql: pool connection error 127.0.0.3:9042: read tcp 127.0.0.1:60928->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:41:21 gocql: control connection error 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): read tcp 127.0.0.1:60939->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:41:21 gocql: reconnecting the control connection.
2024/05/29 10:41:21 gocql: pool connection error 127.0.0.3:9042: read tcp 127.0.0.1:60931->127.0.0.3:9042: wsarecv: An existing connection was forcibly closed by the remote host.
2024/05/29 10:41:22 gocql: control connection heartbeat failed: gocql: connection closed waiting for response.
2024/05/29 10:41:23 gocql: unable to dial control conn 127.0.0.3:9042 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:41:23 gocql: unable to dial 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:41:23 gocql: connection pool filling failed 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:41:23 gocql: control connection connected to 127.0.0.2 (b1d368d0-d545-4213-843f-1e0229be11c4).
2024/05/29 10:41:23 gocql: refreshed ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:41:23 gocql: conns of pool after stopped 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): 0
2024/05/29 10:41:23 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 10:41:40 gocql: handling event frame: [status_change change=DOWN host=127.0.0.3 port=9042]
2024/05/29 10:41:41 gocql: dispatching status change event: DOWN->127.0.0.3:9042
2024/05/29 10:41:41 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 10:42:16 gocql: connecting to downed hosts if there is any.
2024/05/29 10:42:16 gocql: current ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:DOWN][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:42:16 gocql: reconnecting to downed host 127.0.0.3:9042 (921d79a6-4791-4cc3-9426-d5a85cd1cb24).
2024/05/29 10:42:18 gocql: unable to dial 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:42:18 gocql: connection pool filling failed 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:42:18 gocql: conns of pool after stopped 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): 0
2024/05/29 10:42:18 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 10:43:15 gocql: handling event frame: [topology_change change=REMOVED_NODE host=127.0.0.3 port=9042]
2024/05/29 10:43:16 gocql: received topology change event: REMOVED_NODE->127.0.0.3:9042
2024/05/29 10:43:16 gocql: connecting to downed hosts if there is any.
2024/05/29 10:43:16 gocql: current ring: [127.0.0.3-921d79a6-4791-4cc3-9426-d5a85cd1cb24:DOWN][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP][127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP].
2024/05/29 10:43:16 gocql: reconnecting to downed host 127.0.0.3:9042 (921d79a6-4791-4cc3-9426-d5a85cd1cb24).
2024/05/29 10:43:17 gocql: removing host 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24).
2024/05/29 10:43:17 gocql: refreshed ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:43:18 gocql: unable to dial 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:43:18 gocql: connection pool filling failed 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): dial tcp 127.0.0.3:9042: connectex: No connection could be made because the target machine actively refused it.
2024/05/29 10:43:18 gocql: conns of pool after stopped 127.0.0.3 (921d79a6-4791-4cc3-9426-d5a85cd1cb24): 0
2024/05/29 10:43:18 gocql: node is DOWN: 127.0.0.3:9042
2024/05/29 10:44:16 gocql: connecting to downed hosts if there is any.
2024/05/29 10:44:16 gocql: current ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:45:12 gocql: handling event frame: [topology_change change=NEW_NODE host=127.0.0.3 port=9042]
2024/05/29 10:45:12 gocql: handling event frame: [status_change change=UP host=127.0.0.3 port=9042]
2024/05/29 10:45:13 gocql: received topology change event: NEW_NODE->127.0.0.3:9042
2024/05/29 10:45:13 gocql: dispatching status change event: UP->127.0.0.3:9042
2024/05/29 10:45:13 gocql: node is UP: 127.0.0.3:9042
2024/05/29 10:45:14 gocql: adding host 127.0.0.3 (60f32865-2f22-47fa-b3f4-034aea1b2bcc).
2024/05/29 10:45:14 gocql: refreshed ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
2024/05/29 10:45:14 gocql: connected to node: 127.0.0.3:9042 (60f32865-2f22-47fa-b3f4-034aea1b2bcc)
2024/05/29 10:45:14 gocql: conns of pool after stopped 127.0.0.3 (60f32865-2f22-47fa-b3f4-034aea1b2bcc): 2
2024/05/29 10:45:16 gocql: connecting to downed hosts if there is any.
2024/05/29 10:45:16 gocql: current ring: [127.0.0.1-d0586c1b-9546-429a-81a6-278a6ffe903f:UP][127.0.0.3-60f32865-2f22-47fa-b3f4-034aea1b2bcc:UP][127.0.0.2-b1d368d0-d545-4213-843f-1e0229be11c4:UP].
```