### PR TITLE
CASSGO-1 CASSGO-30 Native Protocol 5 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,12 @@ jobs:
         go: [ '1.22', '1.23' ]
         cassandra_version: [ '4.0.13', '4.1.6' ]
         auth: [ "false" ]
-        compressor: [ "snappy" ]
+        compressor: [ "no-compression", "snappy", "lz4" ]
         tags: [ "cassandra", "integration", "ccm" ]
+        proto_version: [ "4", "5" ]
+        exclude:
+          - proto_version: "5"
+            compressor: "snappy"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -102,7 +106,7 @@ jobs:
           ccm status
           ccm node1 nodetool status
 
-          args="-gocql.timeout=60s -runssl -proto=4 -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${{ matrix.compressor }} -gocql.cversion=$VERSION -cluster=$(ccm liveset) ./..."
+          args="-gocql.timeout=60s -runssl -proto=${{ matrix.proto_version }} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${{ matrix.compressor }} -gocql.cversion=$VERSION -cluster=$(ccm liveset) ./..."
 
           echo "args=$args" >> $GITHUB_ENV
           echo "JVM_EXTRA_OPTS=$JVM_EXTRA_OPTS" >> $GITHUB_ENV
@@ -115,7 +119,7 @@ jobs:
         if: 'failure()'
         uses: actions/upload-artifact@v4
         with:
-          name: ccm-cluster-cassandra-${{ matrix.cassandra_version }}-go-${{ matrix.go }}-tag-${{ matrix.tags }}
+          name: ccm-cluster-cassandra-${{ matrix.cassandra_version }}-go-${{ matrix.go }}-tag-${{ matrix.tags }}-proto-version-${{ matrix.proto_version }}-compressor-${{ matrix.compressor }}
           path: /home/runner/.ccm/test
           retention-days: 5
   integration-auth-cassandra:
@@ -129,9 +133,12 @@ jobs:
       matrix:
         go: [ '1.22', '1.23' ]
         cassandra_version: [ '4.0.13' ]
-        compressor: [ "snappy" ]
+        compressor: [ "no-compression", "snappy", "lz4" ]
         tags: [ "integration" ]
-
+        proto_version: [ "4", "5" ]
+        exclude:
+          - proto_version: "5"
+            compressor: "snappy"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -193,7 +200,7 @@ jobs:
           ccm status
           ccm node1 nodetool status
 
-          args="-gocql.timeout=60s -runssl -proto=4 -rf=3 -clusterSize=1 -autowait=2000ms -compressor=${{ matrix.compressor }} -gocql.cversion=$VERSION -cluster=$(ccm liveset) ./..."
+          args="-gocql.timeout=60s -runssl -proto=${{ matrix.proto_version }} -rf=3 -clusterSize=1 -autowait=2000ms -compressor=${{ matrix.compressor }} -gocql.cversion=$VERSION -cluster=$(ccm liveset) ./..."
 
           echo "args=$args" >> $GITHUB_ENV
           echo "JVM_EXTRA_OPTS=$JVM_EXTRA_OPTS" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support of sending queries to the specific node with Query.SetHostID() (CASSGO-4)
 
+- Support for Native Protocol 5. Following protocol changes exposed new API 
+  Query.SetKeyspace(), Query.WithNowInSeconds(), Batch.SetKeyspace(), Batch.WithNowInSeconds() (CASSGO-1)
+
 ### Changed
 
 - Move lz4 compressor to lz4 package within the gocql module (CASSGO-32)
@@ -40,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized spelling of datacenter (CASSGO-35)
 
 - Refactor HostInfo creation and ConnectAddress() method (CASSGO-45)
+
+- gocql.Compressor interface changes to follow append-like design. Bumped Go version to 1.19 (CASSGO-1)
 
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1585,7 +1585,7 @@ func TestQueryInfo(t *testing.T) {
 	defer session.Close()
 
 	conn := getRandomConn(t, session)
-	info, err := conn.prepareStatement(context.Background(), "SELECT release_version, host_id FROM system.local WHERE key = ?", nil)
+	info, err := conn.prepareStatement(context.Background(), "SELECT release_version, host_id FROM system.local WHERE key = ?", nil, conn.currentKeyspace)
 
 	if err != nil {
 		t.Fatalf("Failed to execute query for preparing statement: %v", err)
@@ -2675,7 +2675,7 @@ func TestRoutingKey(t *testing.T) {
 		t.Fatalf("failed to create table with error '%v'", err)
 	}
 
-	routingKeyInfo, err := session.routingKeyInfo(context.Background(), "SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?")
+	routingKeyInfo, err := session.routingKeyInfo(context.Background(), "SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?", "")
 	if err != nil {
 		t.Fatalf("failed to get routing key info due to error: %v", err)
 	}
@@ -2699,7 +2699,7 @@ func TestRoutingKey(t *testing.T) {
 	}
 
 	// verify the cache is working
-	routingKeyInfo, err = session.routingKeyInfo(context.Background(), "SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?")
+	routingKeyInfo, err = session.routingKeyInfo(context.Background(), "SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?", "")
 	if err != nil {
 		t.Fatalf("failed to get routing key info due to error: %v", err)
 	}
@@ -2733,7 +2733,7 @@ func TestRoutingKey(t *testing.T) {
 		t.Errorf("Expected routing key %v but was %v", expectedRoutingKey, routingKey)
 	}
 
-	routingKeyInfo, err = session.routingKeyInfo(context.Background(), "SELECT * FROM test_composite_routing_key WHERE second_id=? AND first_id=?")
+	routingKeyInfo, err = session.routingKeyInfo(context.Background(), "SELECT * FROM test_composite_routing_key WHERE second_id=? AND first_id=?", "")
 	if err != nil {
 		t.Fatalf("failed to get routing key info due to error: %v", err)
 	}
@@ -3256,6 +3256,10 @@ func TestCreateSession_DontSwallowError(t *testing.T) {
 func TestControl_DiscoverProtocol(t *testing.T) {
 	cluster := createCluster()
 	cluster.ProtoVersion = 0
+	// Forcing to run this test without any compression.
+	// If compressor is presented, then CI will fail when snappy compression is enabled, since
+	// protocol v5 doesn't support it.
+	cluster.Compressor = nil
 
 	session, err := cluster.CreateSession()
 	if err != nil {
@@ -3409,4 +3413,459 @@ func TestQuery_SetHostID(t *testing.T) {
 	if !errors.Is(err, ErrNoConnections) {
 		t.Fatalf("Expected error to be: %v, but got %v", ErrNoConnections, err)
 	}
+}
+
+func TestQuery_WithNowInSeconds(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if session.cfg.ProtoVersion < protoVersion5 {
+		t.Skip("Query now in seconds are only available on protocol >= 5")
+	}
+
+	if err := createTable(session, `CREATE TABLE IF NOT EXISTS query_now_in_seconds (id int primary key, val text)`); err != nil {
+		t.Fatal(err)
+	}
+
+	err := session.Query("INSERT INTO query_now_in_seconds (id, val) VALUES (?, ?) USING TTL 20", 1, "val").
+		WithNowInSeconds(int(0)).
+		Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var remainingTTL int
+	err = session.Query(`SELECT TTL(val) FROM query_now_in_seconds WHERE id = ?`, 1).
+		WithNowInSeconds(10).
+		Scan(&remainingTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, remainingTTL, 10)
+}
+
+func TestQuery_SetKeyspace(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if session.cfg.ProtoVersion < protoVersion5 {
+		t.Skip("keyspace for QUERY message is not supported in protocol < 5")
+	}
+
+	const keyspaceStmt = `
+		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test 
+		WITH replication = {
+			'class': 'SimpleStrategy', 
+			'replication_factor': '1'
+		};
+`
+
+	err := session.Query(keyspaceStmt).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, "CREATE TABLE IF NOT EXISTS gocql_query_keyspace_override_test.query_keyspace(id int, value text, PRIMARY KEY (id))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedID := 1
+	expectedText := "text"
+
+	// Testing PREPARE message
+	err = session.Query("INSERT INTO gocql_query_keyspace_override_test.query_keyspace (id, value) VALUES (?, ?)", expectedID, expectedText).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		id   int
+		text string
+	)
+
+	q := session.Query("SELECT * FROM gocql_query_keyspace_override_test.query_keyspace").
+		SetKeyspace("gocql_query_keyspace_override_test")
+	err = q.Scan(&id, &text)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, expectedID, id)
+	require.Equal(t, expectedText, text)
+
+	// Testing QUERY message
+	id = 0
+	text = ""
+
+	q = session.Query("SELECT * FROM gocql_query_keyspace_override_test.query_keyspace").
+		SetKeyspace("gocql_query_keyspace_override_test")
+	q.skipPrepare = true
+	err = q.Scan(&id, &text)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, expectedID, id)
+	require.Equal(t, expectedText, text)
+}
+
+// TestLargeSizeQuery runs a query bigger than the max allowed size of the payload of a frame,
+// so it should be sent as 2 different frames where each contains a self-contained bit set to zero.
+func TestLargeSizeQuery(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.large_size_query(id int, text_col text, PRIMARY KEY (id))"); err != nil {
+		t.Fatal(err)
+	}
+
+	longString := strings.Repeat("a", 500_000)
+
+	err := session.Query("INSERT INTO gocql_test.large_size_query (id, text_col) VALUES (?, ?)", "1", longString).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result string
+	err = session.Query("SELECT text_col FROM gocql_test.large_size_query").Scan(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, longString, result)
+}
+
+// TestQueryCompressionNotWorthIt runs a query that is not likely to be compressed efficiently
+// (uncompressed payload size > compressed payload size).
+// So, it should send a Compressed Frame where:
+//  1. Compressed length is set to the length of the uncompressed payload;
+//  2. Uncompressed length is set to zero;
+//  3. Payload is the uncompressed payload.
+func TestQueryCompressionNotWorthIt(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.compression_now_worth_it(id int, text_col text, PRIMARY KEY (id))"); err != nil {
+		t.Fatal(err)
+	}
+
+	str := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*()_+"
+	err := session.Query("INSERT INTO gocql_test.large_size_query (id, text_col) VALUES (?, ?)", "1", str).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result string
+	err = session.Query("SELECT text_col FROM gocql_test.large_size_query").Scan(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, str, result)
+}
+
+// This test ensures that the whole Metadata_changed flow
+// is handled properly.
+//
+// To trigger C* to return Metadata_changed we should do:
+//  1. Create a table
+//  2. Prepare stmt which uses the created table
+//  3. Change the table schema in order to affect prepared stmt (e.g. add a column)
+//  4. Execute prepared stmt. As a result C* should return RESULT/ROWS response with
+//     Metadata_changed flag, new metadata id and updated metadata resultset.
+//
+// The driver should handle this by updating its prepared statement inside the cache
+// when it receives RESULT/ROWS with Metadata_changed flag
+func TestPrepareExecuteMetadataChangedFlag(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if session.cfg.ProtoVersion < protoVersion5 {
+		t.Skip("Metadata_changed mechanism is only available in proto > 4")
+	}
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.metadata_changed(id int, PRIMARY KEY (id))"); err != nil {
+		t.Fatal(err)
+	}
+
+	type record struct {
+		id     int
+		newCol int
+	}
+
+	firstRecord := record{
+		id: 1,
+	}
+	err := session.Query("INSERT INTO gocql_test.metadata_changed (id) VALUES (?)", firstRecord.id).Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We have to specify conn for all queries to ensure that
+	// all queries are running on the same node
+	conn := session.getConn()
+
+	const selectStmt = "SELECT * FROM gocql_test.metadata_changed"
+	queryBeforeTableAltering := session.Query(selectStmt)
+	queryBeforeTableAltering.conn = conn
+	row := make(map[string]interface{})
+	err = queryBeforeTableAltering.MapScan(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Len(t, row, 1, "Expected to retrieve a single column")
+	require.Equal(t, 1, row["id"])
+
+	stmtCacheKey := session.stmtsLRU.keyFor(conn.host.HostID(), conn.currentKeyspace, queryBeforeTableAltering.stmt)
+	inflight, _ := session.stmtsLRU.get(stmtCacheKey)
+	preparedStatementBeforeTableAltering := inflight.preparedStatment
+
+	// Changing table schema in order to cause C* to return RESULT/ROWS Metadata_changed
+	alteringTableQuery := session.Query("ALTER TABLE gocql_test.metadata_changed ADD new_col int")
+	alteringTableQuery.conn = conn
+	err = alteringTableQuery.Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondRecord := record{
+		id:     2,
+		newCol: 10,
+	}
+	err = session.Query("INSERT INTO gocql_test.metadata_changed (id, new_col) VALUES (?, ?)", secondRecord.id, secondRecord.newCol).
+		Exec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Handles result from iter and ensures integrity of the result,
+	// closes iter and handles error
+	handleRows := func(iter *Iter) {
+		t.Helper()
+
+		var scannedID int
+		var scannedNewCol *int // to perform null values
+
+		// when the driver handling null values during unmarshalling
+		// it sets to dest type its zero value, which is (*int)(nil) for this case
+		var nilIntPtr *int
+
+		// Scanning first row
+		if iter.Scan(&scannedID, &scannedNewCol) {
+			require.Equal(t, firstRecord.id, scannedID)
+			require.Equal(t, nilIntPtr, scannedNewCol)
+		}
+
+		// Scanning second row
+		if iter.Scan(&scannedID, &scannedNewCol) {
+			require.Equal(t, secondRecord.id, scannedID)
+			require.Equal(t, &secondRecord.newCol, scannedNewCol)
+		}
+
+		err := iter.Close()
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Fatal("It is likely failed due deadlock")
+			}
+			t.Fatal(err)
+		}
+	}
+
+	// Expecting C* will return RESULT/ROWS Metadata_changed
+	// and it will be properly handled
+	queryAfterTableAltering := session.Query(selectStmt)
+	queryAfterTableAltering.conn = conn
+	iter := queryAfterTableAltering.Iter()
+	handleRows(iter)
+
+	// Ensuring if cache contains updated prepared statement
+	inflight, _ = session.stmtsLRU.get(stmtCacheKey)
+	preparedStatementAfterTableAltering := inflight.preparedStatment
+	require.NotEqual(t, preparedStatementBeforeTableAltering.resultMetadataID, preparedStatementAfterTableAltering.resultMetadataID)
+	require.NotEqual(t, preparedStatementBeforeTableAltering.response, preparedStatementAfterTableAltering.response)
+
+	// FORCE SEND OLD RESULT METADATA ID (https://issues.apache.org/jira/browse/CASSANDRA-20028)
+	closedCh := make(chan struct{})
+	close(closedCh)
+	session.stmtsLRU.add(stmtCacheKey, &inflightPrepare{
+		done:             closedCh,
+		err:              nil,
+		preparedStatment: preparedStatementBeforeTableAltering,
+	})
+
+	// Running query with timeout to ensure there is no deadlocks.
+	// However, it doesn't 100% proves that there is a deadlock...
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	queryAfterTableAltering2 := session.Query(selectStmt).WithContext(ctx)
+	queryAfterTableAltering2.conn = conn
+	iter = queryAfterTableAltering2.Iter()
+	handleRows(iter)
+	err = iter.Close()
+
+	inflight, _ = session.stmtsLRU.get(stmtCacheKey)
+	preparedStatementAfterTableAltering2 := inflight.preparedStatment
+	require.NotEqual(t, preparedStatementBeforeTableAltering.resultMetadataID, preparedStatementAfterTableAltering2.resultMetadataID)
+	require.NotEqual(t, preparedStatementBeforeTableAltering.response, preparedStatementAfterTableAltering2.response)
+
+	require.Equal(t, preparedStatementAfterTableAltering.resultMetadataID, preparedStatementAfterTableAltering2.resultMetadataID)
+	require.NotEqual(t, preparedStatementAfterTableAltering.response, preparedStatementAfterTableAltering2.response) // METADATA_CHANGED flag
+	require.True(t, preparedStatementAfterTableAltering2.response.flags&flagMetaDataChanged != 0)
+
+	// Executing prepared stmt and expecting that C* won't return
+	// Metadata_changed because the table is not being changed.
+	queryAfterTableAltering3 := session.Query(selectStmt).WithContext(ctx)
+	queryAfterTableAltering3.conn = conn
+	iter = queryAfterTableAltering2.Iter()
+	handleRows(iter)
+
+	// Ensuring metadata of prepared stmt is not changed
+	inflight, _ = session.stmtsLRU.get(stmtCacheKey)
+	preparedStatementAfterTableAltering3 := inflight.preparedStatment
+	require.Equal(t, preparedStatementAfterTableAltering2.resultMetadataID, preparedStatementAfterTableAltering3.resultMetadataID)
+	require.Equal(t, preparedStatementAfterTableAltering2.response, preparedStatementAfterTableAltering3.response)
+}
+
+func TestStmtCacheUsesOverriddenKeyspace(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if session.cfg.ProtoVersion < protoVersion5 {
+		t.Skip("This tests only runs on proto > 4 due SetKeyspace availability")
+	}
+
+	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+	WITH replication = {
+		'class' : 'SimpleStrategy',
+			'replication_factor' : 1
+	}`
+
+	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_stmt_cache"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.stmt_cache_uses_overridden_ks(id int, PRIMARY KEY (id))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test_stmt_cache.stmt_cache_uses_overridden_ks(id int, PRIMARY KEY (id))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const insertQuery = "INSERT INTO stmt_cache_uses_overridden_ks (id) VALUES (?)"
+
+	// Inserting data via Batch to ensure that batches
+	// properly accounts for keyspace overriding
+	b1 := session.NewBatch(LoggedBatch)
+	b1.Query(insertQuery, 1)
+	err = session.ExecuteBatch(b1)
+	require.NoError(t, err)
+
+	b2 := session.NewBatch(LoggedBatch)
+	b2.SetKeyspace("gocql_test_stmt_cache")
+	b2.Query(insertQuery, 2)
+	err = session.ExecuteBatch(b2)
+	require.NoError(t, err)
+
+	var scannedID int
+
+	const selectStmt = "SELECT * FROM stmt_cache_uses_overridden_ks"
+
+	// By default in our test suite session uses gocql_test ks
+	err = session.Query(selectStmt).Scan(&scannedID)
+	require.NoError(t, err)
+	require.Equal(t, 1, scannedID)
+
+	scannedID = 0
+	err = session.Query(selectStmt).SetKeyspace("gocql_test_stmt_cache").Scan(&scannedID)
+	require.NoError(t, err)
+	require.Equal(t, 2, scannedID)
+
+	session.Query("DROP KEYSPACE IF EXISTS gocql_test_stmt_cache").Exec()
+}
+
+func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if session.cfg.ProtoVersion < protoVersion5 {
+		t.Skip("This tests only runs on proto > 4 due SetKeyspace availability")
+	}
+
+	const createKeyspaceStmt = `CREATE KEYSPACE IF NOT EXISTS %s
+	WITH replication = {
+		'class' : 'SimpleStrategy',
+			'replication_factor' : 1
+	}`
+
+	err := createTable(session, fmt.Sprintf(createKeyspaceStmt, "gocql_test_routing_key_cache"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.routing_key_cache_uses_overridden_ks(id int, PRIMARY KEY (id))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test_routing_key_cache.routing_key_cache_uses_overridden_ks(id int, PRIMARY KEY (id))")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getRoutingKeyInfo := func(key string) *routingKeyInfo {
+		t.Helper()
+		session.routingKeyInfoCache.mu.Lock()
+		value, _ := session.routingKeyInfoCache.lru.Get(key)
+		session.routingKeyInfoCache.mu.Unlock()
+
+		inflight := value.(*inflightCachedEntry)
+		return inflight.value.(*routingKeyInfo)
+	}
+
+	const insertQuery = "INSERT INTO routing_key_cache_uses_overridden_ks (id) VALUES (?)"
+
+	// Running batch in default ks gocql_test
+	b1 := session.NewBatch(LoggedBatch)
+	b1.Query(insertQuery, 1)
+	_, err = b1.GetRoutingKey()
+	require.NoError(t, err)
+
+	// Ensuring that the cache contains the query with default ks
+	routingKeyInfo1 := getRoutingKeyInfo("gocql_test" + b1.Entries[0].Stmt)
+	require.Equal(t, "gocql_test", routingKeyInfo1.keyspace)
+
+	// Running batch in gocql_test_routing_key_cache ks
+	b2 := session.NewBatch(LoggedBatch)
+	b2.SetKeyspace("gocql_test_routing_key_cache")
+	b2.Query(insertQuery, 2)
+	_, err = b2.GetRoutingKey()
+	require.NoError(t, err)
+
+	// Ensuring that the cache contains the query with gocql_test_routing_key_cache ks
+	routingKeyInfo2 := getRoutingKeyInfo("gocql_test_routing_key_cache" + b2.Entries[0].Stmt)
+	require.Equal(t, "gocql_test_routing_key_cache", routingKeyInfo2.keyspace)
+
+	const selectStmt = "SELECT * FROM routing_key_cache_uses_overridden_ks WHERE id=?"
+
+	// Running query in default ks gocql_test
+	q1 := session.Query(selectStmt, 1)
+	_, err = q1.GetRoutingKey()
+	require.NoError(t, err)
+	require.Equal(t, "gocql_test", q1.routingInfo.keyspace)
+
+	// Running query in gocql_test_routing_key_cache ks
+	q2 := session.Query(selectStmt, 1)
+	_, err = q2.SetKeyspace("gocql_test_routing_key_cache").GetRoutingKey()
+	require.NoError(t, err)
+	require.Equal(t, "gocql_test_routing_key_cache", q2.routingInfo.keyspace)
+
+	session.Query("DROP KEYSPACE IF EXISTS gocql_test_routing_key_cache").Exec()
 }

--- a/common_test.go
+++ b/common_test.go
@@ -27,7 +27,6 @@ package gocql
 import (
 	"flag"
 	"fmt"
-	"github.com/gocql/gocql/lz4"
 	"log"
 	"net"
 	"reflect"
@@ -35,6 +34,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql/lz4"
 )
 
 var (
@@ -47,7 +48,7 @@ var (
 	flagAutoWait     = flag.Duration("autowait", 1000*time.Millisecond, "time to wait for autodiscovery to fill the hosts poll")
 	flagRunSslTest   = flag.Bool("runssl", false, "Set to true to run ssl test")
 	flagRunAuthTest  = flag.Bool("runauth", false, "Set to true to run authentication test")
-	flagCompressTest = flag.String("compressor", "", "compressor to use")
+	flagCompressTest = flag.String("compressor", "no-compression", "compressor to use")
 	flagTimeout      = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
 
 	flagCassVersion cassVersion
@@ -114,7 +115,7 @@ func createCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
 		cluster.Compressor = &SnappyCompressor{}
 	case "lz4":
 		cluster.Compressor = &lz4.LZ4Compressor{}
-	case "":
+	case "no-compression":
 	default:
 		panic("invalid compressor: " + *flagCompressTest)
 	}

--- a/compressor.go
+++ b/compressor.go
@@ -24,14 +24,28 @@
 
 package gocql
 
-import (
-	"github.com/golang/snappy"
-)
+import "github.com/golang/snappy"
 
 type Compressor interface {
 	Name() string
-	Encode(data []byte) ([]byte, error)
-	Decode(data []byte) ([]byte, error)
+
+	// AppendCompressedWithLength compresses src bytes, appends the length of the compressed bytes to dst
+	// and then appends the compressed bytes to dst.
+	// It returns a new byte slice that is the result of the append operation.
+	AppendCompressedWithLength(dst, src []byte) ([]byte, error)
+
+	// AppendDecompressedWithLength reads the length of the decompressed bytes from src,
+	// decompressed bytes from src and appends the decompressed bytes to dst.
+	// It returns a new byte slice that is the result of the append operation.
+	AppendDecompressedWithLength(dst, src []byte) ([]byte, error)
+
+	// AppendCompressed compresses src bytes and appends the compressed bytes to dst.
+	// It returns a new byte slice that is the result of the append operation.
+	AppendCompressed(dst, src []byte) ([]byte, error)
+
+	// AppendDecompressed decompresses bytes from src and appends the decompressed bytes to dst.
+	// It returns a new byte slice that is the result of the append operation.
+	AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error)
 }
 
 // SnappyCompressor implements the Compressor interface and can be used to
@@ -43,10 +57,18 @@ func (s SnappyCompressor) Name() string {
 	return "snappy"
 }
 
-func (s SnappyCompressor) Encode(data []byte) ([]byte, error) {
-	return snappy.Encode(nil, data), nil
+func (s SnappyCompressor) AppendCompressedWithLength(dst, src []byte) ([]byte, error) {
+	return snappy.Encode(dst, src), nil
 }
 
-func (s SnappyCompressor) Decode(data []byte) ([]byte, error) {
-	return snappy.Decode(nil, data)
+func (s SnappyCompressor) AppendDecompressedWithLength(dst, src []byte) ([]byte, error) {
+	return snappy.Decode(dst, src)
+}
+
+func (s SnappyCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	panic("SnappyCompressor.AppendCompressed is not supported")
+}
+
+func (s SnappyCompressor) AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error) {
+	panic("SnappyCompressor.AppendDecompressed is not supported")
 }

--- a/compressor_test.go
+++ b/compressor_test.go
@@ -40,13 +40,13 @@ func TestSnappyCompressor(t *testing.T) {
 	str := "My Test String"
 	//Test Encoding
 	expected := snappy.Encode(nil, []byte(str))
-	if res, err := c.Encode([]byte(str)); err != nil {
+	if res, err := c.AppendCompressedWithLength(nil, []byte(str)); err != nil {
 		t.Fatalf("failed to encode '%v' with error %v", str, err)
 	} else if bytes.Compare(expected, res) != 0 {
 		t.Fatal("failed to match the expected encoded value with the result encoded value.")
 	}
 
-	val, err := c.Encode([]byte(str))
+	val, err := c.AppendCompressedWithLength(nil, []byte(str))
 	if err != nil {
 		t.Fatalf("failed to encode '%v' with error '%v'", str, err)
 	}
@@ -54,7 +54,7 @@ func TestSnappyCompressor(t *testing.T) {
 	//Test Decoding
 	if expected, err := snappy.Decode(nil, val); err != nil {
 		t.Fatalf("failed to decode '%v' with error %v", val, err)
-	} else if res, err := c.Decode(val); err != nil {
+	} else if res, err := c.AppendDecompressedWithLength(nil, val); err != nil {
 		t.Fatalf("failed to decode '%v' with error %v", val, err)
 	} else if bytes.Compare(expected, res) != 0 {
 		t.Fatal("failed to match the expected decoded value with the result decoded value.")

--- a/control.go
+++ b/control.go
@@ -225,7 +225,7 @@ func (c *controlConn) discoverProtocol(hosts []*HostInfo) (int, error) {
 	hosts = shuffleHosts(hosts)
 
 	connCfg := *c.session.connCfg
-	connCfg.ProtoVersion = 4 // TODO: define maxProtocol
+	connCfg.ProtoVersion = 5 // TODO: define maxProtocol
 
 	handler := connErrorHandlerFn(func(c *Conn, err error, closed bool) {
 		// we should never get here, but if we do it means we connected to a
@@ -303,7 +303,7 @@ type connHost struct {
 func (c *controlConn) setupConn(conn *Conn) error {
 	// we need up-to-date host info for the filterHost call below
 	iter := conn.querySystemLocal(context.TODO())
-	host, err := c.session.hostInfoFromIter(iter, conn.host.connectAddress, conn.conn.RemoteAddr().(*net.TCPAddr).Port)
+	host, err := c.session.hostInfoFromIter(iter, conn.host.connectAddress, conn.r.RemoteAddr().(*net.TCPAddr).Port)
 	if err != nil {
 		return err
 	}

--- a/crc.go
+++ b/crc.go
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"hash/crc32"
+)
+
+var (
+	// Initial CRC32 bytes: 0xFA, 0x2D, 0x55, 0xCA
+	initialCRC32Bytes = []byte{0xfa, 0x2d, 0x55, 0xca}
+)
+
+// Crc32 calculates the CRC32 checksum of the given byte slice.
+func Crc32(b []byte) uint32 {
+	crc := crc32.NewIEEE()
+	crc.Write(initialCRC32Bytes) // Include initial CRC32 bytes
+	crc.Write(b)
+	return crc.Sum32()
+}
+
+const (
+	crc24Init = 0x875060  // Initial value for CRC24 calculation
+	crc24Poly = 0x1974F0B // Polynomial for CRC24 calculation
+)
+
+// Crc24 calculates the CRC24 checksum using the Koopman polynomial.
+func Crc24(buf []byte) uint32 {
+	crc := crc24Init
+	for _, b := range buf {
+		crc ^= int(b) << 16
+
+		for i := 0; i < 8; i++ {
+			crc <<= 1
+			if crc&0x1000000 != 0 {
+				crc ^= crc24Poly
+			}
+		}
+	}
+
+	return uint32(crc)
+}

--- a/crc_test.go
+++ b/crc_test.go
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksumIEEE(t *testing.T) {
+	tests := []struct {
+		name     string
+		buf      []byte
+		expected uint32
+	}{
+		// expected values are manually generated using crc24 impl in Cassandra
+		{
+			name:     "empty buf",
+			buf:      []byte{},
+			expected: 1148681939,
+		},
+		{
+			name:     "buf filled with 0",
+			buf:      []byte{0, 0, 0, 0, 0},
+			expected: 1178391023,
+		},
+		{
+			name:     "buf filled with some data",
+			buf:      []byte{1, 2, 3, 4, 5, 6},
+			expected: 3536190002,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, Crc32(tt.buf))
+		})
+	}
+}
+
+func TestKoopmanChecksum(t *testing.T) {
+	tests := []struct {
+		name     string
+		buf      []byte
+		expected uint32
+	}{
+		// expected values are manually generated using crc32 impl in Cassandra
+		{
+			name:     "buf filled with 0 (len 3)",
+			buf:      []byte{0, 0, 0},
+			expected: 8251255,
+		},
+		{
+			name:     "buf filled with 0 (len 5)",
+			buf:      []byte{0, 0, 0, 0, 0},
+			expected: 11185162,
+		},
+		{
+			name:     "buf filled with some data (len 3)",
+			buf:      []byte{64, -30 & 0xff, 1},
+			expected: 5891942,
+		},
+		{
+			name:     "buf filled with some data (len 5)",
+			buf:      []byte{64, -30 & 0xff, 1, 0, 0},
+			expected: 8775784,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, Crc24(tt.buf))
+		})
+	}
+}

--- a/frame.go
+++ b/frame.go
@@ -25,7 +25,9 @@
 package gocql
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -70,6 +72,8 @@ const (
 	protoVersion5      = 0x05
 
 	maxFrameSize = 256 * 1024 * 1024
+
+	maxSegmentPayloadSize = 0x1FFFF
 )
 
 type protoVersion byte
@@ -168,16 +172,18 @@ const (
 	flagGlobalTableSpec int = 0x01
 	flagHasMorePages    int = 0x02
 	flagNoMetaData      int = 0x04
+	flagMetaDataChanged int = 0x08
 
 	// query flags
-	flagValues                byte = 0x01
-	flagSkipMetaData          byte = 0x02
-	flagPageSize              byte = 0x04
-	flagWithPagingState       byte = 0x08
-	flagWithSerialConsistency byte = 0x10
-	flagDefaultTimestamp      byte = 0x20
-	flagWithNameValues        byte = 0x40
-	flagWithKeyspace          byte = 0x80
+	flagValues                uint32 = 0x01
+	flagSkipMetaData          uint32 = 0x02
+	flagPageSize              uint32 = 0x04
+	flagWithPagingState       uint32 = 0x08
+	flagWithSerialConsistency uint32 = 0x10
+	flagDefaultTimestamp      uint32 = 0x20
+	flagWithNameValues        uint32 = 0x40
+	flagWithKeyspace          uint32 = 0x80
+	flagWithNowInSeconds      uint32 = 0x100
 
 	// prepare flags
 	flagWithPreparedKeyspace uint32 = 0x01
@@ -513,12 +519,12 @@ func (f *framer) readFrame(r io.Reader, head *frameHeader) error {
 		return fmt.Errorf("unable to read frame body: read %d/%d bytes: %v", n, head.length, err)
 	}
 
-	if head.flags&flagCompress == flagCompress {
+	if f.proto < protoVersion5 && head.flags&flagCompress == flagCompress {
 		if f.compres == nil {
 			return NewErrProtocol("no compressor available with compressed frame body")
 		}
 
-		f.buf, err = f.compres.Decode(f.buf)
+		f.buf, err = f.compres.AppendDecompressedWithLength(nil, f.buf)
 		if err != nil {
 			return err
 		}
@@ -757,13 +763,13 @@ func (f *framer) finish() error {
 		return ErrFrameTooBig
 	}
 
-	if f.buf[1]&flagCompress == flagCompress {
+	if f.proto < protoVersion5 && f.buf[1]&flagCompress == flagCompress {
 		if f.compres == nil {
 			panic("compress flag set with no compressor")
 		}
 
 		// TODO: only compress frames which are big enough
-		compressed, err := f.compres.Encode(f.buf[f.headSize:])
+		compressed, err := f.compres.AppendCompressedWithLength(nil, f.buf[f.headSize:])
 		if err != nil {
 			return err
 		}
@@ -1006,14 +1012,20 @@ type resultMetadata struct {
 	// it is at minimum len(columns) but may be larger, for instance when a column
 	// is a UDT or tuple.
 	actualColCount int
+
+	newMetadataID []byte
 }
 
 func (r *resultMetadata) morePages() bool {
 	return r.flags&flagHasMorePages == flagHasMorePages
 }
 
+func (r *resultMetadata) noMetaData() bool {
+	return r.flags&flagNoMetaData == flagNoMetaData
+}
+
 func (r resultMetadata) String() string {
-	return fmt.Sprintf("[metadata flags=0x%x paging_state=% X columns=%v]", r.flags, r.pagingState, r.columns)
+	return fmt.Sprintf("[metadata flags=0x%x paging_state=% X columns=%v new_metadata_id=% X]", r.flags, r.pagingState, r.columns, r.newMetadataID)
 }
 
 func (f *framer) readCol(col *ColumnInfo, meta *resultMetadata, globalSpec bool, keyspace, table string) {
@@ -1049,7 +1061,11 @@ func (f *framer) parseResultMetadata() resultMetadata {
 		meta.pagingState = copyBytes(f.readBytes())
 	}
 
-	if meta.flags&flagNoMetaData == flagNoMetaData {
+	if f.proto > protoVersion4 && meta.flags&flagMetaDataChanged == flagMetaDataChanged {
+		meta.newMetadataID = copyBytes(f.readShortBytes())
+	}
+
+	if meta.noMetaData() {
 		return meta
 	}
 
@@ -1153,17 +1169,23 @@ func (f *framer) parseResultSetKeyspace() frame {
 type resultPreparedFrame struct {
 	frameHeader
 
-	preparedID []byte
-	reqMeta    preparedMetadata
-	respMeta   resultMetadata
+	preparedID       []byte
+	resultMetadataID []byte
+	reqMeta          preparedMetadata
+	respMeta         resultMetadata
 }
 
 func (f *framer) parseResultPrepared() frame {
 	frame := &resultPreparedFrame{
 		frameHeader: *f.header,
 		preparedID:  f.readShortBytes(),
-		reqMeta:     f.parsePreparedMetadata(),
 	}
+
+	if f.proto > protoVersion4 {
+		frame.resultMetadataID = copyBytes(f.readShortBytes())
+	}
+
+	frame.reqMeta = f.parsePreparedMetadata()
 
 	if f.proto < protoVersion2 {
 		return frame
@@ -1446,12 +1468,13 @@ type queryParams struct {
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	// v5+
-	keyspace string
+	keyspace     string
+	nowInSeconds *int
 }
 
 func (q queryParams) String() string {
-	return fmt.Sprintf("[query_params consistency=%v skip_meta=%v page_size=%d paging_state=%q serial_consistency=%v default_timestamp=%v values=%v keyspace=%s]",
-		q.consistency, q.skipMeta, q.pageSize, q.pagingState, q.serialConsistency, q.defaultTimestamp, q.values, q.keyspace)
+	return fmt.Sprintf("[query_params consistency=%v skip_meta=%v page_size=%d paging_state=%q serial_consistency=%v default_timestamp=%v values=%v keyspace=%s now_in_seconds=%v]",
+		q.consistency, q.skipMeta, q.pageSize, q.pagingState, q.serialConsistency, q.defaultTimestamp, q.values, q.keyspace, q.nowInSeconds)
 }
 
 func (f *framer) writeQueryParams(opts *queryParams) {
@@ -1461,7 +1484,9 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 		return
 	}
 
-	var flags byte
+	var flags uint32
+	names := false
+
 	if len(opts.values) > 0 {
 		flags |= flagValues
 	}
@@ -1478,8 +1503,6 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 		flags |= flagWithSerialConsistency
 	}
 
-	names := false
-
 	// protoV3 specific things
 	if f.proto > protoVersion2 {
 		if opts.defaultTimestamp {
@@ -1493,17 +1516,23 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 	}
 
 	if opts.keyspace != "" {
-		if f.proto > protoVersion4 {
-			flags |= flagWithKeyspace
-		} else {
+		if f.proto < protoVersion5 {
 			panic(fmt.Errorf("the keyspace can only be set with protocol 5 or higher"))
 		}
+		flags |= flagWithKeyspace
+	}
+
+	if opts.nowInSeconds != nil {
+		if f.proto < protoVersion5 {
+			panic(fmt.Errorf("now_in_seconds can only be set with protocol 5 or higher"))
+		}
+		flags |= flagWithNowInSeconds
 	}
 
 	if f.proto > protoVersion4 {
-		f.writeUint(uint32(flags))
+		f.writeUint(flags)
 	} else {
-		f.writeByte(flags)
+		f.writeByte(byte(flags))
 	}
 
 	if n := len(opts.values); n > 0 {
@@ -1546,6 +1575,10 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 
 	if opts.keyspace != "" {
 		f.writeString(opts.keyspace)
+	}
+
+	if opts.nowInSeconds != nil {
+		f.writeInt(int32(*opts.nowInSeconds))
 	}
 }
 
@@ -1593,6 +1626,9 @@ type writeExecuteFrame struct {
 
 	// v4+
 	customPayload map[string][]byte
+
+	// v5+
+	resultMetadataID []byte
 }
 
 func (e *writeExecuteFrame) String() string {
@@ -1600,16 +1636,21 @@ func (e *writeExecuteFrame) String() string {
 }
 
 func (e *writeExecuteFrame) buildFrame(fr *framer, streamID int) error {
-	return fr.writeExecuteFrame(streamID, e.preparedID, &e.params, &e.customPayload)
+	return fr.writeExecuteFrame(streamID, e.preparedID, e.resultMetadataID, &e.params, &e.customPayload)
 }
 
-func (f *framer) writeExecuteFrame(streamID int, preparedID []byte, params *queryParams, customPayload *map[string][]byte) error {
+func (f *framer) writeExecuteFrame(streamID int, preparedID, resultMetadataID []byte, params *queryParams, customPayload *map[string][]byte) error {
 	if len(*customPayload) > 0 {
 		f.payload()
 	}
 	f.writeHeader(f.flags, opExecute, streamID)
 	f.writeCustomPayload(customPayload)
 	f.writeShortBytes(preparedID)
+
+	if f.proto > protoVersion4 {
+		f.writeShortBytes(resultMetadataID)
+	}
+
 	if f.proto > protoVersion1 {
 		f.writeQueryParams(params)
 	} else {
@@ -1648,6 +1689,10 @@ type writeBatchFrame struct {
 
 	//v4+
 	customPayload map[string][]byte
+
+	//v5+
+	keyspace     string
+	nowInSeconds *int
 }
 
 func (w *writeBatchFrame) buildFrame(framer *framer, streamID int) error {
@@ -1665,7 +1710,7 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 	n := len(w.statements)
 	f.writeShort(uint16(n))
 
-	var flags byte
+	var flags uint32
 
 	for i := 0; i < n; i++ {
 		b := &w.statements[i]
@@ -1706,26 +1751,48 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 		if w.defaultTimestamp {
 			flags |= flagDefaultTimestamp
 		}
+	}
 
-		if f.proto > protoVersion4 {
-			f.writeUint(uint32(flags))
+	if w.keyspace != "" {
+		if f.proto < protoVersion5 {
+			panic(fmt.Errorf("the keyspace can only be set with protocol 5 or higher"))
+		}
+		flags |= flagWithKeyspace
+	}
+
+	if w.nowInSeconds != nil {
+		if f.proto < protoVersion5 {
+			panic(fmt.Errorf("now_in_seconds can only be set with protocol 5 or higher"))
+		}
+		flags |= flagWithNowInSeconds
+	}
+
+	if f.proto > protoVersion4 {
+		f.writeUint(flags)
+	} else {
+		f.writeByte(byte(flags))
+	}
+
+	if w.serialConsistency > 0 {
+		f.writeConsistency(Consistency(w.serialConsistency))
+	}
+
+	if w.defaultTimestamp {
+		var ts int64
+		if w.defaultTimestampValue != 0 {
+			ts = w.defaultTimestampValue
 		} else {
-			f.writeByte(flags)
+			ts = time.Now().UnixNano() / 1000
 		}
+		f.writeLong(ts)
+	}
 
-		if w.serialConsistency > 0 {
-			f.writeConsistency(Consistency(w.serialConsistency))
-		}
+	if w.keyspace != "" {
+		f.writeString(w.keyspace)
+	}
 
-		if w.defaultTimestamp {
-			var ts int64
-			if w.defaultTimestampValue != 0 {
-				ts = w.defaultTimestampValue
-			} else {
-				ts = time.Now().UnixNano() / 1000
-			}
-			f.writeLong(ts)
-		}
+	if w.nowInSeconds != nil {
+		f.writeInt(int32(*w.nowInSeconds))
 	}
 
 	return f.finish()
@@ -2058,4 +2125,263 @@ func (f *framer) writeBytesMap(m map[string][]byte) {
 		f.writeString(k)
 		f.writeBytes(v)
 	}
+}
+
+func (f *framer) prepareModernLayout() error {
+	// Ensure protocol version is V5 or higher
+	if f.proto < protoVersion5 {
+		panic("Modern layout is not supported with version V4 or less")
+	}
+
+	selfContained := true
+
+	var (
+		adjustedBuf []byte
+		tempBuf     []byte
+		err         error
+	)
+
+	// Process the buffer in chunks if it exceeds the max payload size
+	for len(f.buf) > maxSegmentPayloadSize {
+		if f.compres != nil {
+			tempBuf, err = newCompressedSegment(f.buf[:maxSegmentPayloadSize], false, f.compres)
+		} else {
+			tempBuf, err = newUncompressedSegment(f.buf[:maxSegmentPayloadSize], false)
+		}
+		if err != nil {
+			return err
+		}
+
+		adjustedBuf = append(adjustedBuf, tempBuf...)
+		f.buf = f.buf[maxSegmentPayloadSize:]
+		selfContained = false
+	}
+
+	// Process the remaining buffer
+	if f.compres != nil {
+		tempBuf, err = newCompressedSegment(f.buf, selfContained, f.compres)
+	} else {
+		tempBuf, err = newUncompressedSegment(f.buf, selfContained)
+	}
+	if err != nil {
+		return err
+	}
+
+	adjustedBuf = append(adjustedBuf, tempBuf...)
+	f.buf = adjustedBuf
+
+	return nil
+}
+
+const (
+	crc24Size = 3
+	crc32Size = 4
+)
+
+func readUncompressedSegment(r io.Reader) ([]byte, bool, error) {
+	const (
+		headerSize = 3
+	)
+
+	header := [headerSize + crc24Size]byte{}
+
+	// Read the frame header
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, false, fmt.Errorf("gocql: failed to read uncompressed frame, err: %w", err)
+	}
+
+	// Compute and verify the header CRC24
+	computedHeaderCRC24 := Crc24(header[:headerSize])
+	readHeaderCRC24 := uint32(header[3]) | uint32(header[4])<<8 | uint32(header[5])<<16
+	if computedHeaderCRC24 != readHeaderCRC24 {
+		return nil, false, fmt.Errorf("gocql: crc24 mismatch in frame header, computed: %d, got: %d", computedHeaderCRC24, readHeaderCRC24)
+	}
+
+	// Extract the payload length and self-contained flag
+	headerInt := uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16
+	payloadLen := int(headerInt & maxSegmentPayloadSize)
+	isSelfContained := (headerInt & (1 << 17)) != 0
+
+	// Read the payload
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, false, fmt.Errorf("gocql: failed to read uncompressed frame payload, err: %w", err)
+	}
+
+	// Read and verify the payload CRC32
+	if _, err := io.ReadFull(r, header[:crc32Size]); err != nil {
+		return nil, false, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
+	}
+
+	computedPayloadCRC32 := Crc32(payload)
+	readPayloadCRC32 := binary.LittleEndian.Uint32(header[:crc32Size])
+	if computedPayloadCRC32 != readPayloadCRC32 {
+		return nil, false, fmt.Errorf("gocql: payload crc32 mismatch, computed: %d, got: %d", computedPayloadCRC32, readPayloadCRC32)
+	}
+
+	return payload, isSelfContained, nil
+}
+
+func newUncompressedSegment(payload []byte, isSelfContained bool) ([]byte, error) {
+	const (
+		headerSize       = 6
+		selfContainedBit = 1 << 17
+	)
+
+	payloadLen := len(payload)
+	if payloadLen > maxSegmentPayloadSize {
+		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", payloadLen, maxSegmentPayloadSize)
+	}
+
+	// Create the segment
+	segmentSize := headerSize + payloadLen + crc32Size
+	segment := make([]byte, segmentSize)
+
+	// First 3 bytes: payload length and self-contained flag
+	headerInt := uint32(payloadLen)
+	if isSelfContained {
+		headerInt |= selfContainedBit // Set the self-contained flag
+	}
+
+	// Encode the first 3 bytes as a single little-endian integer
+	segment[0] = byte(headerInt)
+	segment[1] = byte(headerInt >> 8)
+	segment[2] = byte(headerInt >> 16)
+
+	// Calculate CRC24 for the first 3 bytes of the header
+	crc := Crc24(segment[:3])
+
+	// Encode CRC24 into the next 3 bytes of the header
+	segment[3] = byte(crc)
+	segment[4] = byte(crc >> 8)
+	segment[5] = byte(crc >> 16)
+
+	copy(segment[headerSize:], payload) // Copy the payload to the segment
+
+	// Calculate CRC32 for the payload
+	payloadCRC32 := Crc32(payload)
+	binary.LittleEndian.PutUint32(segment[headerSize+payloadLen:], payloadCRC32)
+
+	return segment, nil
+}
+
+func newCompressedSegment(uncompressedPayload []byte, isSelfContained bool, compressor Compressor) ([]byte, error) {
+	const (
+		headerSize       = 5
+		selfContainedBit = 1 << 34
+	)
+
+	uncompressedLen := len(uncompressedPayload)
+	if uncompressedLen > maxSegmentPayloadSize {
+		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", uncompressedPayload, maxSegmentPayloadSize)
+	}
+
+	compressedPayload, err := compressor.AppendCompressed(nil, uncompressedPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	compressedLen := len(compressedPayload)
+
+	// Compression is not worth it
+	if uncompressedLen < compressedLen {
+		// native_protocol_v5.spec
+		// 2.2
+		//  An uncompressed length of 0 signals that the compressed payload
+		//  should be used as-is and not decompressed.
+		compressedPayload = uncompressedPayload
+		compressedLen = uncompressedLen
+		uncompressedLen = 0
+	}
+
+	// Combine compressed and uncompressed lengths and set the self-contained flag if needed
+	combined := uint64(compressedLen) | uint64(uncompressedLen)<<17
+	if isSelfContained {
+		combined |= selfContainedBit
+	}
+
+	var headerBuf [headerSize + crc24Size]byte
+
+	// Write the combined value into the header buffer
+	binary.LittleEndian.PutUint64(headerBuf[:], combined)
+
+	// Create a buffer with enough capacity to hold the header, compressed payload, and checksums
+	buf := bytes.NewBuffer(make([]byte, 0, headerSize+crc24Size+compressedLen+crc32Size))
+
+	// Write the first 5 bytes of the header (compressed and uncompressed sizes)
+	buf.Write(headerBuf[:headerSize])
+
+	// Compute and write the CRC24 checksum of the first 5 bytes
+	headerChecksum := Crc24(headerBuf[:headerSize])
+
+	// LittleEndian 3 bytes
+	headerBuf[0] = byte(headerChecksum)
+	headerBuf[1] = byte(headerChecksum >> 8)
+	headerBuf[2] = byte(headerChecksum >> 16)
+	buf.Write(headerBuf[:3])
+
+	buf.Write(compressedPayload)
+
+	// Compute and write the CRC32 checksum of the payload
+	payloadChecksum := Crc32(compressedPayload)
+	binary.LittleEndian.PutUint32(headerBuf[:], payloadChecksum)
+	buf.Write(headerBuf[:4])
+
+	return buf.Bytes(), nil
+}
+
+func readCompressedSegment(r io.Reader, compressor Compressor) ([]byte, bool, error) {
+	const headerSize = 5
+	var (
+		headerBuf [headerSize + crc24Size]byte
+		err       error
+	)
+
+	if _, err = io.ReadFull(r, headerBuf[:]); err != nil {
+		return nil, false, err
+	}
+
+	// Reading checksum from frame header
+	readHeaderChecksum := uint32(headerBuf[5]) | uint32(headerBuf[6])<<8 | uint32(headerBuf[7])<<16
+	if computedHeaderChecksum := Crc24(headerBuf[:headerSize]); computedHeaderChecksum != readHeaderChecksum {
+		return nil, false, fmt.Errorf("gocql: crc24 mismatch in frame header, read: %d, computed: %d", readHeaderChecksum, computedHeaderChecksum)
+	}
+
+	// First 17 bits - payload size after compression
+	compressedLen := uint32(headerBuf[0]) | uint32(headerBuf[1])<<8 | uint32(headerBuf[2]&0x1)<<16
+
+	// The next 17 bits - payload size before compression
+	uncompressedLen := (uint32(headerBuf[2]) >> 1) | uint32(headerBuf[3])<<7 | uint32(headerBuf[4]&0b11)<<15
+
+	// Self-contained flag
+	selfContained := (headerBuf[4] & 0b100) != 0
+
+	compressedPayload := make([]byte, compressedLen)
+	if _, err = io.ReadFull(r, compressedPayload); err != nil {
+		return nil, false, fmt.Errorf("gocql: failed to read compressed frame payload, err: %w", err)
+	}
+
+	if _, err = io.ReadFull(r, headerBuf[:crc32Size]); err != nil {
+		return nil, false, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
+	}
+
+	// Ensuring if payload checksum matches
+	readPayloadChecksum := binary.LittleEndian.Uint32(headerBuf[:crc32Size])
+	if computedPayloadChecksum := Crc32(compressedPayload); readPayloadChecksum != computedPayloadChecksum {
+		return nil, false, fmt.Errorf("gocql: crc32 mismatch in payload, read: %d, computed: %d", readPayloadChecksum, computedPayloadChecksum)
+	}
+
+	var uncompressedPayload []byte
+	if uncompressedLen > 0 {
+		if uncompressedPayload, err = compressor.AppendDecompressed(nil, compressedPayload, uncompressedLen); err != nil {
+			return nil, false, err
+		}
+		if uint32(len(uncompressedPayload)) != uncompressedLen {
+			return nil, false, fmt.Errorf("gocql: length mismatch after payload decoding, got %d, expected %d", len(uncompressedPayload), uncompressedLen)
+		}
+	} else {
+		uncompressedPayload = compressedPayload
+	}
+
+	return uncompressedPayload, selfContained, nil
 }

--- a/lz4/lz4_test.go
+++ b/lz4/lz4_test.go
@@ -25,6 +25,7 @@
 package lz4
 
 import (
+	"github.com/pierrec/lz4/v4"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,21 +35,215 @@ func TestLZ4Compressor(t *testing.T) {
 	var c LZ4Compressor
 	require.Equal(t, "lz4", c.Name())
 
-	_, err := c.Decode([]byte{0, 1, 2})
+	_, err := c.AppendDecompressedWithLength(nil, []byte{0, 1, 2})
 	require.EqualError(t, err, "cassandra lz4 block size should be >4, got=3")
 
-	_, err = c.Decode([]byte{0, 1, 2, 4, 5})
+	_, err = c.AppendDecompressedWithLength(nil, []byte{0, 1, 2, 4, 5})
 	require.EqualError(t, err, "lz4: invalid source or destination buffer too short")
 
 	// If uncompressed size is zero then nothing is decoded even if present.
-	decoded, err := c.Decode([]byte{0, 0, 0, 0, 5, 7, 8})
+	decoded, err := c.AppendDecompressedWithLength(nil, []byte{0, 0, 0, 0, 5, 7, 8})
 	require.NoError(t, err)
 	require.Nil(t, decoded)
 
 	original := []byte("My Test String")
-	encoded, err := c.Encode(original)
+	encoded, err := c.AppendCompressedWithLength(nil, original)
 	require.NoError(t, err)
-	decoded, err = c.Decode(encoded)
+	decoded, err = c.AppendDecompressedWithLength(nil, encoded)
 	require.NoError(t, err)
 	require.Equal(t, original, decoded)
+}
+
+func TestLZ4Compressor_AppendCompressedDecompressed(t *testing.T) {
+	c := LZ4Compressor{}
+
+	invalidUncompressedLength := uint32(10)
+	_, err := c.AppendDecompressed(nil, []byte{0, 1, 2, 4, 5}, invalidUncompressedLength)
+	require.EqualError(t, err, "lz4: invalid source or destination buffer too short")
+
+	original := []byte("My Test String")
+	encoded, err := c.AppendCompressed(nil, original)
+	require.NoError(t, err)
+	decoded, err := c.AppendDecompressed(nil, encoded, uint32(len(original)))
+	require.NoError(t, err)
+	require.Equal(t, original, decoded)
+}
+
+func TestLZ4Compressor_AppendWithLengthGrowSliceWithData(t *testing.T) {
+	var tests = []struct {
+		name                 string
+		src                  []byte
+		dst                  []byte
+		shouldReuseDst       bool
+		decodeDst            []byte
+		shouldReuseDecodeDst bool
+	}{
+		{
+			name:      "both dst are empty",
+			src:       []byte("small data"),
+			dst:       nil,
+			decodeDst: nil,
+		},
+		{
+			name:      "dst is nil",
+			src:       []byte("another piece of data"),
+			dst:       nil,
+			decodeDst: []byte("something"),
+		},
+		{
+			name:      "decodeDst is nil",
+			src:       []byte("another piece of data"),
+			dst:       []byte("some"),
+			decodeDst: nil,
+		},
+		{
+			name:      "both dst are not empty",
+			src:       []byte("another piece of data"),
+			dst:       []byte("dst"),
+			decodeDst: []byte("decodeDst"),
+		},
+		{
+			name:                 "both dst slices have enough capacity",
+			src:                  []byte("small"),
+			dst:                  createBufWithCapAndData("cap=128", 128),
+			shouldReuseDst:       true,
+			decodeDst:            createBufWithCapAndData("cap=256", 256),
+			shouldReuseDecodeDst: true,
+		},
+		{
+			name:      "both dsts have some data and not enough capacity",
+			src:       []byte("small"),
+			dst:       createBufWithCapAndData("data", 6),
+			decodeDst: createBufWithCapAndData("wow", 4),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compressor := LZ4Compressor{}
+
+			// Appending compressed data to dst,
+			// expecting that dst still contains "test"
+			result, err := compressor.AppendCompressedWithLength(tt.dst, tt.src)
+			require.NoError(t, err)
+
+			var expectedCap int
+			if tt.shouldReuseDst {
+				expectedCap = cap(tt.dst)
+			} else {
+				expectedCap = len(tt.dst) + lz4.CompressBlockBound(len(tt.src)) + dataLengthSize
+			}
+
+			require.Equal(t, expectedCap, cap(result))
+			if len(tt.dst) > 0 {
+				require.Equal(t, tt.dst, result[:len(tt.dst)])
+			}
+
+			result, err = compressor.AppendDecompressedWithLength(tt.decodeDst, result[len(tt.dst):])
+			require.NoError(t, err)
+
+			var expectedDecodeCap int
+			if tt.shouldReuseDecodeDst {
+				expectedDecodeCap = cap(tt.decodeDst)
+			} else {
+				expectedDecodeCap = len(tt.decodeDst) + len(tt.src)
+			}
+
+			require.Equal(t, expectedDecodeCap, cap(result))
+			require.Equal(t, tt.src, result[len(tt.decodeDst):])
+		})
+	}
+}
+
+func TestLZ4Compressor_AppendGrowSliceWithData(t *testing.T) {
+	var tests = []struct {
+		name                 string
+		src                  []byte
+		dst                  []byte
+		shouldReuseDst       bool
+		decodeDst            []byte
+		shouldReuseDecodeDst bool
+	}{
+		{
+			name:      "both dst are empty",
+			src:       []byte("small data"),
+			dst:       nil,
+			decodeDst: nil,
+		},
+		{
+			name:      "dst is nil",
+			src:       []byte("another piece of data"),
+			dst:       nil,
+			decodeDst: []byte("something"),
+		},
+		{
+			name:      "decodeDst is nil",
+			src:       []byte("another piece of data"),
+			dst:       []byte("some"),
+			decodeDst: nil,
+		},
+		{
+			name:      "both dst are not empty",
+			src:       []byte("another piece of data"),
+			dst:       []byte("dst"),
+			decodeDst: []byte("decodeDst"),
+		},
+		{
+			name:                 "both dst slices have enough capacity",
+			src:                  []byte("small"),
+			dst:                  createBufWithCapAndData("cap=128", 128),
+			shouldReuseDst:       true,
+			decodeDst:            createBufWithCapAndData("cap=256", 256),
+			shouldReuseDecodeDst: true,
+		},
+		{
+			name:      "both dst slices have some data and not enough capacity",
+			src:       []byte("small"),
+			dst:       createBufWithCapAndData("data", 6),
+			decodeDst: createBufWithCapAndData("wow", 4),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compressor := LZ4Compressor{}
+
+			// Appending compressed data to dst,
+			// expecting that dst still contains "test"
+			result, err := compressor.AppendCompressed(tt.dst, tt.src)
+			require.NoError(t, err)
+
+			var expectedCap int
+			if tt.shouldReuseDst {
+				expectedCap = cap(tt.dst)
+			} else {
+				expectedCap = len(tt.dst) + lz4.CompressBlockBound(len(tt.src))
+			}
+
+			require.Equal(t, expectedCap, cap(result))
+			if len(tt.dst) > 0 {
+				require.Equal(t, tt.dst, result[:len(tt.dst)])
+			}
+
+			uncompressedLen := uint32(len(tt.src))
+			result, err = compressor.AppendDecompressed(tt.decodeDst, result[len(tt.dst):], uncompressedLen)
+			require.NoError(t, err)
+
+			var expectedDecodeCap int
+			if tt.shouldReuseDst {
+				expectedDecodeCap = cap(tt.decodeDst)
+			} else {
+				expectedDecodeCap = len(tt.decodeDst) + len(tt.src)
+			}
+
+			require.Equal(t, expectedDecodeCap, cap(result))
+			require.Equal(t, tt.src, result[len(tt.decodeDst):])
+		})
+	}
+}
+
+func createBufWithCapAndData(data string, cap int) []byte {
+	buf := make([]byte, cap)
+	copy(buf, data)
+	return buf[:len(data)]
 }

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -100,3 +100,20 @@ func (p *preparedLRU) evictPreparedID(key string, id []byte) {
 	}
 
 }
+
+func (p *preparedLRU) get(key string) (*inflightPrepare, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	val, ok := p.lru.Get(key)
+	if !ok {
+		return nil, false
+	}
+
+	ifp, ok := val.(*inflightPrepare)
+	if !ok {
+		return nil, false
+	}
+
+	return ifp, true
+}


### PR DESCRIPTION
## Overview

C* 4.0 introduced Native Protocol 5, so we should make gocql to support it.
This PR consists of other my PRs, which also provides support for the v5 version of the protocol.

This PR provides support of Native Protocol 5 features as:
* New frames format [CASSANDRA-15299](https://issues.apache.org/jira/browse/CASSANDRA-15299)
* `result_metadata_id` field for **EXECUTE** and **PREPARED** messages [CASSANDRA-10786](https://issues.apache.org/jira/browse/CASSANDRA-10786)
* `now_in_seconds` field for `BATCH` and `QUERY` messages [CASSANDRA-14664](https://issues.apache.org/jira/browse/CASSANDRA-14664)
* `keyspace` field for `BATCH` and `QUERY` messages

closes #1750