### PR TITLE
fix: set useSystemSchema before policy setup

### DIFF
--- a/session.go
+++ b/session.go
@@ -13,7 +13,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the Lficense.
+ * limitations under the License.
  */
 /*
  * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40


### PR DESCRIPTION
During `NewSession` followed by `init`, 

 `AddHosts` is called in the policy before `useSystemSchema`  is set.
```
if v, ok := s.policy.(bulkAddHosts); ok {
		v.AddHosts(hosts)
	}
```

 So, `getKeyspaceMetadata` called by `updateReplicas` during `AddHosts` will take `useSystemSchema=false` and so 2nd query `system.schema_keyspaces` is called instead of `system_schema.keyspaces`.
 
```
 func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetadata, error) {
	keyspace := &KeyspaceMetadata{Name: keyspaceName}

	if session.useSystemSchema { // Cassandra 3.x+
		const stmt = `
		SELECT durable_writes, replication
		FROM system_schema.keyspaces
		WHERE keyspace_name = ?`
		.......................
        } else {
		const stmt = `
		SELECT durable_writes, strategy_class, strategy_options
		FROM system.schema_keyspaces
		WHERE keyspace_name = ?`	
                .......................
         } 
    	
```

so was getting following issue

```
control: error executing "In\t\tSELECT durable_writes, strategy_class, strategy-options\n
It\tFROM system.schema_keyspaces\n\t\tWHERE keyspace_name = ?": table system. schema_keyspa
ces does not exist
```