### PR TITLE
Add query interceptors

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -214,6 +214,14 @@ type ClusterConfig struct {
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
 	DisableSkipMetadata bool
 
+	// QueryInterceptor will set the provided query interceptor on all queries created from this session.
+	// Use it to intercept and modify queries by providing an implementation of QueryInterceptor.
+	QueryInterceptor QueryInterceptor
+
+	// QueryInterceptor will set the provided query interceptor on all queries created from this session.
+	// Use it to intercept and modify batches by providing an implementation of BatchInterceptor.
+	BatchInterceptor BatchInterceptor
+
 	// QueryObserver will set the provided query observer on all queries created from this session.
 	// Use it to collect metrics / stats from queries by providing an implementation of QueryObserver.
 	QueryObserver QueryObserver

--- a/doc.go
+++ b/doc.go
@@ -362,6 +362,26 @@
 //
 // See Example_userDefinedTypesMap, Example_userDefinedTypesStruct, ExampleUDTMarshaler, ExampleUDTUnmarshaler.
 //
+// # Query Interceptors
+//
+// Query Interceptors wrap query execution and can be used to inject logic that should apply to all query and batch
+// executions. For example, interceptors can be used for rate limiting, logging, attaching distributed tracing
+// metadata to the context, modifying queries, and inspecting query results.
+//
+// Interceptors are invoked once prior to query execution and are not re-invoked on retry attempts or speculative
+// execution attempts. Interceptors are responsible for calling the provided handler and returning a non-nil Iter
+// or error.
+//
+//	type MyQueryInterceptor struct {}
+//
+//	func (q MyQueryInterceptor) InterceptQuery(qry *gocql.Query, handler gocql.QueryHandler) (*gocql.Iter, error) {
+//	    return handler(qry.WithContext(context.WithValue(qry.Context(), "trace-id", "123")))
+//	}
+//
+//	func (q MyQueryInterceptor) InterceptBatch(batch *gocql.Batch, handler gocql.BatchHandler) (*gocql.Iter, error) {
+//	    return handler(batch.WithContext(context.WithValue(batch.Context(), "trace-id", "456")))
+//	}
+//
 // # Metrics and tracing
 //
 // It is possible to provide observer implementations that could be used to gather metrics:


### PR DESCRIPTION
This PR introduces `QueryInterceptor` and `BatchInterceptor` interfaces for intercepting queries immediately before execution, which allows clients to inject logic that should apply to all queries. My personal use case is `context` manipulation and conditionally enabling cassandra tracing, but the interfaces could be used for rate limiting, query modification, logging, fault injection, metrics, etc. 

The approach here is similar to https://github.com/apache/cassandra-gocql-driver/issues/1786, but intercepts at the higher query execution level rather than the query attempt/request level. I like the idea of intercepting attempts, but I think the nuances of request handling (retry policies, speculative execution, client side host selection) could lead to unexpected behavior. For example, rewriting and replacing a query via attempt interceptor would lose query retry metrics and violate the retry policy. Or rate limiting a speculative execution request via attempt interceptor would defeat the purpose of speculative execution. However, if an attempt interceptor is preferred, it would not be difficult to move the interception point. 