### PR TITLE
CASSGO-2 Marshal big int returns variable length slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retry policy now takes into account query idempotency (CASSGO-27)
 - Don't return error to caller with RetryType Ignore (CASSGO-28)
+- The marshalBigInt return 8 bytes slice in all cases except for big.Int,
+  which returns a variable length slice, but should be 8 bytes slice as well (CASSGO-2)
 
 ## [1.7.0] - 2024-09-23
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -39,6 +39,8 @@ import (
 	"time"
 
 	"gopkg.in/inf.v0"
+
+	"github.com/stretchr/testify/require"
 )
 
 type AliasInt int
@@ -1349,7 +1351,7 @@ func TestMarshal_Encode(t *testing.T) {
 			}
 		} else {
 			if _, err := Marshal(test.Info, test.Value); err != test.MarshalError {
-				t.Errorf("unmarshalTest[%d] (%v=>%t): %#v returned error %#v, want %#v.", i, test.Info, test.Value, test.Value, err, test.MarshalError)
+				t.Errorf("marshalTest[%d] (%v=>%t): %#v returned error %#v, want %#v.", i, test.Info, test.Value, test.Value, err, test.MarshalError)
 			}
 		}
 	}
@@ -1533,6 +1535,32 @@ func TestMarshalVarint(t *testing.T) {
 			t.Errorf("unmarshaled varint mismatch: expected %v, got %v (test #%d)", test.Unmarshaled, binder, i)
 		}
 	}
+}
+
+func TestMarshalBigInt(t *testing.T) {
+	var testStruct = []struct {
+		Info         TypeInfo
+		Value        interface{}
+		MarshalError error
+	}{
+		{
+			NativeType{proto: 2, typ: TypeBigInt},
+			"-78635384813432117863538481343211",
+			MarshalError("can not marshal string to bigint: strconv.ParseInt: parsing \"-78635384813432117863538481343211\": value out of range"),
+		},
+		{
+			NativeType{proto: 2, typ: TypeBigInt},
+			"922337203685477692259749625974294",
+			MarshalError("can not marshal string to bigint: strconv.ParseInt: parsing \"922337203685477692259749625974294\": value out of range"),
+		},
+	}
+
+	t.Run("testMarshalBigInt", func(t *testing.T) {
+		for _, tc := range testStruct {
+			_, err := Marshal(tc.Info, tc.Value)
+			require.Equal(t, tc.MarshalError, err)
+		}
+	})
 }
 
 func equalStringPointerSlice(leftList, rightList []*string) bool {


### PR DESCRIPTION
Closes #1740
Currently, gocql supports arbitrary-precision type big.Int, but in Cassandra the bigint is implemented as an eight-byte two's complement integer (see [Data Type Serialization Formats](https://cassandra.apache.org/_/native_protocol.html)).
Fixed this issue in the PR, and added a few tests to cover changes. 
