### PR TITLE
CASSGO-18 Add MutualTls authenticators to defaultApprovedAuthenticators

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -46,6 +46,8 @@ import (
 var (
 	defaultApprovedAuthenticators = []string{
 		"org.apache.cassandra.auth.PasswordAuthenticator",
+		"org.apache.cassandra.auth.MutualTlsAuthenticator",
+		"org.apache.cassandra.auth.MutualTlsWithPasswordFallbackAuthenticator",
 		"com.instaclustr.cassandra.auth.SharedSecretAuthenticator",
 		"com.datastax.bdp.cassandra.auth.DseAuthenticator",
 		"io.aiven.cassandra.auth.AivenAuthenticator",

--- a/conn_test.go
+++ b/conn_test.go
@@ -56,6 +56,8 @@ const (
 func TestApprove(t *testing.T) {
 	tests := map[bool]bool{
 		approve("org.apache.cassandra.auth.PasswordAuthenticator", []string{}):                                          true,
+		approve("org.apache.cassandra.auth.MutualTlsWithPasswordFallbackAuthenticator", []string{}):                     true,
+		approve("org.apache.cassandra.auth.MutualTlsAuthenticator", []string{}):                                         true,
 		approve("com.instaclustr.cassandra.auth.SharedSecretAuthenticator", []string{}):                                 true,
 		approve("com.datastax.bdp.cassandra.auth.DseAuthenticator", []string{}):                                         true,
 		approve("io.aiven.cassandra.auth.AivenAuthenticator", []string{}):                                               true,


### PR DESCRIPTION
Allow MutualTlsWithPasswordFallbackAuthenticator and MutualTlsAuthenticator as possible authenticators.

MutualTlsWithPasswordFallbackAuthenticator should behave functionally the same as PasswordAuthenticator.

MutualTlsAuthenticator's current implementation doesn't send AUTHENTICATE messages to the client, but felt it was worth including here in case it is ever enhanced to possibly also require credentials.

patch by Andy Tolbert; reviewed by Martin Sucha for CASSANDRA-19858