### PR TITLE
Support for `result_metadata_id` in PREPARED and EXECUTE messages

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1394,9 +1394,10 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata)
 
 		frame = &writeExecuteFrame{
-			preparedID:    info.id,
-			params:        params,
-			customPayload: qry.customPayload,
+			preparedID:         info.id,
+			params:             params,
+			customPayload:      qry.customPayload,
+			preparedMetadataID: info.request.id,
 		}
 
 		// Set "keyspace" and "table" property in the query if it is present in preparedMetadata

--- a/frame.go
+++ b/frame.go
@@ -942,6 +942,9 @@ type preparedMetadata struct {
 	keyspace string
 
 	table string
+
+	// proto v5+
+	id []byte
 }
 
 func (r preparedMetadata) String() string {
@@ -951,6 +954,10 @@ func (r preparedMetadata) String() string {
 func (f *framer) parsePreparedMetadata() preparedMetadata {
 	// TODO: deduplicate this from parseMetadata
 	meta := preparedMetadata{}
+
+	if f.proto > protoVersion4 {
+		meta.id = copyBytes(f.readShortBytes())
+	}
 
 	meta.flags = f.readInt()
 	meta.colCount = f.readInt()
@@ -1604,6 +1611,9 @@ type writeExecuteFrame struct {
 
 	// v4+
 	customPayload map[string][]byte
+
+	// v5+
+	preparedMetadataID []byte
 }
 
 func (e *writeExecuteFrame) String() string {
@@ -1611,16 +1621,21 @@ func (e *writeExecuteFrame) String() string {
 }
 
 func (e *writeExecuteFrame) buildFrame(fr *framer, streamID int) error {
-	return fr.writeExecuteFrame(streamID, e.preparedID, &e.params, &e.customPayload)
+	return fr.writeExecuteFrame(streamID, e.preparedID, e.preparedMetadataID, &e.params, &e.customPayload)
 }
 
-func (f *framer) writeExecuteFrame(streamID int, preparedID []byte, params *queryParams, customPayload *map[string][]byte) error {
+func (f *framer) writeExecuteFrame(streamID int, preparedID, preparedMetadataID []byte, params *queryParams, customPayload *map[string][]byte) error {
 	if len(*customPayload) > 0 {
 		f.payload()
 	}
 	f.writeHeader(f.flags, opExecute, streamID)
 	f.writeCustomPayload(customPayload)
 	f.writeShortBytes(preparedID)
+
+	if f.proto > protoVersion4 {
+		f.writeShortBytes(preparedMetadataID)
+	}
+
 	if f.proto > protoVersion1 {
 		f.writeQueryParams(params)
 	} else {

--- a/frame_test.go
+++ b/frame_test.go
@@ -135,11 +135,11 @@ func Test_framer_writeExecuteFrame_preparedMetadataID(t *testing.T) {
 		customPayload: map[string][]byte{
 			"key1": []byte("value1"),
 		},
-		preparedMetadataID: []byte{4, 5, 6},
+		resultMetadataID: []byte{4, 5, 6},
 	}
 
 	expectedStreamID := 123
-	err := f.writeExecuteFrame(expectedStreamID, frame.preparedID, frame.preparedMetadataID, &frame.params, &frame.customPayload)
+	err := f.writeExecuteFrame(expectedStreamID, frame.preparedID, frame.resultMetadataID, &frame.params, &frame.customPayload)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,5 +149,5 @@ func Test_framer_writeExecuteFrame_preparedMetadataID(t *testing.T) {
 
 	assertDeepEqual(t, "customPayload", frame.customPayload, f.readBytesMap())
 	assertDeepEqual(t, "preparedID", frame.preparedID, f.readShortBytes())
-	assertDeepEqual(t, "preparedMetadataID", frame.preparedMetadataID, f.readShortBytes())
+	assertDeepEqual(t, "resultMetadataID", frame.resultMetadataID, f.readShortBytes())
 }

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -100,3 +100,20 @@ func (p *preparedLRU) evictPreparedID(key string, id []byte) {
 	}
 
 }
+
+func (p *preparedLRU) get(key string) (*inflightPrepare, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	val, ok := p.lru.Get(key)
+	if !ok {
+		return nil, false
+	}
+
+	ifp, ok := val.(*inflightPrepare)
+	if !ok {
+		return nil, false
+	}
+
+	return ifp, true
+}


### PR DESCRIPTION
This PR provides support for the `result_metadata_id` field in **[PREPARED](https://github.com/apache/cassandra/blob/315cbac25503e61c6f0832f12177cebe88698445/doc/native_protocol_v5.spec#L603)** response and **[EXECUTE](https://github.com/apache/cassandra/blob/315cbac25503e61c6f0832f12177cebe88698445/doc/native_protocol_v5.spec#L899)** messages.
This PR is part of Native Protocol v5 support.