### PR TITLE
CASSGO-20 Fix integration tests

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,50 @@
+name: Setup environment
+description: Setup environment for integration tests execution
+runs:
+  using: "composite"
+  steps:
+    - name: Set up cache for SDKMAN
+      uses: actions/cache@v3
+      with:
+        path: ~/.sdkman
+        key: ${{ runner.os }}-sdkman
+
+    - name: Set up cache for PIP
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install Java
+      shell: bash
+      run: |
+        echo "Installing SDKMAN..."
+        curl -s "https://get.sdkman.io" | bash
+        source "$HOME/.sdkman/bin/sdkman-init.sh"
+        echo "sdkman_auto_answer=true" >> ~/.sdkman/etc/config
+
+        echo "Installing Java versions..."
+        sdk install java 11.0.24-zulu
+        sdk install java 17.0.12-zulu
+
+        sdk default java 11.0.24-zulu
+        sdk use java 11.0.24-zulu
+
+        echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
+        echo "JAVA17_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        echo "JAVA_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
+        echo "PATH=$PATH" >> $GITHUB_ENV
+
+    - name: Install CCM
+      shell: bash
+      run: |
+        echo "Creating Python virtual environment..."
+        VENV_DIR="$HOME/venv"
+        python3 -m venv $VENV_DIR
+        source $VENV_DIR/bin/activate
+        pip install --upgrade pip setuptools
+
+        echo "Installing CCM..."
+        pip install "git+https://github.com/riptano/ccm.git@${CCM_VERSION}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,11 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('go.mod') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Install CCM
-        run: pip install "git+https://github.com/riptano/ccm.git@${CCM_VERSION}"
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
       - name: Start cassandra nodes
         run: |
+          source ~/venv/bin/activate
           VERSION=${{ matrix.cassandra_version }}
           keypath="$(pwd)/testdata/pki"
           conf=(
@@ -107,6 +108,7 @@ jobs:
           echo "JVM_EXTRA_OPTS=$JVM_EXTRA_OPTS" >> $GITHUB_ENV
       - name: Integration tests
         run: |
+          source ~/venv/bin/activate
           export JVM_EXTRA_OPTS="${{env.JVM_EXTRA_OPTS}}"
           go test -v -tags "${{ matrix.tags }} gocql_debug" -timeout=5m -race ${{ env.args }}
       - name: 'Save ccm logs'
@@ -135,10 +137,11 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-      - name: Install CCM
-        run: pip install "git+https://github.com/riptano/ccm.git@${CCM_VERSION}"
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
       - name: Start cassandra nodes
         run: |
+          source ~/venv/bin/activate
           VERSION=${{ matrix.cassandra_version }}
           keypath="$(pwd)/testdata/pki"
           conf=(
@@ -197,5 +200,6 @@ jobs:
           sleep 30s
       - name: Integration tests
         run: |
+          source ~/venv/bin/activate
           export JVM_EXTRA_OPTS="${{env.JVM_EXTRA_OPTS}}"
           go test -v -run=TestAuthentication -tags "${{ matrix.tags }} gocql_debug" -timeout=15s -runauth ${{ env.args }}


### PR DESCRIPTION
- Java 17 is installed for future testing.
- C* 4.0.13 fails to start with CCM if only Java 17 is available.
- Creating environment variables expected by CCM.