### PR TITLE
CASSGO-39 Add query attempt interceptor

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -214,6 +214,10 @@ type ClusterConfig struct {
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
 	DisableSkipMetadata bool
 
+	// QueryAttemptInterceptor will set the provided query interceptor on all queries created from this session.
+	// Use it to intercept and modify queries by providing an implementation of QueryAttemptInterceptor.
+	QueryAttemptInterceptor QueryAttemptInterceptor
+
 	// QueryObserver will set the provided query observer on all queries created from this session.
 	// Use it to collect metrics / stats from queries by providing an implementation of QueryObserver.
 	QueryObserver QueryObserver

--- a/doc.go
+++ b/doc.go
@@ -362,6 +362,18 @@
 //
 // See Example_userDefinedTypesMap, Example_userDefinedTypesStruct, ExampleUDTMarshaler, ExampleUDTUnmarshaler.
 //
+// # Interceptors
+//
+// A QueryAttemptInterceptor wraps query execution and can be used to inject logic that should apply to all query
+// and batch execution attempts. For example, interceptors can be used for rate limiting, logging, attaching
+// distributed tracing metadata to the context, modifying queries, and inspecting query results.
+//
+// A QueryAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
+// and speculative execution attempts. Interceptors are responsible for calling the provided handler and returning
+// a non-nil Iter.
+//
+// See Example_interceptor for full example.
+//
 // # Metrics and tracing
 //
 // It is possible to provide observer implementations that could be used to gather metrics:

--- a/doc.go
+++ b/doc.go
@@ -370,7 +370,7 @@
 //
 // A QueryAttemptInterceptor will be invoked once prior to each query execution attempt, including retry attempts
 // and speculative execution attempts. Interceptors are responsible for calling the provided handler and returning
-// a non-nil Iter.
+// a non-nil Iter or an error.
 //
 // See Example_interceptor for full example.
 //

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -55,7 +55,7 @@ func (q MyQueryAttemptInterceptor) Intercept(
 
 	// Optionally bypass the handler and return an error to prevent query execution.
 	// For example, to simulate query timeouts.
-	if q.injectFault && attempt.Number == 1 {
+	if q.injectFault && attempt.Attempts == 0 {
 		<-time.After(1 * time.Second)
 		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
 	}

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2016, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
+package gocql_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	gocql "github.com/gocql/gocql"
+)
+
+type MyQueryAttemptInterceptor struct {
+	injectFault bool
+}
+
+func (q MyQueryAttemptInterceptor) Intercept(
+	ctx context.Context,
+	query gocql.ExecutableQuery,
+	conn *gocql.Conn,
+	handler gocql.QueryAttemptHandler,
+) *gocql.Iter {
+	switch q := query.(type) {
+	case *gocql.Query:
+		// Inspect or modify query
+		query = q
+	case *gocql.Batch:
+		// Inspect or modify batch
+		query = q
+	}
+
+	// Inspect or modify context
+	ctx = context.WithValue(ctx, "trace-id", "123")
+
+	// Optionally bypass the handler and return an error to prevent query execution.
+	// For example, to simulate query timeouts.
+	if q.injectFault && query.Attempts() == 0 {
+		<-time.After(1 * time.Second)
+		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
+	}
+
+	// The interceptor *must* invoke the handler to execute the query.
+	return handler(ctx, query, conn)
+}
+
+// Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.
+func Example_interceptor() {
+	cluster := gocql.NewCluster("localhost:9042")
+	cluster.QueryAttemptInterceptor = MyQueryAttemptInterceptor{injectFault: true}
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer session.Close()
+
+	ctx := context.Background()
+
+	var stringValue string
+	err = session.Query("select now() from system.local").
+		WithContext(ctx).
+		RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 2}).
+		Scan(&stringValue)
+	if err != nil {
+		log.Fatalf("query failed %T", err)
+	}
+	fmt.Println(stringValue)
+	// Output: MOOOO!
+}

--- a/example_interceptor_test.go
+++ b/example_interceptor_test.go
@@ -40,7 +40,7 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	ctx context.Context,
 	attempt gocql.QueryAttempt,
 	handler gocql.QueryAttemptHandler,
-) *gocql.Iter {
+) (*gocql.Iter, error) {
 	switch q := attempt.Query.(type) {
 	case *gocql.Query:
 		// Inspect or modify query
@@ -57,11 +57,11 @@ func (q MyQueryAttemptInterceptor) Intercept(
 	// For example, to simulate query timeouts.
 	if q.injectFault && attempt.Attempts == 0 {
 		<-time.After(1 * time.Second)
-		return gocql.NewIterWithErr(gocql.RequestErrWriteTimeout{})
+		return nil, gocql.RequestErrWriteTimeout{}
 	}
 
 	// The interceptor *must* invoke the handler to execute the query.
-	return handler(ctx, attempt)
+	return handler(ctx, attempt), nil
 }
 
 // Example_interceptor demonstrates how to implement a QueryAttemptInterceptor.

--- a/query_executor.go
+++ b/query_executor.go
@@ -82,7 +82,6 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry ExecutableQuery, c
 		})
 	} else {
 		iter = qry.execute(ctx, conn)
-		return iter
 	}
 
 	end := time.Now()

--- a/query_executor.go
+++ b/query_executor.go
@@ -65,7 +65,7 @@ type QueryAttempt struct {
 }
 
 // QueryAttemptHandler is a function that attempts query execution.
-type QueryAttemptHandler = func(context.Context, QueryAttempt) *Iter
+type QueryAttemptHandler = func(context.Context, QueryAttempt) (*Iter, error)
 
 // QueryAttemptInterceptor is the interface implemented by query interceptors / middleware.
 //
@@ -93,9 +93,10 @@ func (q *queryExecutor) attemptQuery(ctx context.Context, qry ExecutableQuery, c
 			Host:     conn.host,
 			Attempts: qry.Attempts(),
 		}
-		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) *Iter {
+		iter, err = q.interceptor.Intercept(_ctx, attempt, func(_ctx context.Context, attempt QueryAttempt) (*Iter, error) {
 			ctx = _ctx
-			return attempt.Query.execute(ctx, attempt.Conn)
+			iter := attempt.Query.execute(ctx, attempt.Conn)
+			return iter, iter.err
 		})
 		if err != nil {
 			iter = &Iter{err: err}

--- a/session.go
+++ b/session.go
@@ -1449,11 +1449,6 @@ func (iter *Iter) Columns() []ColumnInfo {
 	return iter.meta.columns
 }
 
-// NewIterWithErr return a new *Iter with an error.
-func NewIterWithErr(err error) *Iter {
-	return &Iter{err: err}
-}
-
 type Scanner interface {
 	// Next advances the row pointer to point at the next row, the row is valid until
 	// the next call of Next. It returns true if there is a row which is available to be


### PR DESCRIPTION
As suggested in https://github.com/apache/cassandra-gocql-driver/issues/1786, this PR introduces a `QueryAttemptInterceptor` interface for intercepting query attempts, which allows clients to inject logic that should apply to all queries e.g. context manipulation, rate limiting, query modification, logging, fault injection, metrics, etc.

Alternative to https://github.com/apache/cassandra-gocql-driver/pull/1810. 