### PR TITLE
CASSGO-35 standardize spelling of datacenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -29,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve error messages for marshalling (CASSGO-38)
 
 - Remove HostPoolHostPolicy from gocql package (CASSGO-21)
+
+- Standardized spelling of datacenter (CASSGO-35)
 
 ### Fixed
 

--- a/cluster.go
+++ b/cluster.go
@@ -198,7 +198,7 @@ type ClusterConfig struct {
 	// If DisableInitialHostLookup then the driver will not attempt to get host info
 	// from the system.peers table, this will mean that the driver will connect to
 	// hosts supplied and will not attempt to lookup the hosts information, this will
-	// mean that data_centre, rack and token information will not be available and as
+	// mean that data_center, rack and token information will not be available and as
 	// such host filtering and token aware query routing will not be available.
 	DisableInitialHostLookup bool
 

--- a/filters.go
+++ b/filters.go
@@ -53,12 +53,18 @@ func DenyAllFilter() HostFilter {
 	})
 }
 
-// DataCentreHostFilter filters all hosts such that they are in the same data centre
-// as the supplied data centre.
-func DataCentreHostFilter(dataCentre string) HostFilter {
+// DataCenterHostFilter filters all hosts such that they are in the same data center
+// as the supplied data center.
+func DataCenterHostFilter(dataCenter string) HostFilter {
 	return HostFilterFunc(func(host *HostInfo) bool {
-		return host.DataCenter() == dataCentre
+		return host.DataCenter() == dataCenter
 	})
+}
+
+// Deprecated: Use DataCenterHostFilter instead.
+// DataCentreHostFilter is an alias that doesn't use the preferred spelling.
+func DataCentreHostFilter(dataCenter string) HostFilter {
+	return DataCenterHostFilter(dataCenter)
 }
 
 // WhiteListHostFilter filters incoming hosts by checking that their address is

--- a/filters_test.go
+++ b/filters_test.go
@@ -95,8 +95,10 @@ func TestFilter_DenyAll(t *testing.T) {
 	}
 }
 
-func TestFilter_DataCentre(t *testing.T) {
-	f := DataCentreHostFilter("dc1")
+func TestFilter_DataCenter(t *testing.T) {
+	f := DataCenterHostFilter("dc1")
+	fDeprecated := DataCentreHostFilter("dc1")
+
 	tests := [...]struct {
 		dc     string
 		accept bool
@@ -112,6 +114,10 @@ func TestFilter_DataCentre(t *testing.T) {
 			}
 		} else if test.accept {
 			t.Errorf("%d: should have been accepted but wasn't", i)
+		}
+
+		if f.Accept(&HostInfo{dataCenter: test.dc}) != fDeprecated.Accept(&HostInfo{dataCenter: test.dc}) {
+			t.Errorf("%d: DataCenterHostFilter and DataCentreHostFilter should be the same", i)
 		}
 	}
 }

--- a/host_source.go
+++ b/host_source.go
@@ -35,8 +35,10 @@ import (
 	"time"
 )
 
-var ErrCannotFindHost = errors.New("cannot find host")
-var ErrHostAlreadyExists = errors.New("host already exists")
+var (
+	ErrCannotFindHost    = errors.New("cannot find host")
+	ErrHostAlreadyExists = errors.New("host already exists")
+)
 
 type nodeState int32
 
@@ -111,7 +113,6 @@ func (c cassVersion) Before(major, minor, patch int) bool {
 		} else if c.Minor == minor && c.Patch < patch {
 			return true
 		}
-
 	}
 	return false
 }
@@ -439,7 +440,7 @@ func (h *HostInfo) String() string {
 	connectAddr, source := h.connectAddressLocked()
 	return fmt.Sprintf("[HostInfo hostname=%q connectAddress=%q peer=%q rpc_address=%q broadcast_address=%q "+
 		"preferred_ip=%q connect_addr=%q connect_addr_source=%q "+
-		"port=%d data_centre=%q rack=%q host_id=%q version=%q state=%s num_tokens=%d]",
+		"port=%d data_center=%q rack=%q host_id=%q version=%q state=%s num_tokens=%d]",
 		h.hostname, h.connectAddress, h.peer, h.rpcAddress, h.broadcastAddress, h.preferredIP,
 		connectAddr, source,
 		h.port, h.dataCenter, h.rack, h.hostId, h.version, h.state, len(h.tokens))

--- a/policies.go
+++ b/policies.go
@@ -24,7 +24,7 @@
 
 package gocql
 
-//This file will be the future home for more policies
+// This file will be the future home for more policies
 
 import (
 	"context"
@@ -157,7 +157,7 @@ type RetryPolicy interface {
 //	//Assign to a query
 //	query.RetryPolicy(&gocql.SimpleRetryPolicy{NumRetries: 1})
 type SimpleRetryPolicy struct {
-	NumRetries int //Number of times to retry a query
+	NumRetries int // Number of times to retry a query
 }
 
 // Attempt tells gocql to attempt the query again based on query.Attempts being less
@@ -696,8 +696,8 @@ type dcAwareRR struct {
 }
 
 // DCAwareRoundRobinPolicy is a host selection policies which will prioritize and
-// return hosts which are in the local datacentre before returning hosts in all
-// other datercentres
+// return hosts which are in the local datacenter before returning hosts in all
+// other datacenters
 func DCAwareRoundRobinPolicy(localDC string) HostSelectionPolicy {
 	return &dcAwareRR{local: localDC}
 }
@@ -742,7 +742,6 @@ func roundRobbin(shift int, hosts ...[]*HostInfo) NextHost {
 	currentlyObserved := 0
 
 	return func() SelectedHost {
-
 		// iterate over layers
 		for {
 			if currentLayer == len(hosts) {
@@ -778,7 +777,7 @@ func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 
 // RackAwareRoundRobinPolicy is a host selection policies which will prioritize and
 // return hosts which are in the local rack, before hosts in the local datacenter but
-// a different rack, before hosts in all other datercentres
+// a different rack, before hosts in all other datacenters
 
 type rackAwareRR struct {
 	// lastUsedHostIdx keeps the index of the last used host.
@@ -888,14 +887,13 @@ func (s *singleHostReadyPolicy) Ready() bool {
 type ConvictionPolicy interface {
 	// Implementations should return `true` if the host should be convicted, `false` otherwise.
 	AddFailure(error error, host *HostInfo) bool
-	//Implementations should clear out any convictions or state regarding the host.
+	// Implementations should clear out any convictions or state regarding the host.
 	Reset(host *HostInfo)
 }
 
 // SimpleConvictionPolicy implements a ConvictionPolicy which convicts all hosts
 // regardless of error
-type SimpleConvictionPolicy struct {
-}
+type SimpleConvictionPolicy struct{}
 
 func (e *SimpleConvictionPolicy) AddFailure(error error, host *HostInfo) bool {
 	return true


### PR DESCRIPTION
Keeps the repo internally consistent. The public interface is kept to prevent breakage.