### PR TITLE
CASSGO-40: skip metadata only if prepared result included metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't return error to caller with RetryType Ignore (CASSGO-28)
 
+- Skip metadata only if the prepared result includes metadata (CASSGO-40)
+
 - Don't panic in MapExecuteBatchCAS if no `[applied]` column is returned (CASSGO-42)
 
 ## [1.7.0] - 2024-09-23

--- a/conn.go
+++ b/conn.go
@@ -1375,7 +1375,8 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 			}
 		}
 
-		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata)
+		// if the metadata was not present in the response then we should not skip it
+		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata) && info != nil && info.response.flags&flagNoMetaData == 0
 
 		frame = &writeExecuteFrame{
 			preparedID:    info.id,


### PR DESCRIPTION
If the prepare result doesn't include metadata we shouldn't skip metadata when executing the query. Fixes CASSGO-40.

Patch by James Hartig for CASSGO-40