### PR TITLE
Support for `now_in_seconds` option field for QUERY, BATCH and EXECUTE messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1348,6 +1348,8 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 	}
 	if c.version > protoVersion4 {
 		params.keyspace = c.currentKeyspace
+		params.nowInSeconds = qry.nowInSeconds
+		params.nowInSecondsValue = qry.nowInSecondsValue
 	}
 
 	var (
@@ -1552,6 +1554,12 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 		defaultTimestamp:      batch.defaultTimestamp,
 		defaultTimestampValue: batch.defaultTimestampValue,
 		customPayload:         batch.CustomPayload,
+	}
+
+	if c.version > protoVersion4 {
+		req.keyspace = c.currentKeyspace
+		req.nowInSeconds = batch.nowInSeconds
+		req.nowInSecondsValue = batch.nowInSecondsValue
 	}
 
 	stmts := make(map[string]string, len(batch.Entries))

--- a/session.go
+++ b/session.go
@@ -936,6 +936,9 @@ type Query struct {
 
 	// routingInfo is a pointer because Query can be copied and copyable struct can't hold a mutex.
 	routingInfo *queryRoutingInfo
+
+	nowInSeconds      bool
+	nowInSecondsValue int
 }
 
 type queryRoutingInfo struct {
@@ -1423,6 +1426,16 @@ func (q *Query) releaseAfterExecution() {
 	q.decRefCount()
 }
 
+// WithNowInSeconds will enable the with now_in_seconds flag on the query.
+// Also, it allows to define now_in_seconds value.
+//
+// Only available on protocol >= 5
+func (q *Query) WithNowInSeconds(now int) *Query {
+	q.nowInSeconds = true
+	q.nowInSecondsValue = now
+	return q
+}
+
 // Iter represents an iterator that can be used to iterate over all rows that
 // were returned by a query. The iterator might send additional queries to the
 // database during the iteration if paging was enabled.
@@ -1742,6 +1755,8 @@ type Batch struct {
 	cancelBatch           func()
 	keyspace              string
 	metrics               *queryMetrics
+	nowInSeconds          bool
+	nowInSecondsValue     int
 
 	// routingInfo is a pointer because Query can be copied and copyable struct can't hold a mutex.
 	routingInfo *queryRoutingInfo
@@ -2040,6 +2055,16 @@ func (b *Batch) borrowForExecution() {
 func (b *Batch) releaseAfterExecution() {
 	// empty, because Batch has no equivalent of Query.Release()
 	// that would race with speculative executions.
+}
+
+// WithNowInSeconds will enable the with now_in_seconds flag on the query.
+// Also, it allows to define now_in_seconds value.
+//
+// Only available on protocol >= 5
+func (b *Batch) WithNowInSeconds(now int) *Batch {
+	b.nowInSeconds = true
+	b.nowInSecondsValue = now
+	return b
 }
 
 type BatchType byte


### PR DESCRIPTION
This PR provides support for [now_in_seconds](https://github.com/apache/cassandra/blob/42d18a83e4468827da234c68fad3e3058b368d7c/doc/native_protocol_v5.spec#L1455C1-L1456C1) optional field for QUERY, BATCH and EXECUTE messages as part of Native Protocol v5 support.
The implementation is mostly based on previous implementations for such optional fields as _timestamp_, _keyspace_, etc.