### PR TITLE
CASSGO-54: Add a LatencyAwareHostPolicy that will deprioritize the host(s) with worse average latencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add a LatencyAwarePolicy that prioritizes the host with smaller average latency
 
 ### Changed
 


### PR DESCRIPTION
Add a LatencyAwarePolicy that will deprioritize the host(s) with worse average latency to fix the [issue-1078](https://github.com/apache/cassandra-gocql-driver/issues/1078) and also as the counterpart of the LatencyAwarePolicy in the cassandra-java-driver client.