### PR TITLE
CASSGO-33 snappy has been moved to a separate package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved the Snappy compressor into its own separate package (CASSGO-33)
+
 - Move lz4 compressor to lz4 package within the gocql module (CASSGO-32)
 
 - Don't restrict server authenticator unless PasswordAuthentictor.AllowedAuthenticators is provided (CASSGO-19)

--- a/common_test.go
+++ b/common_test.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql/lz4"
+	"github.com/gocql/gocql/snappy"
 )
 
 var (
@@ -112,7 +113,7 @@ func createCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
 
 	switch *flagCompressTest {
 	case "snappy":
-		cluster.Compressor = &SnappyCompressor{}
+		cluster.Compressor = &snappy.SnappyCompressor{}
 	case "lz4":
 		cluster.Compressor = &lz4.LZ4Compressor{}
 	case "no-compression":

--- a/compressor.go
+++ b/compressor.go
@@ -24,8 +24,6 @@
 
 package gocql
 
-import "github.com/golang/snappy"
-
 type Compressor interface {
 	Name() string
 
@@ -46,29 +44,4 @@ type Compressor interface {
 	// AppendDecompressed decompresses bytes from src and appends the decompressed bytes to dst.
 	// It returns a new byte slice that is the result of the append operation.
 	AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error)
-}
-
-// SnappyCompressor implements the Compressor interface and can be used to
-// compress incoming and outgoing frames. The snappy compression algorithm
-// aims for very high speeds and reasonable compression.
-type SnappyCompressor struct{}
-
-func (s SnappyCompressor) Name() string {
-	return "snappy"
-}
-
-func (s SnappyCompressor) AppendCompressedWithLength(dst, src []byte) ([]byte, error) {
-	return snappy.Encode(dst, src), nil
-}
-
-func (s SnappyCompressor) AppendDecompressedWithLength(dst, src []byte) ([]byte, error) {
-	return snappy.Decode(dst, src)
-}
-
-func (s SnappyCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
-	panic("SnappyCompressor.AppendCompressed is not supported")
-}
-
-func (s SnappyCompressor) AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error) {
-	panic("SnappyCompressor.AppendDecompressed is not supported")
 }

--- a/snappy/compressor.go
+++ b/snappy/compressor.go
@@ -1,0 +1,28 @@
+package snappy
+
+import "github.com/golang/snappy"
+
+// SnappyCompressor implements the Compressor interface and can be used to
+// compress incoming and outgoing frames. The snappy compression algorithm
+// aims for very high speeds and reasonable compression.
+type SnappyCompressor struct{}
+
+func (s SnappyCompressor) Name() string {
+	return "snappy"
+}
+
+func (s SnappyCompressor) AppendCompressedWithLength(dst, src []byte) ([]byte, error) {
+	return snappy.Encode(dst, src), nil
+}
+
+func (s SnappyCompressor) AppendDecompressedWithLength(dst, src []byte) ([]byte, error) {
+	return snappy.Decode(dst, src)
+}
+
+func (s SnappyCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	panic("SnappyCompressor.AppendCompressed is not supported")
+}
+
+func (s SnappyCompressor) AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error) {
+	panic("SnappyCompressor.AppendDecompressed is not supported")
+}

--- a/snappy/compressor_test.go
+++ b/snappy/compressor_test.go
@@ -22,7 +22,7 @@
  * See the NOTICE file distributed with this work for additional information.
  */
 
-package gocql
+package snappy
 
 import (
 	"bytes"


### PR DESCRIPTION
This PR should be reviewed right after https://github.com/apache/cassandra-gocql-driver/pull/1822 is merged.