### PR TITLE
CASSGO-6 'Unable to discover cluster nodes with an empty rack name' issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactoring hostpool package test and Expose HostInfo creation (CASSGO-59)
 
+- Unable to discover cluster nodes with an empty rack name (CASSGO-6)
+
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -25,6 +25,7 @@
 package gocql
 
 import (
+	"errors"
 	"net"
 	"reflect"
 	"testing"
@@ -79,4 +80,60 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
 	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
 	assertEqual(t, "translated port", 5432, newPort)
+}
+
+func TestEmptyRack(t *testing.T) {
+	s := &Session{}
+	host := &HostInfo{}
+
+	row := make(map[string]interface{})
+
+	row["preferred_ip"] = "172.3.0.2"
+	row["rpc_address"] = "172.3.0.2"
+	row["host_id"] = UUIDFromTime(time.Now())
+	row["data_center"] = "dc1"
+	row["tokens"] = []string{"t1", "t2"}
+	row["rack"] = "rack1"
+
+	validHost, err := s.hostInfoFromMap(row, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isValidPeer(validHost) {
+		t.Fatal(errors.New("expected valid host"))
+	}
+
+	row["rack"] = ""
+
+	validHost, err = s.hostInfoFromMap(row, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isValidPeer(validHost) {
+		t.Fatal(errors.New("expected valid host"))
+	}
+
+	strPtr := new(string)
+	*strPtr = "rack"
+	row["rack"] = strPtr
+
+	validHost, err = s.hostInfoFromMap(row, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isValidPeer(validHost) {
+		t.Fatal(errors.New("expected valid host"))
+	}
+
+	strPtr = new(string)
+	strPtr = nil
+	row["rack"] = strPtr
+
+	validHost, err = s.hostInfoFromMap(row, host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isValidPeer(validHost) {
+		t.Fatal(errors.New("expected invalid host"))
+	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -332,23 +332,29 @@ func (iter *Iter) RowData() (RowData, error) {
 	values := make([]interface{}, 0, len(iter.Columns()))
 
 	for _, column := range iter.Columns() {
-		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
-			val, err := column.TypeInfo.NewWithError()
-			if err != nil {
-				iter.err = err
-				return RowData{}, err
-			}
+		if column.Name == "rack" && column.Keyspace == "system" && (column.Table == "peers_v2" || column.Table == "peers") {
+			var strPtr = new(string)
 			columns = append(columns, column.Name)
-			values = append(values, val)
+			values = append(values, &strPtr)
 		} else {
-			for i, elem := range c.Elems {
-				columns = append(columns, TupleColumnName(column.Name, i))
-				val, err := elem.NewWithError()
+			if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
+				val, err := column.TypeInfo.NewWithError()
 				if err != nil {
 					iter.err = err
 					return RowData{}, err
 				}
+				columns = append(columns, column.Name)
 				values = append(values, val)
+			} else {
+				for i, elem := range c.Elems {
+					columns = append(columns, TupleColumnName(column.Name, i))
+					val, err := elem.NewWithError()
+					if err != nil {
+						iter.err = err
+						return RowData{}, err
+					}
+					values = append(values, val)
+				}
 			}
 		}
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -179,6 +179,7 @@ type HostInfo struct {
 	state            nodeState
 	schemaVersion    string
 	tokens           []string
+	isRackNil        bool
 }
 
 // NewHostInfo creates HostInfo with provided connectAddress and port.
@@ -511,9 +512,18 @@ func (s *Session) hostInfoFromMap(row map[string]interface{}, host *HostInfo) (*
 				return nil, fmt.Errorf(assertErrorMsg, "data_center")
 			}
 		case "rack":
-			host.rack, ok = value.(string)
+			rack, ok := value.(*string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "rack")
+				host.rack, ok = value.(string)
+				if !ok {
+					return nil, fmt.Errorf(assertErrorMsg, "rack")
+				}
+			} else {
+				if rack != nil {
+					host.rack = *rack
+				} else {
+					host.isRackNil = true
+				}
 			}
 		case "host_id":
 			hostId, ok := value.(UUID)
@@ -703,7 +713,7 @@ func isValidPeer(host *HostInfo) bool {
 	return !(len(host.RPCAddress()) == 0 ||
 		host.hostId == "" ||
 		host.dataCenter == "" ||
-		host.rack == "" ||
+		host.isRackNil ||
 		len(host.tokens) == 0)
 }
 


### PR DESCRIPTION
This PR addresses issue #1706.

The driver was unable to discover nodes with an empty rack name because the `isValidPeer()` function incorrectly checked for an empty string in the rack value (which is a valid case). The correct validation should ensure the rack name is not null (as a null value indicates an invalid peer).

This PR fixes the method of retrieving the rack value from the `system.peers` and `system.peers_v2` tables. Now, the rack value is set as a pointer to a string, allowing the value to be checked for null.