### PR TITLE
CASSGO-31 Autolink CASSGO JIRA issues

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,3 +34,4 @@ github:
     projects: false
   autolink_jira:
     - CASSANDRA
+    - CASSGO


### PR DESCRIPTION
Autolink JIRA issues is enabled for the CASSANDRA project but not the new CASSGO project.

This patch enables autolink for CASSGO issues while preserving the autolink for CASSANDRA issues since there's existing commits that reference them.

@michaelsembwever does this work? I.e. autolink for 2 separate JIRA projects on the same repo?