### PR TITLE
Update driver name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20' ]
+        go: [ '1.22', '1.23' ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19', '1.20' ]
-        cassandra_version: [ '4.0.8', '4.1.1' ]
+        go: [ '1.22', '1.23' ]
+        cassandra_version: [ '4.0.13', '4.1.6' ]
         auth: [ "false" ]
         compressor: [ "snappy" ]
         tags: [ "cassandra", "integration", "ccm" ]
@@ -125,8 +125,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.19', '1.20' ]
-        cassandra_version: [ '4.0.8' ]
+        go: [ '1.22', '1.23' ]
+        cassandra_version: [ '4.0.13' ]
         compressor: [ "snappy" ]
         tags: [ "integration" ]
 

--- a/version.go
+++ b/version.go
@@ -27,7 +27,7 @@ package gocql
 import "runtime/debug"
 
 const (
-	mainModule = "github.com/gocql/gocql"
+	mainModule = "github.com/apache/cassandra-gocql-driver"
 )
 
 var driverName string


### PR DESCRIPTION
Update the driver name to allow servers to clearly distinguish between gocql and cassandra-gocql-driver.  Note that something [similar was done](https://github.com/apache/cassandra-java-driver/commit/16260261d3df50fcf24fac1fc2d37896c4a111bf#diff-c45a71e429526ff721761d6a9f3fc0cec3f82a3c44c3f81a1c2ed0157a9f5d70) for the Java driver when it was donated.