### PR TITLE
CASSGO-43: externally-defined type registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support vector type (CASSGO-11)
 - Allow SERIAL and LOCAL_SERIAL on SELECT statements (CASSGO-26)
 - Support of sending queries to the specific node with Query.SetHostID() (CASSGO-4)
-- Support for Native Protocol 5 (CASSGO-1)
+- Support for Native Protocol 5. Following protocol changes exposed new API
+  Query.SetKeyspace(), Query.WithNowInSeconds(), Batch.SetKeyspace(), Batch.WithNowInSeconds() (CASSGO-1)
+- Externally-defined type registration (CASSGO-43)
 
 ### Changed
 
@@ -36,12 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor HostInfo creation and ConnectAddress() method (CASSGO-45)
 - gocql.Compressor interface changes to follow append-like design. Bumped Go version to 1.19 (CASSGO-1)
 - Refactoring hostpool package test and Expose HostInfo creation (CASSGO-59)
-
 - Move "execute batch" methods to Batch type (CASSGO-57)
-
 - Make `Session` immutable by removing setters and associated mutex (CASSGO-23)
+- inet columns default to net.IP when using MapScan or SliceMap (CASSGO-43)
+- NativeType removed (CASSGO-43)
+- `New` and `NewWithError` removed and replaced with `Zero` (CASSGO-43)
 
 ### Fixed
+
 - Cassandra version unmarshal fix (CASSGO-49)
 - Retry policy now takes into account query idempotency (CASSGO-27)
 - Don't return error to caller with RetryType Ignore (CASSGO-28)
@@ -50,7 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip metadata only if the prepared result includes metadata (CASSGO-40)
 - Don't panic in MapExecuteBatchCAS if no `[applied]` column is returned (CASSGO-42)
 - Fix deadlock in refresh debouncer stop (CASSGO-41)
-
 - Endless query execution fix (CASSGO-50)
 
 ## [1.7.0] - 2024-09-23

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -645,7 +645,7 @@ func TestDurationType(t *testing.T) {
 	defer session.Close()
 
 	if session.cfg.ProtoVersion < 5 {
-		t.Skip("Duration type is not supported. Please use protocol version >= 4 and cassandra version >= 3.11")
+		t.Skip("Duration type is not supported. Please use protocol version > 4")
 	}
 
 	if err := createTable(session, `CREATE TABLE gocql_test.duration_table (
@@ -1068,7 +1068,7 @@ func TestMapScan(t *testing.T) {
 	}
 	assertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
 	assertEqual(t, "age", 30, row["age"])
-	assertEqual(t, "address", "10.0.0.2", row["address"])
+	assertDeepEqual(t, "address", net.ParseIP("10.0.0.2").To4(), row["address"])
 	assertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
 
 	// Second iteration using a new map
@@ -1078,7 +1078,7 @@ func TestMapScan(t *testing.T) {
 	}
 	assertEqual(t, "fullname", "Grace Hopper", row["fullname"])
 	assertEqual(t, "age", 31, row["age"])
-	assertEqual(t, "address", "10.0.0.1", row["address"])
+	assertDeepEqual(t, "address", net.ParseIP("10.0.0.1").To4(), row["address"])
 	assertDeepEqual(t, "data", []byte(nil), row["data"])
 }
 
@@ -1125,7 +1125,7 @@ func TestSliceMap(t *testing.T) {
 	m["testset"] = []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
 	m["testmap"] = map[string]string{"field1": "val1", "field2": "val2", "field3": "val3"}
 	m["testvarint"] = bigInt
-	m["testinet"] = "213.212.2.19"
+	m["testinet"] = net.ParseIP("213.212.2.19").To4()
 	sliceMap := []map[string]interface{}{m}
 	if err := session.Query(`INSERT INTO slice_map_table (testuuid, testtimestamp, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testdecimal, testlist, testset, testmap, testvarint, testinet) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		m["testuuid"], m["testtimestamp"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testdecimal"], m["testlist"], m["testset"], m["testmap"], m["testvarint"], m["testinet"]).Exec(); err != nil {
@@ -1157,51 +1157,105 @@ func TestSliceMap(t *testing.T) {
 }
 func matchSliceMap(t *testing.T, sliceMap []map[string]interface{}, testMap map[string]interface{}) {
 	if sliceMap[0]["testuuid"] != testMap["testuuid"] {
-		t.Fatal("returned testuuid did not match")
+		t.Fatalf("returned testuuid %#v did not match %#v", sliceMap[0]["testuuid"], testMap["testuuid"])
 	}
 	if sliceMap[0]["testtimestamp"] != testMap["testtimestamp"] {
-		t.Fatal("returned testtimestamp did not match")
+		t.Fatalf("returned testtimestamp %#v did not match %#v", sliceMap[0]["testtimestamp"], testMap["testtimestamp"])
 	}
 	if sliceMap[0]["testvarchar"] != testMap["testvarchar"] {
-		t.Fatal("returned testvarchar did not match")
+		t.Fatalf("returned testvarchar %#v did not match %#v", sliceMap[0]["testvarchar"], testMap["testvarchar"])
 	}
 	if sliceMap[0]["testbigint"] != testMap["testbigint"] {
-		t.Fatal("returned testbigint did not match")
+		t.Fatalf("returned testbigint %#v did not match %#v", sliceMap[0]["testbigint"], testMap["testbigint"])
 	}
 	if !reflect.DeepEqual(sliceMap[0]["testblob"], testMap["testblob"]) {
-		t.Fatal("returned testblob did not match")
+		t.Fatalf("returned testblob %#v did not match %#v", sliceMap[0]["testblob"], testMap["testblob"])
 	}
 	if sliceMap[0]["testbool"] != testMap["testbool"] {
-		t.Fatal("returned testbool did not match")
+		t.Fatalf("returned testbool %#v did not match %#v", sliceMap[0]["testbool"], testMap["testbool"])
 	}
 	if sliceMap[0]["testfloat"] != testMap["testfloat"] {
-		t.Fatal("returned testfloat did not match")
+		t.Fatalf("returned testfloat %#v did not match %#v", sliceMap[0]["testfloat"], testMap["testfloat"])
 	}
 	if sliceMap[0]["testdouble"] != testMap["testdouble"] {
-		t.Fatal("returned testdouble did not match")
+		t.Fatalf("returned testdouble %#v did not match %#v", sliceMap[0]["testdouble"], testMap["testdouble"])
 	}
-	if sliceMap[0]["testinet"] != testMap["testinet"] {
-		t.Fatal("returned testinet did not match")
+	if !reflect.DeepEqual(sliceMap[0]["testinet"], testMap["testinet"]) {
+		t.Fatalf("returned testinet %#v did not match %#v", sliceMap[0]["testinet"], testMap["testinet"])
 	}
 
 	expectedDecimal := sliceMap[0]["testdecimal"].(*inf.Dec)
 	returnedDecimal := testMap["testdecimal"].(*inf.Dec)
 
 	if expectedDecimal.Cmp(returnedDecimal) != 0 {
-		t.Fatal("returned testdecimal did not match")
+		t.Fatalf("returned testdecimal %#v did not match %#v", sliceMap[0]["testdecimal"], testMap["testdecimal"])
 	}
 
 	if !reflect.DeepEqual(sliceMap[0]["testlist"], testMap["testlist"]) {
-		t.Fatal("returned testlist did not match")
+		t.Fatalf("returned testlist %#v did not match %#v", sliceMap[0]["testlist"], testMap["testlist"])
 	}
 	if !reflect.DeepEqual(sliceMap[0]["testset"], testMap["testset"]) {
-		t.Fatal("returned testset did not match")
+		t.Fatalf("returned testset %#v did not match %#v", sliceMap[0]["testset"], testMap["testset"])
 	}
 	if !reflect.DeepEqual(sliceMap[0]["testmap"], testMap["testmap"]) {
-		t.Fatal("returned testmap did not match")
+		t.Fatalf("returned testmap %#v did not match %#v", sliceMap[0]["testmap"], testMap["testmap"])
 	}
 	if sliceMap[0]["testint"] != testMap["testint"] {
-		t.Fatal("returned testint did not match")
+		t.Fatalf("returned testint %#v did not match %#v", sliceMap[0]["testint"], testMap["testint"])
+	}
+}
+
+func TestSliceMap_CopySlices(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+	if err := createTable(session, `CREATE TABLE gocql_test.slice_map_copy_table (
+			t text,
+			u timeuuid,
+			l list<text>,
+			PRIMARY KEY (t, u)
+		)`); err != nil {
+		t.Fatal("create table:", err)
+	}
+
+	err := session.Query(
+		`INSERT INTO slice_map_copy_table (t, u, l) VALUES ('test', ?, ?)`,
+		TimeUUID(), []string{"1", "2"},
+	).Exec()
+	if err != nil {
+		t.Fatal("insert:", err)
+	}
+
+	err = session.Query(
+		`INSERT INTO slice_map_copy_table (t, u, l) VALUES ('test', ?, ?)`,
+		TimeUUID(), []string{"3", "4"},
+	).Exec()
+	if err != nil {
+		t.Fatal("insert:", err)
+	}
+
+	err = session.Query(
+		`INSERT INTO slice_map_copy_table (t, u, l) VALUES ('test', ?, ?)`,
+		TimeUUID(), []string{"5", "6"},
+	).Exec()
+	if err != nil {
+		t.Fatal("insert:", err)
+	}
+
+	if returned, retErr := session.Query(`SELECT * FROM slice_map_copy_table WHERE t = 'test'`).Iter().SliceMap(); retErr != nil {
+		t.Fatal("select:", retErr)
+	} else {
+		if len(returned) != 3 {
+			t.Fatal("expected 3 rows, got", len(returned))
+		}
+		if !reflect.DeepEqual(returned[0]["l"], []string{"1", "2"}) {
+			t.Fatal("expected [1, 2], got", returned[0]["l"])
+		}
+		if !reflect.DeepEqual(returned[1]["l"], []string{"3", "4"}) {
+			t.Fatal("expected [3, 4], got", returned[1]["l"])
+		}
+		if !reflect.DeepEqual(returned[2]["l"], []string{"5", "6"}) {
+			t.Fatal("expected [5, 6], got", returned[2]["l"])
+		}
 	}
 }
 
@@ -1278,7 +1332,7 @@ func TestSmallInt(t *testing.T) {
 		t.Fatal("select:", retErr)
 	} else {
 		if sliceMap[0]["testsmallint"] != returned[0]["testsmallint"] {
-			t.Fatal("returned testsmallint did not match")
+			t.Fatalf("returned testsmallint %#v did not match %#v", returned[0]["testsmallint"], sliceMap[0]["testsmallint"])
 		}
 	}
 }
@@ -1598,7 +1652,7 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 						Keyspace: "gocql_test",
 						Table:    table,
 						Name:     "foo",
-						TypeInfo: NativeType{
+						TypeInfo: varcharLikeTypeInfo{
 							typ: TypeVarchar,
 						},
 					},
@@ -2497,19 +2551,18 @@ func TestAggregateMetadata(t *testing.T) {
 		t.Fatal("expected two aggregates")
 	}
 
-	protoVer := byte(session.cfg.ProtoVersion)
 	expectedAggregrate := AggregateMetadata{
 		Keyspace:      "gocql_test",
 		Name:          "average",
-		ArgumentTypes: []TypeInfo{NativeType{typ: TypeInt, proto: protoVer}},
+		ArgumentTypes: []TypeInfo{intTypeInfo{}},
 		InitCond:      "(0, 0)",
-		ReturnType:    NativeType{typ: TypeDouble, proto: protoVer},
+		ReturnType:    doubleTypeInfo{},
 		StateType: TupleTypeInfo{
-			NativeType: NativeType{typ: TypeTuple, proto: protoVer},
-
 			Elems: []TypeInfo{
-				NativeType{typ: TypeInt, proto: protoVer},
-				NativeType{typ: TypeBigInt, proto: protoVer},
+				intTypeInfo{},
+				bigIntLikeTypeInfo{
+					typ: TypeBigInt,
+				},
 			},
 		},
 		stateFunc: "avgstate",
@@ -2522,11 +2575,11 @@ func TestAggregateMetadata(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(aggregates[0], expectedAggregrate) {
-		t.Fatalf("aggregate 'average' is %+v, but expected %+v", aggregates[0], expectedAggregrate)
+		t.Fatalf("aggregate 'average' is %#v, but expected %#v", aggregates[0], expectedAggregrate)
 	}
 	expectedAggregrate.Name = "average2"
 	if !reflect.DeepEqual(aggregates[1], expectedAggregrate) {
-		t.Fatalf("aggregate 'average2' is %+v, but expected %+v", aggregates[1], expectedAggregrate)
+		t.Fatalf("aggregate 'average2' is %#v, but expected %#v", aggregates[1], expectedAggregrate)
 	}
 }
 
@@ -2548,29 +2601,28 @@ func TestFunctionMetadata(t *testing.T) {
 	avgState := functions[1]
 	avgFinal := functions[0]
 
-	protoVer := byte(session.cfg.ProtoVersion)
 	avgStateBody := "if (val !=null) {state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue());}return state;"
 	expectedAvgState := FunctionMetadata{
 		Keyspace: "gocql_test",
 		Name:     "avgstate",
 		ArgumentTypes: []TypeInfo{
 			TupleTypeInfo{
-				NativeType: NativeType{typ: TypeTuple, proto: protoVer},
-
 				Elems: []TypeInfo{
-					NativeType{typ: TypeInt, proto: protoVer},
-					NativeType{typ: TypeBigInt, proto: protoVer},
+					intTypeInfo{},
+					bigIntLikeTypeInfo{
+						typ: TypeBigInt,
+					},
 				},
 			},
-			NativeType{typ: TypeInt, proto: protoVer},
+			intTypeInfo{},
 		},
 		ArgumentNames: []string{"state", "val"},
 		ReturnType: TupleTypeInfo{
-			NativeType: NativeType{typ: TypeTuple, proto: protoVer},
-
 			Elems: []TypeInfo{
-				NativeType{typ: TypeInt, proto: protoVer},
-				NativeType{typ: TypeBigInt, proto: protoVer},
+				intTypeInfo{},
+				bigIntLikeTypeInfo{
+					typ: TypeBigInt,
+				},
 			},
 		},
 		CalledOnNullInput: true,
@@ -2587,22 +2639,22 @@ func TestFunctionMetadata(t *testing.T) {
 		Name:     "avgfinal",
 		ArgumentTypes: []TypeInfo{
 			TupleTypeInfo{
-				NativeType: NativeType{typ: TypeTuple, proto: protoVer},
-
 				Elems: []TypeInfo{
-					NativeType{typ: TypeInt, proto: protoVer},
-					NativeType{typ: TypeBigInt, proto: protoVer},
+					intTypeInfo{},
+					bigIntLikeTypeInfo{
+						typ: TypeBigInt,
+					},
 				},
 			},
 		},
 		ArgumentNames:     []string{"state"},
-		ReturnType:        NativeType{typ: TypeDouble, proto: protoVer},
+		ReturnType:        doubleTypeInfo{},
 		CalledOnNullInput: true,
 		Language:          "java",
 		Body:              finalStateBody,
 	}
 	if !reflect.DeepEqual(avgFinal, expectedAvgFinal) {
-		t.Fatalf("function is %+v, but expected %+v", avgFinal, expectedAvgFinal)
+		t.Fatalf("function is %#v, but expected %#v", avgFinal, expectedAvgFinal)
 	}
 }
 
@@ -2700,20 +2752,25 @@ func TestKeyspaceMetadata(t *testing.T) {
 	if flagCassVersion.Before(3, 0, 0) {
 		textType = TypeVarchar
 	}
-	protoVer := byte(session.cfg.ProtoVersion)
 	expectedType := UserTypeMetadata{
 		Keyspace:   "gocql_test",
 		Name:       "basicview",
 		FieldNames: []string{"birthday", "nationality", "weight", "height"},
 		FieldTypes: []TypeInfo{
-			NativeType{typ: TypeTimestamp, proto: protoVer},
-			NativeType{typ: textType, proto: protoVer},
-			NativeType{typ: textType, proto: protoVer},
-			NativeType{typ: textType, proto: protoVer},
+			timestampTypeInfo{},
+			varcharLikeTypeInfo{
+				typ: textType,
+			},
+			varcharLikeTypeInfo{
+				typ: textType,
+			},
+			varcharLikeTypeInfo{
+				typ: textType,
+			},
 		},
 	}
 	if !reflect.DeepEqual(*keyspaceMetadata.UserTypes["basicview"], expectedType) {
-		t.Fatalf("type is %+v, but expected %+v", keyspaceMetadata.UserTypes["basicview"], expectedType)
+		t.Fatalf("type is %#v, but expected %#v", keyspaceMetadata.UserTypes["basicview"], expectedType)
 	}
 	if flagCassVersion.Major >= 3 {
 		materializedView, found := keyspaceMetadata.MaterializedViews["view_view"]
@@ -3520,9 +3577,9 @@ func TestQuery_SetKeyspace(t *testing.T) {
 	}
 
 	const keyspaceStmt = `
-		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test 
+		CREATE KEYSPACE IF NOT EXISTS gocql_query_keyspace_override_test
 		WITH replication = {
-			'class': 'SimpleStrategy', 
+			'class': 'SimpleStrategy',
 			'replication_factor': '1'
 		};
 `

--- a/cluster.go
+++ b/cluster.go
@@ -274,6 +274,10 @@ type ClusterConfig struct {
 	// default: 0.25.
 	NextPagePrefetch float64
 
+	// RegisteredTypes will be copied for all sessions created from this Cluster.
+	// If not provided, a copy of GlobalTypes will be used.
+	RegisteredTypes *RegisteredTypes
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/common_test.go
+++ b/common_test.go
@@ -245,7 +245,7 @@ func createFunctions(t *testing.T, session *Session) {
 		CALLED ON NULL INPUT
 		RETURNS double
 		LANGUAGE java AS
-		$$double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r/= state.getInt(0); return Double.valueOf(r);$$ 
+		$$double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r/= state.getInt(0); return Double.valueOf(r);$$
 	`).Exec(); err != nil {
 		t.Fatalf("failed to create function with err: %v", err)
 	}
@@ -297,20 +297,20 @@ func randomText(size int) string {
 func assertEqual(t *testing.T, description string, expected, actual interface{}) {
 	t.Helper()
 	if expected != actual {
-		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
+		t.Fatalf("expected %s to be (%#v) but was (%#v) instead", description, expected, actual)
 	}
 }
 
 func assertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
+		t.Fatalf("expected %s to be (%#v) but was (%#v) instead", description, expected, actual)
 	}
 }
 
 func assertNil(t *testing.T, description string, actual interface{}) {
 	t.Helper()
 	if actual != nil {
-		t.Fatalf("expected %s to be (nil) but was (%+v) instead", description, actual)
+		t.Fatalf("expected %s to be (nil) but was (%#v) instead", description, actual)
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -25,392 +25,20 @@
 package gocql
 
 import (
-	"encoding/hex"
 	"fmt"
-	"math/big"
 	"net"
 	"reflect"
-	"strconv"
-	"strings"
-	"time"
-
-	"gopkg.in/inf.v0"
 )
 
+// RowData contains the column names and pointers to the default values for each
+// column
 type RowData struct {
 	Columns []string
 	Values  []interface{}
 }
 
-func goType(t TypeInfo) (reflect.Type, error) {
-	switch t.Type() {
-	case TypeVarchar, TypeAscii, TypeInet, TypeText:
-		return reflect.TypeOf(*new(string)), nil
-	case TypeBigInt, TypeCounter:
-		return reflect.TypeOf(*new(int64)), nil
-	case TypeTime:
-		return reflect.TypeOf(*new(time.Duration)), nil
-	case TypeTimestamp:
-		return reflect.TypeOf(*new(time.Time)), nil
-	case TypeBlob:
-		return reflect.TypeOf(*new([]byte)), nil
-	case TypeBoolean:
-		return reflect.TypeOf(*new(bool)), nil
-	case TypeFloat:
-		return reflect.TypeOf(*new(float32)), nil
-	case TypeDouble:
-		return reflect.TypeOf(*new(float64)), nil
-	case TypeInt:
-		return reflect.TypeOf(*new(int)), nil
-	case TypeSmallInt:
-		return reflect.TypeOf(*new(int16)), nil
-	case TypeTinyInt:
-		return reflect.TypeOf(*new(int8)), nil
-	case TypeDecimal:
-		return reflect.TypeOf(*new(*inf.Dec)), nil
-	case TypeUUID, TypeTimeUUID:
-		return reflect.TypeOf(*new(UUID)), nil
-	case TypeList, TypeSet:
-		elemType, err := goType(t.(CollectionType).Elem)
-		if err != nil {
-			return nil, err
-		}
-		return reflect.SliceOf(elemType), nil
-	case TypeMap:
-		keyType, err := goType(t.(CollectionType).Key)
-		if err != nil {
-			return nil, err
-		}
-		valueType, err := goType(t.(CollectionType).Elem)
-		if err != nil {
-			return nil, err
-		}
-		return reflect.MapOf(keyType, valueType), nil
-	case TypeVarint:
-		return reflect.TypeOf(*new(*big.Int)), nil
-	case TypeTuple:
-		// what can we do here? all there is to do is to make a list of interface{}
-		tuple := t.(TupleTypeInfo)
-		return reflect.TypeOf(make([]interface{}, len(tuple.Elems))), nil
-	case TypeUDT:
-		return reflect.TypeOf(make(map[string]interface{})), nil
-	case TypeDate:
-		return reflect.TypeOf(*new(time.Time)), nil
-	case TypeDuration:
-		return reflect.TypeOf(*new(Duration)), nil
-	default:
-		return nil, fmt.Errorf("cannot create Go type for unknown CQL type %s", t)
-	}
-}
-
 func dereference(i interface{}) interface{} {
 	return reflect.Indirect(reflect.ValueOf(i)).Interface()
-}
-
-func getCassandraBaseType(name string) Type {
-	switch name {
-	case "ascii":
-		return TypeAscii
-	case "bigint":
-		return TypeBigInt
-	case "blob":
-		return TypeBlob
-	case "boolean":
-		return TypeBoolean
-	case "counter":
-		return TypeCounter
-	case "date":
-		return TypeDate
-	case "decimal":
-		return TypeDecimal
-	case "double":
-		return TypeDouble
-	case "duration":
-		return TypeDuration
-	case "float":
-		return TypeFloat
-	case "int":
-		return TypeInt
-	case "smallint":
-		return TypeSmallInt
-	case "tinyint":
-		return TypeTinyInt
-	case "time":
-		return TypeTime
-	case "timestamp":
-		return TypeTimestamp
-	case "uuid":
-		return TypeUUID
-	case "varchar":
-		return TypeVarchar
-	case "text":
-		return TypeText
-	case "varint":
-		return TypeVarint
-	case "timeuuid":
-		return TypeTimeUUID
-	case "inet":
-		return TypeInet
-	case "MapType":
-		return TypeMap
-	case "ListType":
-		return TypeList
-	case "SetType":
-		return TypeSet
-	case "TupleType":
-		return TypeTuple
-	default:
-		return TypeCustom
-	}
-}
-
-// TODO: Cover with unit tests.
-// Parses long Java-style type definition to internal data structures.
-func getCassandraLongType(name string, protoVer byte, logger StdLogger) TypeInfo {
-	if strings.HasPrefix(name, SET_TYPE) {
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeSet),
-			Elem:       getCassandraLongType(unwrapCompositeTypeDefinition(name, SET_TYPE, '('), protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, LIST_TYPE) {
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeList),
-			Elem:       getCassandraLongType(unwrapCompositeTypeDefinition(name, LIST_TYPE, '('), protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, MAP_TYPE) {
-		names := splitJavaCompositeTypes(name, MAP_TYPE)
-		if len(names) != 2 {
-			logger.Printf("gocql: error parsing map type, it has %d subelements, expecting 2\n", len(names))
-			return NewNativeType(protoVer, TypeCustom)
-		}
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeMap),
-			Key:        getCassandraLongType(names[0], protoVer, logger),
-			Elem:       getCassandraLongType(names[1], protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, TUPLE_TYPE) {
-		names := splitJavaCompositeTypes(name, TUPLE_TYPE)
-		types := make([]TypeInfo, len(names))
-
-		for i, name := range names {
-			types[i] = getCassandraLongType(name, protoVer, logger)
-		}
-
-		return TupleTypeInfo{
-			NativeType: NewNativeType(protoVer, TypeTuple),
-			Elems:      types,
-		}
-	} else if strings.HasPrefix(name, UDT_TYPE) {
-		names := splitJavaCompositeTypes(name, UDT_TYPE)
-		fields := make([]UDTField, len(names)-2)
-
-		for i := 2; i < len(names); i++ {
-			spec := strings.Split(names[i], ":")
-			fieldName, _ := hex.DecodeString(spec[0])
-			fields[i-2] = UDTField{
-				Name: string(fieldName),
-				Type: getCassandraLongType(spec[1], protoVer, logger),
-			}
-		}
-
-		udtName, _ := hex.DecodeString(names[1])
-		return UDTTypeInfo{
-			NativeType: NewNativeType(protoVer, TypeUDT),
-			KeySpace:   names[0],
-			Name:       string(udtName),
-			Elements:   fields,
-		}
-	} else if strings.HasPrefix(name, VECTOR_TYPE) {
-		names := splitJavaCompositeTypes(name, VECTOR_TYPE)
-		subType := getCassandraLongType(strings.TrimSpace(names[0]), protoVer, logger)
-		dim, err := strconv.Atoi(strings.TrimSpace(names[1]))
-		if err != nil {
-			logger.Printf("gocql: error parsing vector dimensions: %v\n", err)
-			return NewNativeType(protoVer, TypeCustom)
-		}
-
-		return VectorType{
-			NativeType: NewCustomType(protoVer, TypeCustom, VECTOR_TYPE),
-			SubType:    subType,
-			Dimensions: dim,
-		}
-	} else {
-		// basic type
-		return NativeType{
-			proto: protoVer,
-			typ:   getApacheCassandraType(name),
-		}
-	}
-}
-
-// Parses short CQL type representation (e.g. map<text, text>) to internal data structures.
-func getCassandraType(name string, protoVer byte, logger StdLogger) TypeInfo {
-	if strings.HasPrefix(name, "frozen<") {
-		return getCassandraType(unwrapCompositeTypeDefinition(name, "frozen", '<'), protoVer, logger)
-	} else if strings.HasPrefix(name, "set<") {
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeSet),
-			Elem:       getCassandraType(unwrapCompositeTypeDefinition(name, "set", '<'), protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, "list<") {
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeList),
-			Elem:       getCassandraType(unwrapCompositeTypeDefinition(name, "list", '<'), protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, "map<") {
-		names := splitCQLCompositeTypes(name, "map")
-		if len(names) != 2 {
-			logger.Printf("Error parsing map type, it has %d subelements, expecting 2\n", len(names))
-			return NewNativeType(protoVer, TypeCustom)
-		}
-		return CollectionType{
-			NativeType: NewNativeType(protoVer, TypeMap),
-			Key:        getCassandraType(names[0], protoVer, logger),
-			Elem:       getCassandraType(names[1], protoVer, logger),
-		}
-	} else if strings.HasPrefix(name, "tuple<") {
-		names := splitCQLCompositeTypes(name, "tuple")
-		types := make([]TypeInfo, len(names))
-
-		for i, name := range names {
-			types[i] = getCassandraType(name, protoVer, logger)
-		}
-
-		return TupleTypeInfo{
-			NativeType: NewNativeType(protoVer, TypeTuple),
-			Elems:      types,
-		}
-	} else if strings.HasPrefix(name, "vector<") {
-		names := splitCQLCompositeTypes(name, "vector")
-		subType := getCassandraType(strings.TrimSpace(names[0]), protoVer, logger)
-		dim, _ := strconv.Atoi(strings.TrimSpace(names[1]))
-
-		return VectorType{
-			NativeType: NewCustomType(protoVer, TypeCustom, VECTOR_TYPE),
-			SubType:    subType,
-			Dimensions: dim,
-		}
-	} else {
-		return NativeType{
-			proto: protoVer,
-			typ:   getCassandraBaseType(name),
-		}
-	}
-}
-
-func splitCQLCompositeTypes(name string, typeName string) []string {
-	return splitCompositeTypes(name, typeName, '<', '>')
-}
-
-func splitJavaCompositeTypes(name string, typeName string) []string {
-	return splitCompositeTypes(name, typeName, '(', ')')
-}
-
-func unwrapCompositeTypeDefinition(name string, typeName string, typeOpen int32) string {
-	return strings.TrimPrefix(name[:len(name)-1], typeName+string(typeOpen))
-}
-
-func splitCompositeTypes(name string, typeName string, typeOpen int32, typeClose int32) []string {
-	def := unwrapCompositeTypeDefinition(name, typeName, typeOpen)
-	if !strings.Contains(def, string(typeOpen)) {
-		parts := strings.Split(def, ",")
-		for i := range parts {
-			parts[i] = strings.TrimSpace(parts[i])
-		}
-		return parts
-	}
-	var parts []string
-	lessCount := 0
-	segment := ""
-	for _, char := range def {
-		if char == ',' && lessCount == 0 {
-			if segment != "" {
-				parts = append(parts, strings.TrimSpace(segment))
-			}
-			segment = ""
-			continue
-		}
-		segment += string(char)
-		if char == typeOpen {
-			lessCount++
-		} else if char == typeClose {
-			lessCount--
-		}
-	}
-	if segment != "" {
-		parts = append(parts, strings.TrimSpace(segment))
-	}
-	return parts
-}
-
-func getApacheCassandraType(class string) Type {
-	switch strings.TrimPrefix(class, apacheCassandraTypePrefix) {
-	case "AsciiType":
-		return TypeAscii
-	case "LongType":
-		return TypeBigInt
-	case "BytesType":
-		return TypeBlob
-	case "BooleanType":
-		return TypeBoolean
-	case "CounterColumnType":
-		return TypeCounter
-	case "DecimalType":
-		return TypeDecimal
-	case "DoubleType":
-		return TypeDouble
-	case "FloatType":
-		return TypeFloat
-	case "Int32Type":
-		return TypeInt
-	case "ShortType":
-		return TypeSmallInt
-	case "ByteType":
-		return TypeTinyInt
-	case "TimeType":
-		return TypeTime
-	case "DateType", "TimestampType":
-		return TypeTimestamp
-	case "UUIDType", "LexicalUUIDType":
-		return TypeUUID
-	case "UTF8Type":
-		return TypeVarchar
-	case "IntegerType":
-		return TypeVarint
-	case "TimeUUIDType":
-		return TypeTimeUUID
-	case "InetAddressType":
-		return TypeInet
-	case "MapType":
-		return TypeMap
-	case "ListType":
-		return TypeList
-	case "SetType":
-		return TypeSet
-	case "TupleType":
-		return TypeTuple
-	case "DurationType":
-		return TypeDuration
-	case "SimpleDateType":
-		return TypeDate
-	case "UserType":
-		return TypeUDT
-	default:
-		return TypeCustom
-	}
-}
-
-func (r *RowData) rowMap(m map[string]interface{}) {
-	for i, column := range r.Columns {
-		val := dereference(r.Values[i])
-		if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice && !valVal.IsNil() {
-			valCopy := reflect.MakeSlice(valVal.Type(), valVal.Len(), valVal.Cap())
-			reflect.Copy(valCopy, valVal)
-			m[column] = valCopy.Interface()
-		} else {
-			m[column] = val
-		}
-	}
 }
 
 // TupeColumnName will return the column name of a tuple value in a column named
@@ -431,22 +59,15 @@ func (iter *Iter) RowData() (RowData, error) {
 
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
-			val, err := column.TypeInfo.NewWithError()
-			if err != nil {
-				iter.err = err
-				return RowData{}, err
-			}
+			val := c.Zero()
 			columns = append(columns, column.Name)
-			values = append(values, val)
+			values = append(values, &val)
 		} else {
 			for i, elem := range c.Elems {
 				columns = append(columns, TupleColumnName(column.Name, i))
-				val, err := elem.NewWithError()
-				if err != nil {
-					iter.err = err
-					return RowData{}, err
-				}
-				values = append(values, val)
+				var val interface{}
+				val = elem.Zero()
+				values = append(values, &val)
 			}
 		}
 	}
@@ -459,22 +80,6 @@ func (iter *Iter) RowData() (RowData, error) {
 	return rowData, nil
 }
 
-// TODO(zariel): is it worth exporting this?
-func (iter *Iter) rowMap() (map[string]interface{}, error) {
-	if iter.err != nil {
-		return nil, iter.err
-	}
-
-	rowData, err := iter.RowData()
-	if err != nil {
-		return nil, err
-	}
-	iter.Scan(rowData.Values...)
-	m := make(map[string]interface{}, len(rowData.Columns))
-	rowData.rowMap(m)
-	return m, nil
-}
-
 // SliceMap is a helper function to make the API easier to use
 // returns the data from the query in the form of []map[string]interface{}
 func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
@@ -482,15 +87,13 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 		return nil, iter.err
 	}
 
-	// Not checking for the error because we just did
-	rowData, err := iter.RowData()
-	if err != nil {
-		return nil, err
-	}
-	dataToReturn := make([]map[string]interface{}, 0)
-	for iter.Scan(rowData.Values...) {
-		m := make(map[string]interface{}, len(rowData.Columns))
-		rowData.rowMap(m)
+	numCols := len(iter.Columns())
+	var dataToReturn []map[string]interface{}
+	for {
+		m := make(map[string]interface{}, numCols)
+		if !iter.MapScan(m) {
+			break
+		}
 		dataToReturn = append(dataToReturn, m)
 	}
 	if iter.err != nil {
@@ -542,19 +145,43 @@ func (iter *Iter) MapScan(m map[string]interface{}) bool {
 		return false
 	}
 
-	rowData, err := iter.RowData()
-	if err != nil {
-		return false
-	}
-
-	for i, col := range rowData.Columns {
-		if dest, ok := m[col]; ok {
-			rowData.Values[i] = dest
+	cols := iter.Columns()
+	columnNames := make([]string, 0, len(cols))
+	values := make([]interface{}, 0, len(cols))
+	for _, column := range iter.Columns() {
+		if c, ok := column.TypeInfo.(TupleTypeInfo); ok {
+			for i := range c.Elems {
+				columnName := TupleColumnName(column.Name, i)
+				if dest, ok := m[columnName]; ok {
+					values = append(values, dest)
+				} else {
+					zero := c.Elems[i].Zero()
+					// technically this is a *interface{} but later we will fix it
+					values = append(values, &zero)
+				}
+				columnNames = append(columnNames, columnName)
+			}
+		} else {
+			if dest, ok := m[column.Name]; ok {
+				values = append(values, dest)
+			} else {
+				zero := column.TypeInfo.Zero()
+				// technically this is a *interface{} but later we will fix it
+				values = append(values, &zero)
+			}
+			columnNames = append(columnNames, column.Name)
 		}
 	}
-
-	if iter.Scan(rowData.Values...) {
-		rowData.rowMap(m)
+	if iter.Scan(values...) {
+		for i, name := range columnNames {
+			if iptr, ok := values[i].(*interface{}); ok {
+				m[name] = *iptr
+			} else {
+				// TODO: it seems wrong to dereference the values that were passed in
+				// originally in the map but that's what it was doing before
+				m[name] = dereference(values[i])
+			}
+		}
 		return true
 	}
 	return false

--- a/host_source.go
+++ b/host_source.go
@@ -499,7 +499,7 @@ func (s *Session) newHostInfoFromMap(addr net.IP, port int, row map[string]inter
 // Given a map that represents a row from either system.local or system.peers
 // return as much information as we can in *HostInfo
 func (s *Session) hostInfoFromMap(row map[string]interface{}, host *HostInfo) (*HostInfo, error) {
-	const assertErrorMsg = "Assertion failed for %s"
+	const assertErrorMsg = "Assertion failed for %s, type was %T"
 	var ok bool
 
 	// Default to our connected port if the cluster doesn't have port information
@@ -508,101 +508,101 @@ func (s *Session) hostInfoFromMap(row map[string]interface{}, host *HostInfo) (*
 		case "data_center":
 			host.dataCenter, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "data_center")
+				return nil, fmt.Errorf(assertErrorMsg, "data_center", value)
 			}
 		case "rack":
 			host.rack, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "rack")
+				return nil, fmt.Errorf(assertErrorMsg, "rack", value)
 			}
 		case "host_id":
 			hostId, ok := value.(UUID)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "host_id")
+				return nil, fmt.Errorf(assertErrorMsg, "host_id", value)
 			}
 			host.hostId = hostId.String()
 		case "release_version":
 			version, ok := value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "release_version")
+				return nil, fmt.Errorf(assertErrorMsg, "release_version", value)
 			}
 			host.version.Set(version)
 		case "peer":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "peer")
+				return nil, fmt.Errorf(assertErrorMsg, "peer", value)
 			}
-			host.peer = net.ParseIP(ip)
+			host.peer = ip
 		case "cluster_name":
 			host.clusterName, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "cluster_name")
+				return nil, fmt.Errorf(assertErrorMsg, "cluster_name", value)
 			}
 		case "partitioner":
 			host.partitioner, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "partitioner")
+				return nil, fmt.Errorf(assertErrorMsg, "partitioner", value)
 			}
 		case "broadcast_address":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "broadcast_address")
+				return nil, fmt.Errorf(assertErrorMsg, "broadcast_address", value)
 			}
-			host.broadcastAddress = net.ParseIP(ip)
+			host.broadcastAddress = ip
 		case "preferred_ip":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "preferred_ip")
+				return nil, fmt.Errorf(assertErrorMsg, "preferred_ip", value)
 			}
-			host.preferredIP = net.ParseIP(ip)
+			host.preferredIP = ip
 		case "rpc_address":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "rpc_address")
+				return nil, fmt.Errorf(assertErrorMsg, "rpc_address", value)
 			}
-			host.rpcAddress = net.ParseIP(ip)
+			host.rpcAddress = ip
 		case "native_address":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "native_address")
+				return nil, fmt.Errorf(assertErrorMsg, "native_address", value)
 			}
-			host.rpcAddress = net.ParseIP(ip)
+			host.rpcAddress = ip
 		case "listen_address":
-			ip, ok := value.(string)
+			ip, ok := value.(net.IP)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "listen_address")
+				return nil, fmt.Errorf(assertErrorMsg, "listen_address", value)
 			}
-			host.listenAddress = net.ParseIP(ip)
+			host.listenAddress = ip
 		case "native_port":
 			native_port, ok := value.(int)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "native_port")
+				return nil, fmt.Errorf(assertErrorMsg, "native_port", value)
 			}
 			host.port = native_port
 		case "workload":
 			host.workload, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "workload")
+				return nil, fmt.Errorf(assertErrorMsg, "workload", value)
 			}
 		case "graph":
 			host.graph, ok = value.(bool)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "graph")
+				return nil, fmt.Errorf(assertErrorMsg, "graph", value)
 			}
 		case "tokens":
 			host.tokens, ok = value.([]string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "tokens")
+				return nil, fmt.Errorf(assertErrorMsg, "tokens", value)
 			}
 		case "dse_version":
 			host.dseVersion, ok = value.(string)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "dse_version")
+				return nil, fmt.Errorf(assertErrorMsg, "dse_version", value)
 			}
 		case "schema_version":
 			schemaVersion, ok := value.(UUID)
 			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "schema_version")
+				return nil, fmt.Errorf(assertErrorMsg, "schema_version", value)
 			}
 			host.schemaVersion = schemaVersion.String()
 		}

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -29,7 +29,6 @@ package gocql
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -58,7 +57,6 @@ func TestUnmarshalCassVersion(t *testing.T) {
 		} else if *v != test.version {
 			t.Errorf("%d: expected %#+v got %#+v", i, test.version, *v)
 		}
-		fmt.Println(v.String())
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -204,7 +204,7 @@ func TestCustomPayloadMessages(t *testing.T) {
 	iter := query.Iter()
 	rCustomPayload := iter.GetCustomPayload()
 	if !reflect.DeepEqual(customPayload, rCustomPayload) {
-		t.Fatal("The received custom payload should match the sent")
+		t.Fatalf("The received custom payload %#v should match the sent %#v", rCustomPayload, customPayload)
 	}
 	iter.Close()
 
@@ -213,7 +213,7 @@ func TestCustomPayloadMessages(t *testing.T) {
 	iter = query.Iter()
 	rCustomPayload = iter.GetCustomPayload()
 	if !reflect.DeepEqual(customPayload, rCustomPayload) {
-		t.Fatal("The received custom payload should match the sent")
+		t.Fatalf("The received custom payload %#v should match the sent %#v", rCustomPayload, customPayload)
 	}
 	iter.Close()
 
@@ -242,7 +242,7 @@ func TestCustomPayloadValues(t *testing.T) {
 		iter := query.Iter()
 		rCustomPayload := iter.GetCustomPayload()
 		if !reflect.DeepEqual(customPayload, rCustomPayload) {
-			t.Fatal("The received custom payload should match the sent")
+			t.Fatalf("The received custom payload %#v should match the sent %#v", rCustomPayload, customPayload)
 		}
 	}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -30,7 +30,6 @@ package gocql
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"math"
 	"math/big"
 	"net"
@@ -59,56 +58,56 @@ var marshalTests = []struct {
 	UnmarshalError error
 }{
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("hello world"),
 		[]byte("hello world"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("hello world"),
 		"hello world",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte(nil),
 		[]byte(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("hello world"),
 		MyString("hello world"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("HELLO WORLD"),
 		CustomString("hello world"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBlob},
+		varcharLikeTypeInfo{typ: TypeBlob},
 		[]byte("hello\x00"),
 		[]byte("hello\x00"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBlob},
+		varcharLikeTypeInfo{typ: TypeBlob},
 		[]byte(nil),
 		[]byte(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimeUUID},
+		timeUUIDType{},
 		[]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		func() UUID {
 			x, _ := UUIDFromBytes([]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0})
@@ -118,287 +117,287 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimeUUID},
+		timeUUIDType{},
 		[]byte{0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		[]byte{0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		MarshalError("can not marshal []byte 6 bytes long into timeuuid, must be exactly 16 bytes long"),
-		UnmarshalError("unable to parse UUID: UUIDs must be exactly 16 bytes long"),
+		UnmarshalError("unable to parse timeuuid: UUIDs must be exactly 16 bytes long"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimeUUID},
+		timeUUIDType{},
 		[]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		[16]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x00\x00\x00"),
 		0,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x01\x02\x03\x04"),
 		int(16909060),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x01\x02\x03\x04"),
 		AliasInt(16909060),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x80\x00\x00\x00"),
 		int32(math.MinInt32),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x7f\xff\xff\xff"),
 		int32(math.MaxInt32),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x00\x00\x00"),
 		"0",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x01\x02\x03\x04"),
 		"16909060",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x80\x00\x00\x00"),
 		"-2147483648", // math.MinInt32
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x7f\xff\xff\xff"),
 		"2147483647", // math.MaxInt32
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
 		0,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x01\x02\x03\x04\x05\x06\x07\x08"),
 		72623859790382856,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
 		int64(math.MinInt64),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
 		int64(math.MaxInt64),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
 		"0",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x01\x02\x03\x04\x05\x06\x07\x08"),
 		"72623859790382856",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
 		"-9223372036854775808", // math.MinInt64
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
 		"9223372036854775807", // math.MaxInt64
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBoolean},
+		booleanTypeInfo{},
 		[]byte("\x00"),
 		false,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBoolean},
+		booleanTypeInfo{},
 		[]byte("\x01"),
 		true,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeFloat},
+		floatTypeInfo{},
 		[]byte("\x40\x49\x0f\xdb"),
 		float32(3.14159265),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDouble},
+		doubleTypeInfo{},
 		[]byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1"),
 		float64(3.14159265),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x00\x00"),
 		inf.NewDec(0, 0),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x00\x64"),
 		inf.NewDec(100, 0),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x02\x19"),
 		decimalize("0.25"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x13\xD5\a;\x20\x14\xA2\x91"),
 		decimalize("-0.0012095473475870063"), // From the iconara/cql-rb test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x13*\xF8\xC4\xDF\xEB]o"),
 		decimalize("0.0012095473475870063"), // From the iconara/cql-rb test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x12\xF2\xD8\x02\xB6R\x7F\x99\xEE\x98#\x99\xA9V"),
 		decimalize("-1042342234234.123423435647768234"), // From the iconara/cql-rb test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\r\nJ\x04\"^\x91\x04\x8a\xb1\x18\xfe"),
 		decimalize("1243878957943.1234124191998"), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x06\xe5\xde]\x98Y"),
 		decimalize("-112233.441191"), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x14\x00\xfa\xce"),
 		decimalize("0.00000000000000064206"), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\x00\x00\x00\x14\xff\x052"),
 		decimalize("-0.00000000000000064206"), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\xff\xff\xff\x9c\x00\xfa\xce"),
 		inf.NewDec(64206, -100), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion4, typ: TypeTime},
+		timeTypeInfo{},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		time.Duration(int64(1376387523000)),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion4, typ: TypeTime},
+		timeTypeInfo{},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		int64(1376387523000),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimestamp},
+		timestampTypeInfo{},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		time.Date(2013, time.August, 13, 9, 52, 3, 0, time.UTC),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimestamp},
+		timestampTypeInfo{},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		int64(1376387523000),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa2\xc3\xc2\x9a\xe0F\x91\x06"),
 		Duration{Months: 1233, Days: 123213, Nanoseconds: 2312323},
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa1\xc3\xc2\x99\xe0F\x91\x05"),
 		Duration{Months: -1233, Days: -123213, Nanoseconds: -2312323},
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x02\x04\x80\xe6"),
 		Duration{Months: 1, Days: 2, Nanoseconds: 115},
 		nil,
@@ -406,8 +405,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeList,
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
 		[]int{1, 2},
@@ -416,8 +415,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeList,
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
 		[2]int{1, 2},
@@ -426,8 +425,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeSet},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeSet,
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
 		[]int{1, 2},
@@ -436,8 +435,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeSet},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeSet,
+			Elem: intTypeInfo{},
 		},
 		[]byte{0, 0, 0, 0}, // encoding of a list should always include the size of the collection
 		[]int{},
@@ -446,9 +445,9 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x03foo\x00\x00\x00\x04\x00\x00\x00\x01"),
 		map[string]int{"foo": 1},
@@ -457,9 +456,9 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte{0, 0, 0, 0},
 		map[string]int{},
@@ -468,8 +467,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+			typ:  TypeList,
+			Elem: varcharLikeTypeInfo{typ: TypeVarchar},
 		},
 		bytes.Join([][]byte{
 			[]byte("\x00\x00\x00\x01\x00\x00\xff\xff"),
@@ -480,9 +479,9 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: varcharLikeTypeInfo{typ: TypeVarchar},
 		},
 		bytes.Join([][]byte{
 			[]byte("\x00\x00\x00\x01\x00\x00\xff\xff"),
@@ -496,119 +495,119 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("\x00"),
 		0,
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("\x37\xE2\x3C\xEC"),
 		int32(937573612),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("\x37\xE2\x3C\xEC"),
 		big.NewInt(937573612),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("\x03\x9EV \x15\f\x03\x9DK\x18\xCDI\\$?\a["),
 		bigintize("1231312312331283012830129382342342412123"), // From the iconara/cql-rb test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("\xC9v\x8D:\x86"),
 		big.NewInt(-234234234234), // From the iconara/cql-rb test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte("f\x1e\xfd\xf2\xe3\xb1\x9f|\x04_\x15"),
 		bigintize("123456789123456789123456789"), // From the datastax/python-driver test suite
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarint},
+		varintTypeInfo{},
 		[]byte(nil),
 		nil,
 		nil,
 		UnmarshalError("can not unmarshal into non-pointer <nil>"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\x7F\x00\x00\x01"),
 		net.ParseIP("127.0.0.1").To4(),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\xFF\xFF\xFF\xFF"),
 		net.ParseIP("255.255.255.255").To4(),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\x7F\x00\x00\x01"),
 		"127.0.0.1",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\xFF\xFF\xFF\xFF"),
 		"255.255.255.255",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\x21\xDA\x00\xd3\x00\x00\x2f\x3b\x02\xaa\x00\xff\xfe\x28\x9c\x5a"),
 		"21da:d3:0:2f3b:2aa:ff:fe28:9c5a",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x02\xb3\xff\xfe\x1e\x83\x29"),
 		"fe80::202:b3ff:fe1e:8329",
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\x21\xDA\x00\xd3\x00\x00\x2f\x3b\x02\xaa\x00\xff\xfe\x28\x9c\x5a"),
 		net.ParseIP("21da:d3:0:2f3b:2aa:ff:fe28:9c5a"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x02\xb3\xff\xfe\x1e\x83\x29"),
 		net.ParseIP("fe80::202:b3ff:fe1e:8329"),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte(nil),
 		nil,
 		nil,
 		UnmarshalError("can not unmarshal into non-pointer <nil>"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("nullable string"),
 		func() *string {
 			value := "nullable string"
@@ -618,14 +617,14 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte(nil),
 		(*string)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x7f\xff\xff\xff"),
 		func() *int {
 			var value int = math.MaxInt32
@@ -635,28 +634,28 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte(nil),
 		(*int)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimeUUID},
+		timeUUIDType{},
 		[]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		&UUID{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimeUUID},
+		timeUUIDType{},
 		[]byte(nil),
 		(*UUID)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimestamp},
+		timestampTypeInfo{},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		func() *time.Time {
 			t := time.Date(2013, time.August, 13, 9, 52, 3, 0, time.UTC)
@@ -666,14 +665,14 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTimestamp},
+		timestampTypeInfo{},
 		[]byte(nil),
 		(*time.Time)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBoolean},
+		booleanTypeInfo{},
 		[]byte("\x00"),
 		func() *bool {
 			b := false
@@ -683,7 +682,7 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBoolean},
+		booleanTypeInfo{},
 		[]byte("\x01"),
 		func() *bool {
 			b := true
@@ -693,14 +692,14 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBoolean},
+		booleanTypeInfo{},
 		[]byte(nil),
 		(*bool)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeFloat},
+		floatTypeInfo{},
 		[]byte("\x40\x49\x0f\xdb"),
 		func() *float32 {
 			f := float32(3.14159265)
@@ -710,14 +709,14 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeFloat},
+		floatTypeInfo{},
 		[]byte(nil),
 		(*float32)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDouble},
+		doubleTypeInfo{},
 		[]byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1"),
 		func() *float64 {
 			d := float64(3.14159265)
@@ -727,14 +726,14 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDouble},
+		doubleTypeInfo{},
 		[]byte(nil),
 		(*float64)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte("\x7F\x00\x00\x01"),
 		func() *net.IP {
 			ip := net.ParseIP("127.0.0.1").To4()
@@ -744,7 +743,7 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInet},
+		inetType{},
 		[]byte(nil),
 		(*net.IP)(nil),
 		nil,
@@ -752,8 +751,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeList,
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
 		func() *[]int {
@@ -765,21 +764,8 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
-		},
-		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02"),
-		func() *[]int {
-			l := []int{1, 2}
-			return &l
-		}(),
-		nil,
-		nil,
-	},
-	{
-		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeList,
+			Elem: intTypeInfo{},
 		},
 		[]byte(nil),
 		(*[]int)(nil),
@@ -788,9 +774,9 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x03foo\x00\x00\x00\x04\x00\x00\x00\x01"),
 		func() *map[string]int {
@@ -802,9 +788,9 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte(nil),
 		(*map[string]int)(nil),
@@ -812,7 +798,7 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte("HELLO WORLD"),
 		func() *CustomString {
 			customString := CustomString("hello world")
@@ -822,252 +808,252 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte(nil),
 		(*CustomString)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x7f\xff"),
 		32767, // math.MaxInt16
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x7f\xff"),
 		"32767", // math.MaxInt16
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x00\x01"),
 		int16(1),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		int16(-1),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x00\xff"),
 		uint8(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		uint16(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		uint32(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		uint64(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x00\xff"),
 		AliasUint8(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		AliasUint16(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		AliasUint32(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		AliasUint64(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		AliasUint(65535),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\x7f"),
 		127, // math.MaxInt8
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\x7f"),
 		"127", // math.MaxInt8
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\x01"),
 		int16(1),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		int16(-1),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		uint8(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		uint64(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		uint32(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		uint16(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		uint(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		AliasUint8(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		AliasUint64(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		AliasUint32(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		AliasUint16(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTinyInt},
+		tinyIntTypeInfo{},
 		[]byte("\xff"),
 		AliasUint(255),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\xff"),
 		uint8(math.MaxUint8),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\xff\xff"),
 		uint64(math.MaxUint16),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\xff\xff\xff\xff"),
 		uint64(math.MaxUint32),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		uint64(math.MaxUint64),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		uint32(math.MaxUint32),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		uint64(math.MaxUint32),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBlob},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte(nil),
 		([]byte)(nil),
 		nil,
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeVarchar},
+		varcharLikeTypeInfo{typ: TypeVarchar},
 		[]byte{},
 		func() interface{} {
 			var s string
@@ -1077,7 +1063,7 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeTime},
+		timeTypeInfo{},
 		encBigInt(1000),
 		time.Duration(1000),
 		nil,
@@ -1092,177 +1078,177 @@ var unmarshalTests = []struct {
 	UnmarshalError error
 }{
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x01\x00"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x00\x01\x00"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		uint16(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x01\x00\x00"),
 		uint16(0),
 		UnmarshalError("unmarshal int: value 65536 out of range for uint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x01\x00"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x01\x00"),
 		uint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for uint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		uint16(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x01\x00\x00"),
 		uint16(0),
 		UnmarshalError("unmarshal int: value 65536 out of range for uint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		uint32(0),
 		UnmarshalError("unmarshal int: value -1 out of range for uint32"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x00"),
 		uint32(0),
 		UnmarshalError("unmarshal int: value 4294967296 out of range for uint32"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\xff\xff"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeSmallInt},
+		smallIntTypeInfo{},
 		[]byte("\x01\x00"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x00\x01\x00"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\xff\xff\xff\xff"),
 		AliasUint16(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeInt},
+		intTypeInfo{},
 		[]byte("\x00\x01\x00\x00"),
 		AliasUint16(0),
 		UnmarshalError("unmarshal int: value 65536 out of range for gocql.AliasUint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x01\x00"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x01\x00"),
 		AliasUint8(0),
 		UnmarshalError("unmarshal int: value 256 out of range for gocql.AliasUint8"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		AliasUint16(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x01\x00\x00"),
 		AliasUint16(0),
 		UnmarshalError("unmarshal int: value 65536 out of range for gocql.AliasUint16"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 		AliasUint32(0),
 		UnmarshalError("unmarshal int: value -1 out of range for gocql.AliasUint32"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x00"),
 		AliasUint32(0),
 		UnmarshalError("unmarshal int: value 4294967296 out of range for gocql.AliasUint32"),
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeList,
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00"), // truncated data
 		func() *[]int {
@@ -1273,9 +1259,9 @@ var unmarshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x03fo"),
 		map[string]int{"foo": 1},
@@ -1283,49 +1269,58 @@ var unmarshalTests = []struct {
 	},
 	{
 		CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: TypeMap},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeInt},
+			typ:  TypeMap,
+			Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+			Elem: intTypeInfo{},
 		},
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x03foo\x00\x04\x00\x00"),
 		map[string]int{"foo": 1},
 		UnmarshalError("unmarshal map: unexpected eof"),
 	},
 	{
-		NativeType{proto: protoVersion3, typ: TypeDecimal},
+		decimalTypeInfo{},
 		[]byte("\xff\xff\xff"),
 		inf.NewDec(0, 0), // From the datastax/python-driver test suite
 		UnmarshalError("inf.Dec needs at least 4 bytes, while value has only 3"),
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa2\xc3\xc2\x9a\xe0F\x91"),
 		Duration{},
 		UnmarshalError("failed to unmarshal duration into *gocql.Duration: failed to extract nanoseconds: data expect to have 9 bytes, but it has only 8"),
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa2\xc3\xc2\x9a"),
 		Duration{},
 		UnmarshalError("failed to unmarshal duration into *gocql.Duration: failed to extract nanoseconds: unexpected eof"),
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa2\xc3\xc2"),
 		Duration{},
 		UnmarshalError("failed to unmarshal duration into *gocql.Duration: failed to extract days: data expect to have 5 bytes, but it has only 4"),
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89\xa2"),
 		Duration{},
 		UnmarshalError("failed to unmarshal duration into *gocql.Duration: failed to extract days: unexpected eof"),
 	},
 	{
-		NativeType{proto: protoVersion5, typ: TypeDuration},
+		durationTypeInfo{},
 		[]byte("\x89"),
 		Duration{},
 		UnmarshalError("failed to unmarshal duration into *gocql.Duration: failed to extract month: data expect to have 2 bytes, but it has only 1"),
+	},
+	{
+		varcharLikeTypeInfo{typ: TypeVarchar},
+		[]byte("HELLO WORLD"),
+		func() *CustomString {
+			s := CustomString("hello world")
+			return &s
+		}(),
+		nil,
 	},
 }
 
@@ -1364,15 +1359,15 @@ func TestMarshal_Decode(t *testing.T) {
 			v := reflect.New(reflect.TypeOf(test.Value))
 			err := Unmarshal(test.Info, test.Data, v.Interface())
 			if err != nil {
-				t.Errorf("unmarshalTest[%d] (%v=>%T): %v", i, test.Info, test.Value, err)
+				t.Errorf("marshalTest[%d] (%v=>%T): %v", i, test.Info, test.Value, err)
 				continue
 			}
 			if !reflect.DeepEqual(v.Elem().Interface(), test.Value) {
-				t.Errorf("unmarshalTest[%d] (%v=>%T): expected %#v, got %#v.", i, test.Info, test.Value, test.Value, v.Elem().Interface())
+				t.Errorf("marshalTest[%d] (%v=>%T): expected %#v, got %#v.", i, test.Info, test.Value, test.Value, v.Elem().Interface())
 			}
 		} else {
 			if err := Unmarshal(test.Info, test.Data, test.Value); err != test.UnmarshalError {
-				t.Errorf("unmarshalTest[%d] (%v=>%T): %#v returned error %#v, want %#v.", i, test.Info, test.Value, test.Value, err, test.UnmarshalError)
+				t.Errorf("marshalTest[%d] (%v=>%T): %#v returned error %#v, want %#v.", i, test.Info, test.Value, test.Value, err, test.UnmarshalError)
 			}
 		}
 	}
@@ -1459,7 +1454,7 @@ func TestMarshalVarint(t *testing.T) {
 	}
 
 	for i, test := range varintTests {
-		data, err := Marshal(NativeType{proto: protoVersion3, typ: TypeVarint}, test.Value)
+		data, err := Marshal(varintTypeInfo{}, test.Value)
 		if err != nil {
 			t.Errorf("error marshaling varint: %v (test #%d)", err, i)
 		}
@@ -1469,7 +1464,7 @@ func TestMarshalVarint(t *testing.T) {
 		}
 
 		binder := new(big.Int)
-		err = Unmarshal(NativeType{proto: protoVersion3, typ: TypeVarint}, test.Marshaled, binder)
+		err = Unmarshal(varintTypeInfo{}, test.Marshaled, binder)
 		if err != nil {
 			t.Errorf("error unmarshaling varint: %v (test #%d)", err, i)
 		}
@@ -1517,7 +1512,7 @@ func TestMarshalVarint(t *testing.T) {
 	}
 
 	for i, test := range varintUint64Tests {
-		data, err := Marshal(NativeType{proto: protoVersion3, typ: TypeVarint}, test.Value)
+		data, err := Marshal(varintTypeInfo{}, test.Value)
 		if err != nil {
 			t.Errorf("error marshaling varint: %v (test #%d)", err, i)
 		}
@@ -1527,7 +1522,7 @@ func TestMarshalVarint(t *testing.T) {
 		}
 
 		var binder uint64
-		err = Unmarshal(NativeType{proto: protoVersion3, typ: TypeVarint}, test.Marshaled, &binder)
+		err = Unmarshal(varintTypeInfo{}, test.Marshaled, &binder)
 		if err != nil {
 			t.Errorf("error unmarshaling varint to uint64: %v (test #%d)", err, i)
 		}
@@ -1545,12 +1540,12 @@ func TestMarshalBigInt(t *testing.T) {
 		MarshalError error
 	}{
 		{
-			NativeType{proto: protoVersion3, typ: TypeBigInt},
+			bigIntLikeTypeInfo{typ: TypeBigInt},
 			"-78635384813432117863538481343211",
 			MarshalError("can not marshal string to bigint: strconv.ParseInt: parsing \"-78635384813432117863538481343211\": value out of range"),
 		},
 		{
-			NativeType{proto: protoVersion3, typ: TypeBigInt},
+			bigIntLikeTypeInfo{typ: TypeBigInt},
 			"922337203685477692259749625974294",
 			MarshalError("can not marshal string to bigint: strconv.ParseInt: parsing \"922337203685477692259749625974294\": value out of range"),
 		},
@@ -1577,9 +1572,9 @@ func equalStringPointerSlice(leftList, rightList []*string) bool {
 }
 
 func TestMarshalList(t *testing.T) {
-	typeInfoV3 := CollectionType{
-		NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-		Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+	typeInfo := CollectionType{
+		typ:  TypeList,
+		Elem: varcharLikeTypeInfo{typ: TypeVarchar},
 	}
 
 	type tc struct {
@@ -1593,17 +1588,17 @@ func TestMarshalList(t *testing.T) {
 	valueEmpty := ""
 	testCases := []tc{
 		{
-			typeInfo: typeInfoV3,
+			typeInfo: typeInfo,
 			input:    []*string{&valueEmpty},
 			expected: []*string{&valueEmpty},
 		},
 		{
-			typeInfo: typeInfoV3,
+			typeInfo: typeInfo,
 			input:    []*string{nil},
 			expected: []*string{nil},
 		},
 		{
-			typeInfo: typeInfoV3,
+			typeInfo: typeInfo,
 			input:    []*string{&valueA, nil, &valueB},
 			expected: []*string{&valueA, nil, &valueB},
 		},
@@ -1657,46 +1652,6 @@ func (c *CustomString) UnmarshalCQL(info TypeInfo, data []byte) error {
 
 type MyString string
 
-var typeLookupTest = []struct {
-	TypeName     string
-	ExpectedType Type
-}{
-	{"AsciiType", TypeAscii},
-	{"LongType", TypeBigInt},
-	{"BytesType", TypeBlob},
-	{"BooleanType", TypeBoolean},
-	{"CounterColumnType", TypeCounter},
-	{"DecimalType", TypeDecimal},
-	{"DoubleType", TypeDouble},
-	{"FloatType", TypeFloat},
-	{"Int32Type", TypeInt},
-	{"DateType", TypeTimestamp},
-	{"TimestampType", TypeTimestamp},
-	{"UUIDType", TypeUUID},
-	{"UTF8Type", TypeVarchar},
-	{"IntegerType", TypeVarint},
-	{"TimeUUIDType", TypeTimeUUID},
-	{"InetAddressType", TypeInet},
-	{"MapType", TypeMap},
-	{"ListType", TypeList},
-	{"SetType", TypeSet},
-	{"unknown", TypeCustom},
-	{"ShortType", TypeSmallInt},
-	{"ByteType", TypeTinyInt},
-}
-
-func testType(t *testing.T, cassType string, expectedType Type) {
-	if computedType := getApacheCassandraType(apacheCassandraTypePrefix + cassType); computedType != expectedType {
-		t.Errorf("Cassandra custom type lookup for %s failed. Expected %s, got %s.", cassType, expectedType.String(), computedType.String())
-	}
-}
-
-func TestLookupCassType(t *testing.T) {
-	for _, lookupTest := range typeLookupTest {
-		testType(t, lookupTest.TypeName, lookupTest.ExpectedType)
-	}
-}
-
 type MyPointerMarshaler struct{}
 
 func (m *MyPointerMarshaler) MarshalCQL(_ TypeInfo) ([]byte, error) {
@@ -1705,7 +1660,7 @@ func (m *MyPointerMarshaler) MarshalCQL(_ TypeInfo) ([]byte, error) {
 
 func TestMarshalPointer(t *testing.T) {
 	m := &MyPointerMarshaler{}
-	typ := NativeType{proto: protoVersion3, typ: TypeInt}
+	typ := intTypeInfo{}
 
 	data, err := Marshal(typ, m)
 
@@ -1727,24 +1682,23 @@ func TestMarshalTime(t *testing.T) {
 		Value interface{}
 	}{
 		{
-			NativeType{proto: protoVersion4, typ: TypeTime},
+			timeTypeInfo{},
 			expectedData,
 			duration.Nanoseconds(),
 		},
 		{
-			NativeType{proto: protoVersion4, typ: TypeTime},
+			timeTypeInfo{},
 			expectedData,
 			duration,
 		},
 		{
-			NativeType{proto: protoVersion4, typ: TypeTime},
+			timeTypeInfo{},
 			expectedData,
 			&duration,
 		},
 	}
 
 	for i, test := range marshalTimeTests {
-		t.Log(i, test)
 		data, err := Marshal(test.Info, test.Value)
 		if err != nil {
 			t.Errorf("marshalTest[%d]: %v", i, err)
@@ -1764,53 +1718,52 @@ func TestMarshalTimestamp(t *testing.T) {
 		Value interface{}
 	}{
 		{
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 			time.Date(2013, time.August, 13, 9, 52, 3, 0, time.UTC),
 		},
 		{
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 			int64(1376387523000),
 		},
 		{
 			// 9223372036854 is the maximum time representable in ms since the epoch
 			// with int64 if using UnixNano to convert
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\x00\x00\x08\x63\x7b\xd0\x5a\xf6"),
 			time.Date(2262, time.April, 11, 23, 47, 16, 854775807, time.UTC),
 		},
 		{
 			// One nanosecond after causes overflow when using UnixNano
 			// Instead it should resolve to the same time in ms
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\x00\x00\x08\x63\x7b\xd0\x5a\xf6"),
 			time.Date(2262, time.April, 11, 23, 47, 16, 854775808, time.UTC),
 		},
 		{
 			// -9223372036855 is the minimum time representable in ms since the epoch
 			// with int64 if using UnixNano to convert
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
 			time.Date(1677, time.September, 21, 00, 12, 43, 145224192, time.UTC),
 		},
 		{
 			// One nanosecond earlier causes overflow when using UnixNano
 			// it should resolve to the same time in ms
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte("\xff\xff\xf7\x9c\x84\x2f\xa5\x09"),
 			time.Date(1677, time.September, 21, 00, 12, 43, 145224191, time.UTC),
 		},
 		{
 			// Store the zero time as a blank slice
-			NativeType{proto: protoVersion3, typ: TypeTimestamp},
+			timestampTypeInfo{},
 			[]byte{},
 			time.Time{},
 		},
 	}
 
 	for i, test := range marshalTimestampTests {
-		t.Log(i, test)
 		data, err := Marshal(test.Info, test.Value)
 		if err != nil {
 			t.Errorf("marshalTest[%d]: %v", i, err)
@@ -1825,10 +1778,9 @@ func TestMarshalTimestamp(t *testing.T) {
 
 func TestMarshalTuple(t *testing.T) {
 	info := TupleTypeInfo{
-		NativeType: NativeType{proto: protoVersion3, typ: TypeTuple},
 		Elems: []TypeInfo{
-			NativeType{proto: protoVersion3, typ: TypeVarchar},
-			NativeType{proto: protoVersion3, typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
 		},
 	}
 
@@ -1972,10 +1924,9 @@ func TestMarshalTuple(t *testing.T) {
 
 func TestUnmarshalTuple(t *testing.T) {
 	info := TupleTypeInfo{
-		NativeType: NativeType{proto: protoVersion3, typ: TypeTuple},
 		Elems: []TypeInfo{
-			NativeType{proto: protoVersion3, typ: TypeVarchar},
-			NativeType{proto: protoVersion3, typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
 		},
 	}
 
@@ -1995,11 +1946,23 @@ func TestUnmarshalTuple(t *testing.T) {
 			t.Errorf("unmarshalTest: %v", err)
 			return
 		}
-
 		if tmp.A != nil || *tmp.B != "foo" {
-			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", *tmp.A, *tmp.B)
+			t.Errorf("unmarshalTest: expected [nil, foo], got [%#v, %#v]", *tmp.A, *tmp.B)
+		}
+
+		tmp.A = new(string)
+		*tmp.A = "bar"
+
+		err = Unmarshal(info, data, &tmp)
+		if err != nil {
+			t.Errorf("unmarshalTest: %v", err)
+			return
+		}
+		if tmp.A != nil || *tmp.B != "foo" {
+			t.Errorf("unmarshalTest: expected [nil, foo], got [%#v, %#v]", *tmp.A, *tmp.B)
 		}
 	})
+
 	t.Run("struct-nonptr", func(t *testing.T) {
 		var tmp struct {
 			A string
@@ -2011,7 +1974,17 @@ func TestUnmarshalTuple(t *testing.T) {
 			t.Errorf("unmarshalTest: %v", err)
 			return
 		}
+		if tmp.A != "" || tmp.B != "foo" {
+			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", tmp.A, tmp.B)
+		}
 
+		tmp.A = "bar"
+
+		err = Unmarshal(info, data, &tmp)
+		if err != nil {
+			t.Errorf("unmarshalTest: %v", err)
+			return
+		}
 		if tmp.A != "" || tmp.B != "foo" {
 			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", tmp.A, tmp.B)
 		}
@@ -2025,11 +1998,23 @@ func TestUnmarshalTuple(t *testing.T) {
 			t.Errorf("unmarshalTest: %v", err)
 			return
 		}
+		if tmp[0] != nil || *tmp[1] != "foo" {
+			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", *tmp[0], *tmp[1])
+		}
 
+		tmp[0] = new(string)
+		*tmp[0] = "bar"
+
+		err = Unmarshal(info, data, &tmp)
+		if err != nil {
+			t.Errorf("unmarshalTest: %v", err)
+			return
+		}
 		if tmp[0] != nil || *tmp[1] != "foo" {
 			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", *tmp[0], *tmp[1])
 		}
 	})
+
 	t.Run("array-nonptr", func(t *testing.T) {
 		var tmp [2]string
 
@@ -2038,7 +2023,17 @@ func TestUnmarshalTuple(t *testing.T) {
 			t.Errorf("unmarshalTest: %v", err)
 			return
 		}
+		if tmp[0] != "" || tmp[1] != "foo" {
+			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", tmp[0], tmp[1])
+		}
 
+		tmp[0] = "bar"
+
+		err = Unmarshal(info, data, &tmp)
+		if err != nil {
+			t.Errorf("unmarshalTest: %v", err)
+			return
+		}
 		if tmp[0] != "" || tmp[1] != "foo" {
 			t.Errorf("unmarshalTest: expected [nil, foo], got [%v, %v]", tmp[0], tmp[1])
 		}
@@ -2046,11 +2041,14 @@ func TestUnmarshalTuple(t *testing.T) {
 }
 
 func TestMarshalUDTMap(t *testing.T) {
-	typeInfo := UDTTypeInfo{NativeType{proto: protoVersion3, typ: TypeUDT}, "", "xyz", []UDTField{
-		{Name: "x", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-		{Name: "y", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-		{Name: "z", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-	}}
+	typeInfo := UDTTypeInfo{
+		Name: "xyz",
+		Elements: []UDTField{
+			{Name: "x", Type: intTypeInfo{}},
+			{Name: "y", Type: intTypeInfo{}},
+			{Name: "z", Type: intTypeInfo{}},
+		},
+	}
 
 	t.Run("partially bound", func(t *testing.T) {
 		value := map[string]interface{}{
@@ -2101,11 +2099,14 @@ func TestMarshalUDTMap(t *testing.T) {
 }
 
 func TestMarshalUDTStruct(t *testing.T) {
-	typeInfo := UDTTypeInfo{NativeType{proto: protoVersion3, typ: TypeUDT}, "", "xyz", []UDTField{
-		{Name: "x", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-		{Name: "y", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-		{Name: "z", Type: NativeType{proto: protoVersion3, typ: TypeInt}},
-	}}
+	typeInfo := UDTTypeInfo{
+		Name: "xyz",
+		Elements: []UDTField{
+			{Name: "x", Type: intTypeInfo{}},
+			{Name: "y", Type: intTypeInfo{}},
+			{Name: "z", Type: intTypeInfo{}},
+		},
+	}
 
 	type xyzStruct struct {
 		X int32 `cql:"x"`
@@ -2170,26 +2171,26 @@ func TestMarshalUDTStruct(t *testing.T) {
 }
 
 func TestMarshalNil(t *testing.T) {
-	types := []Type{
-		TypeAscii,
-		TypeBlob,
-		TypeBoolean,
-		TypeBigInt,
-		TypeCounter,
-		TypeDecimal,
-		TypeDouble,
-		TypeFloat,
-		TypeInt,
-		TypeTimestamp,
-		TypeUUID,
-		TypeVarchar,
-		TypeVarint,
-		TypeTimeUUID,
-		TypeInet,
+	types := []TypeInfo{
+		varcharLikeTypeInfo{typ: TypeAscii},
+		varcharLikeTypeInfo{typ: TypeBlob},
+		booleanTypeInfo{},
+		bigIntLikeTypeInfo{typ: TypeBigInt},
+		bigIntLikeTypeInfo{typ: TypeCounter},
+		decimalTypeInfo{},
+		doubleTypeInfo{},
+		floatTypeInfo{},
+		intTypeInfo{},
+		timestampTypeInfo{},
+		uuidType{},
+		varcharLikeTypeInfo{typ: TypeVarchar},
+		varintTypeInfo{},
+		timeUUIDType{},
+		inetType{},
 	}
 
 	for _, typ := range types {
-		data, err := Marshal(NativeType{proto: protoVersion3, typ: typ}, nil)
+		data, err := Marshal(typ, nil)
 		if err != nil {
 			t.Errorf("unable to marshal nil %v: %v\n", typ, err)
 		} else if data != nil {
@@ -2198,10 +2199,20 @@ func TestMarshalNil(t *testing.T) {
 	}
 }
 
-func TestUnmarshalInetCopyBytes(t *testing.T) {
+func TestUnmarshalInet_Nil(t *testing.T) {
+	var ip net.IP
+	if err := Unmarshal(inetType{}, []byte(nil), &ip); err != nil {
+		t.Fatal(err)
+	}
+	if ip != nil {
+		t.Fatalf("expected nil ip, got %v", ip)
+	}
+}
+
+func TestUnmarshalInet_CopyBytes(t *testing.T) {
 	data := []byte{127, 0, 0, 1}
 	var ip net.IP
-	if err := unmarshalInet(NativeType{proto: protoVersion3, typ: TypeInet}, data, &ip); err != nil {
+	if err := Unmarshal(inetType{}, data, &ip); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2215,7 +2226,7 @@ func TestUnmarshalInetCopyBytes(t *testing.T) {
 func TestUnmarshalDate(t *testing.T) {
 	data := []uint8{0x80, 0x0, 0x43, 0x31}
 	var date time.Time
-	if err := unmarshalDate(NativeType{proto: protoVersion3, typ: TypeDate}, data, &date); err != nil {
+	if err := Unmarshal(dateTypeInfo{}, data, &date); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2226,7 +2237,7 @@ func TestUnmarshalDate(t *testing.T) {
 		return
 	}
 	var stringDate string
-	if err2 := unmarshalDate(NativeType{proto: protoVersion3, typ: TypeDate}, data, &stringDate); err2 != nil {
+	if err2 := Unmarshal(dateTypeInfo{}, data, &stringDate); err2 != nil {
 		t.Fatal(err2)
 	}
 	if expectedDate != stringDate {
@@ -2246,29 +2257,28 @@ func TestMarshalDate(t *testing.T) {
 		Value interface{}
 	}{
 		{
-			NativeType{proto: protoVersion4, typ: TypeDate},
+			dateTypeInfo{},
 			expectedData,
 			timestamp,
 		},
 		{
-			NativeType{proto: protoVersion4, typ: TypeDate},
+			dateTypeInfo{},
 			expectedData,
 			now,
 		},
 		{
-			NativeType{proto: protoVersion4, typ: TypeDate},
+			dateTypeInfo{},
 			expectedData,
 			&now,
 		},
 		{
-			NativeType{proto: protoVersion4, typ: TypeDate},
+			dateTypeInfo{},
 			expectedData,
 			now.Format("2006-01-02"),
 		},
 	}
 
 	for i, test := range marshalDateTests {
-		t.Log(i, test)
 		data, err := Marshal(test.Info, test.Value)
 		if err != nil {
 			t.Errorf("marshalTest[%d]: %v", i, err)
@@ -2305,12 +2315,10 @@ func TestLargeDate(t *testing.T) {
 		},
 	}
 
-	nativeType := NativeType{proto: protoVersion4, typ: TypeDate}
+	typ := dateTypeInfo{}
 
 	for i, test := range marshalDateTests {
-		t.Log(i, test)
-
-		data, err := Marshal(nativeType, test.Value)
+		data, err := Marshal(typ, test.Value)
 		if err != nil {
 			t.Errorf("largeDateTest[%d]: %v", i, err)
 			continue
@@ -2321,26 +2329,13 @@ func TestLargeDate(t *testing.T) {
 		}
 
 		var date time.Time
-		if err := Unmarshal(nativeType, data, &date); err != nil {
+		if err := Unmarshal(typ, data, &date); err != nil {
 			t.Fatal(err)
 		}
 
 		formattedDate := date.Format("2006-01-02")
 		if test.ExpectedDate != formattedDate {
 			t.Fatalf("largeDateTest: expected %v, got %v", test.ExpectedDate, formattedDate)
-		}
-	}
-}
-
-func BenchmarkUnmarshalVarchar(b *testing.B) {
-	b.ReportAllocs()
-	src := make([]byte, 1024)
-	dst := make([]byte, len(src))
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := unmarshalVarchar(NativeType{}, src, &dst); err != nil {
-			b.Fatal(err)
 		}
 	}
 }
@@ -2355,22 +2350,22 @@ func TestMarshalDuration(t *testing.T) {
 		Value interface{}
 	}{
 		{
-			NativeType{proto: protoVersion5, typ: TypeDuration},
+			durationTypeInfo{},
 			expectedData,
 			duration.Nanoseconds(),
 		},
 		{
-			NativeType{proto: protoVersion5, typ: TypeDuration},
+			durationTypeInfo{},
 			expectedData,
 			duration,
 		},
 		{
-			NativeType{proto: protoVersion5, typ: TypeDuration},
+			durationTypeInfo{},
 			expectedData,
 			durationS,
 		},
 		{
-			NativeType{proto: protoVersion5, typ: TypeDuration},
+			durationTypeInfo{},
 			expectedData,
 			&duration,
 		},
@@ -2391,9 +2386,9 @@ func TestMarshalDuration(t *testing.T) {
 }
 
 func TestReadCollectionSize(t *testing.T) {
-	listV3 := CollectionType{
-		NativeType: NativeType{proto: protoVersion3, typ: TypeList},
-		Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+	list := CollectionType{
+		typ:  TypeList,
+		Elem: varcharLikeTypeInfo{typ: TypeVarchar},
 	}
 
 	tests := []struct {
@@ -2405,31 +2400,31 @@ func TestReadCollectionSize(t *testing.T) {
 	}{
 		{
 			name:    "short read 0 proto 3",
-			info:    listV3,
+			info:    list,
 			data:    []byte{},
 			isError: true,
 		},
 		{
 			name:    "short read 1 proto 3",
-			info:    listV3,
+			info:    list,
 			data:    []byte{0x01},
 			isError: true,
 		},
 		{
 			name:    "short read 2 proto 3",
-			info:    listV3,
+			info:    list,
 			data:    []byte{0x01, 0x38},
 			isError: true,
 		},
 		{
 			name:    "short read 3 proto 3",
-			info:    listV3,
+			info:    list,
 			data:    []byte{0x01, 0x38, 0x42},
 			isError: true,
 		},
 		{
 			name:         "good read proto 3",
-			info:         listV3,
+			info:         list,
 			data:         []byte{0x01, 0x38, 0x42, 0x22},
 			expectedSize: 0x01384222,
 		},
@@ -2453,70 +2448,24 @@ func TestReadCollectionSize(t *testing.T) {
 	}
 }
 
-func TestReadUnsignedVInt(t *testing.T) {
-	tests := []struct {
-		decodedInt  uint64
-		encodedVint []byte
-	}{
-		{
-			decodedInt:  0,
-			encodedVint: []byte{0},
-		},
-		{
-			decodedInt:  100,
-			encodedVint: []byte{100},
-		},
-		{
-			decodedInt:  256000,
-			encodedVint: []byte{195, 232, 0},
-		},
-	}
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%d", test.decodedInt), func(t *testing.T) {
-			actual, _, err := readUnsignedVInt(test.encodedVint)
-			if err != nil {
-				t.Fatalf("Expected no error, got %v", err)
-			}
-			if actual != test.decodedInt {
-				t.Fatalf("Expected %d, but got %d", test.decodedInt, actual)
-			}
-		})
-	}
-}
-
-func BenchmarkUnmarshalUUID(b *testing.B) {
-	b.ReportAllocs()
-	src := make([]byte, 16)
-	dst := UUID{}
-	var ti TypeInfo = NativeType{}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := unmarshalUUID(ti, src, &dst); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func TestUnmarshalUDT(t *testing.T) {
 	info := UDTTypeInfo{
-		NativeType: NativeType{proto: protoVersion4, typ: TypeUDT},
-		Name:       "myudt",
-		KeySpace:   "myks",
+		Name:     "myudt",
+		Keyspace: "myks",
 		Elements: []UDTField{
 			{
 				Name: "first",
-				Type: NativeType{proto: protoVersion4, typ: TypeAscii},
+				Type: varcharLikeTypeInfo{typ: TypeAscii},
 			},
 			{
 				Name: "second",
-				Type: NativeType{proto: protoVersion4, typ: TypeSmallInt},
+				Type: smallIntTypeInfo{},
 			},
 		},
 	}
-	data := bytesWithLength( // UDT
-		bytesWithLength([]byte("Hello")),    // first
-		bytesWithLength([]byte("\x00\x2a")), // second
+	data := append(
+		bytesWithLength([]byte("Hello")),       // first
+		bytesWithLength([]byte("\x00\x2a"))..., // second
 	)
 	value := map[string]interface{}{}
 	expectedErr := UnmarshalError("can not unmarshal into non-pointer map[string]interface {}")
@@ -2524,6 +2473,18 @@ func TestUnmarshalUDT(t *testing.T) {
 	if err := Unmarshal(info, data, value); err != expectedErr {
 		t.Errorf("(%v=>%T): %#v returned error %#v, want %#v.",
 			info, value, value, err, expectedErr)
+	}
+
+	err := Unmarshal(info, data, &value)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	} else {
+		if value["first"] != "Hello" {
+			t.Errorf(`Expected "Hello" for first but received: %T(%v)`, value["first"], value["first"])
+		}
+		if value["second"] != int16(42) {
+			t.Errorf(`Expected 42 for second but received: %T(%v)`, value["second"], value["second"])
+		}
 	}
 }
 
@@ -2545,4 +2506,362 @@ func bytesWithLength(data ...[]byte) []byte {
 		buf = buf[n:]
 	}
 	return ret
+}
+
+func TestUnmarshal_PointerToPointer(t *testing.T) {
+	var a string
+	b := &a
+	data := []byte("foo")
+	info := varcharLikeTypeInfo{
+		typ: TypeVarchar,
+	}
+	err := Unmarshal(info, data, &b)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if b == nil || *b != "foo" {
+			t.Errorf("expected b to be *foo, got %+v", b)
+		}
+		if a != "" {
+			t.Errorf("expected a to be empty, got %v", a)
+		}
+	}
+}
+
+func TestUnmarshal_PointerToInterface(t *testing.T) {
+	var a string
+	var b interface{} = &a
+	data := []byte("foo")
+	info := varcharLikeTypeInfo{
+		typ: TypeVarchar,
+	}
+	err := Unmarshal(info, data, &b)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if b == nil {
+			t.Error("expected b to be *foo, got nil")
+		} else if bstr, ok := b.(*string); !ok {
+			t.Errorf("expected b to be *foo, got %T", b)
+		} else if bstr == nil || *bstr != "foo" {
+			t.Errorf("expected b to be *foo, got %+v", bstr)
+		}
+		if a != "foo" {
+			t.Errorf("expected a to be foo, got %v", a)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_BigInt(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x01\x02\x03\x04\x05\x06\x07\x08")
+	var dst int64
+	var ti TypeInfo = GlobalTypes.fastTypeInfoLookup(TypeBigInt)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Blob(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("hello\x00")
+	var dst []byte
+	var ti TypeInfo = GlobalTypes.fastTypeInfoLookup(TypeBlob)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Boolean(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x01")
+	var dst bool
+	var ti TypeInfo = GlobalTypes.fastTypeInfoLookup(TypeBoolean)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Date(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x80\x00\x43\x31")
+	var dst time.Time
+	var ti TypeInfo = GlobalTypes.fastTypeInfoLookup(TypeDate)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Decimal(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x13*\xF8\xC4\xDF\xEB]o")
+	dst := new(inf.Dec)
+	var ti TypeInfo = NewNativeType(4, TypeDecimal, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Double(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1")
+	var dst float64
+	var ti TypeInfo = NewNativeType(4, TypeDouble, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Duration(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x02\x04\x80\xe6")
+	var dst Duration
+	var ti TypeInfo = NewNativeType(4, TypeDuration, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Float(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x40\x49\x0f\xdb")
+	var dst float32
+	var ti TypeInfo = NewNativeType(4, TypeFloat, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Int(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x01\x02\x03\x04")
+	var dst int32
+	var ti TypeInfo = NewNativeType(4, TypeInt, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Inet(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x7F\x00\x00\x01")
+	var dst net.IP
+	var ti TypeInfo = NewNativeType(4, TypeInet, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_SmallInt(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\xff")
+	var dst int16
+	var ti TypeInfo = NewNativeType(4, TypeSmallInt, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Time(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x01\x40\x77\x16\xe1\xb8")
+	var dst time.Duration
+	var ti TypeInfo = NewNativeType(4, TypeTime, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Timestamp(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x01\x40\x77\x16\xe1\xb8")
+	var dst int64
+	var ti TypeInfo = NewNativeType(4, TypeTimestamp, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_TinyInt(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x01")
+	var dst int8
+	var ti TypeInfo = NewNativeType(4, TypeTinyInt, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_UUID(b *testing.B) {
+	b.ReportAllocs()
+	src := make([]byte, 16)
+	dst := UUID{}
+	var ti TypeInfo = NewNativeType(4, TypeUUID, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Varchar(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("foo")
+	dst := make([]byte, len(src))
+	var ti TypeInfo = NewNativeType(4, TypeVarchar, "")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_List(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02")
+	dst := make([]int32, 2)
+	var ti TypeInfo = CollectionType{
+		typ:  TypeList,
+		Elem: intTypeInfo{},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Set(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x02")
+	dst := make([]int32, 2)
+	var ti TypeInfo = CollectionType{
+		typ:  TypeSet,
+		Elem: intTypeInfo{},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_Map(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x01\x00\x00\x00\x03foo\x00\x00\x00\x04\x00\x00\x00\x01")
+	dst := map[string]int32{}
+	var ti TypeInfo = CollectionType{
+		typ:  TypeMap,
+		Key:  varcharLikeTypeInfo{typ: TypeVarchar},
+		Elem: intTypeInfo{},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_TupleStrings(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x03foo\x00\x00\x00\x03bar")
+	dst := make([]string, 2)
+	var ti TypeInfo = TupleTypeInfo{
+		Elems: []TypeInfo{
+			varcharLikeTypeInfo{typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_TupleInterfaces(b *testing.B) {
+	b.ReportAllocs()
+	src := []byte("\x00\x00\x00\x03foo\x00\x00\x00\x03bar")
+	dst := make([]interface{}, 2)
+	var ti TypeInfo = TupleTypeInfo{
+		Elems: []TypeInfo{
+			varcharLikeTypeInfo{typ: TypeVarchar},
+			varcharLikeTypeInfo{typ: TypeVarchar},
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(ti, src, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/session.go
+++ b/session.go
@@ -65,6 +65,7 @@ type Session struct {
 	hostSource          *ringDescriber
 	ringRefresher       *refreshDebouncer
 	stmtsLRU            *preparedLRU
+	types               *RegisteredTypes
 
 	connCfg *ConnConfig
 
@@ -160,6 +161,11 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		cancel:          cancel,
 		logger:          cfg.logger(),
 		trace:           cfg.Tracer,
+	}
+	if cfg.RegisteredTypes == nil {
+		s.types = GlobalTypes.Copy()
+	} else {
+		s.types = cfg.RegisteredTypes.Copy()
 	}
 
 	s.schemaDescriber = newSchemaDescriber(s)
@@ -1634,7 +1640,7 @@ func (iter *Iter) Scanner() Scanner {
 }
 
 func (iter *Iter) readColumn() ([]byte, error) {
-	return iter.framer.readBytesInternal()
+	return iter.framer.readBytes()
 }
 
 // Scan consumes the next row of the iterator and copies the columns of the

--- a/token_test.go
+++ b/token_test.go
@@ -48,7 +48,7 @@ func TestMurmur3Partitioner(t *testing.T) {
 
 	// at least verify that the partitioner
 	// doesn't return nil
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := Marshal(intTypeInfo{}, 1)
 	token = murmur3Partitioner{}.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")
@@ -73,7 +73,7 @@ func TestOrderedPartitioner(t *testing.T) {
 	// at least verify that the partitioner
 	// doesn't return nil
 	p := orderedPartitioner{}
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := Marshal(intTypeInfo{}, 1)
 	token := p.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")
@@ -109,7 +109,7 @@ func TestRandomPartitioner(t *testing.T) {
 	// at least verify that the partitioner
 	// doesn't return nil
 	p := randomPartitioner{}
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := Marshal(intTypeInfo{}, 1)
 	token := p.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -138,10 +138,10 @@ func TestTuple_TupleNotSet(t *testing.T) {
 	if err := iter.Scan(x, y); err != nil {
 		t.Fatal(err)
 	}
-	if x == nil || *x != 1 {
+	if *x != 1 {
 		t.Fatalf("x should be %d got %+#v, value=%d", 1, x, *x)
 	}
-	if y == nil || *y != 2 {
+	if *y != 2 {
 		t.Fatalf("y should be %d got %+#v, value=%d", 2, y, *y)
 	}
 
@@ -150,10 +150,10 @@ func TestTuple_TupleNotSet(t *testing.T) {
 	if err := iter.Scan(x, y); err != nil {
 		t.Fatal(err)
 	}
-	if x == nil || *x != 0 {
+	if *x != 0 {
 		t.Fatalf("x should be %d got %+#v, value=%d", 0, x, *x)
 	}
-	if y == nil || *y != 0 {
+	if *y != 0 {
 		t.Fatalf("y should be %d got %+#v, value=%d", 0, y, *y)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -1,0 +1,703 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// CQLType is the interface that must be implemented by all registered types.
+// For simple types, you can just wrap a TypeInfo with SimpleCQLType.
+type CQLType interface {
+	// Params should return a new slice of zero values of the closest Go types to'
+	// be filled when parsing a frame. These values associcated with the types
+	// are sent to TypeInfoFromParams after being read from the frame.
+	//
+	// The supported types are: Type, TypeInfo, []UDTField, []byte, string, int, uint16, byte.
+	// Pointers are followed when filling the params but the slice sent to
+	// TypeInfoFromParams will only contain the underlying values. Since
+	// TypeInfo(nil) isn't supported, you can send (*TypeInfo)(nil) and
+	// TypeInfoFromParams will get a TypeInfo (not *TypeInfo since that's not usable).
+	//
+	// If no params are needed this can return a nil slice and TypeInfoFromParams
+	// will be sent nil.
+	Params(proto int) []interface{}
+
+	// TypeInfoFromParams should return a TypeInfo implementation for the type
+	// with the given filled parameters. See the Params() method for what values
+	// to expect.
+	TypeInfoFromParams(proto int, params []interface{}) (TypeInfo, error)
+
+	// TypeInfoFromString should return a TypeInfo implementation for the type with
+	// the given names/classes. Only the portion within the parantheses or arrows
+	// are passed to this function. For simple types, the name passed might be empty.
+	TypeInfoFromString(proto int, name string) (TypeInfo, error)
+}
+
+// SimpleCQLType is a convenience wrapper around a TypeInfo that implements
+// CQLType by returning nil for Params, and the TypeInfo for TypeInfoFromParams
+// and TypeInfoFromString.
+type SimpleCQLType struct {
+	TypeInfo
+}
+
+// Params returns nil.
+func (SimpleCQLType) Params(int) []interface{} {
+	return nil
+}
+
+// TypeInfoFromParams returns the wrapped TypeInfo.
+func (s SimpleCQLType) TypeInfoFromParams(proto int, params []interface{}) (TypeInfo, error) {
+	return s.TypeInfo, nil
+}
+
+// TypeInfoFromString returns the wrapped TypeInfo.
+func (s SimpleCQLType) TypeInfoFromString(proto int, name string) (TypeInfo, error) {
+	return s.TypeInfo, nil
+}
+
+// TypeInfo describes a Cassandra specific data type and handles marshalling
+// and unmarshalling.
+type TypeInfo interface {
+	// Type returns the Type id for the TypeInfo.
+	Type() Type
+
+	// Zero returns the Go zero value. For types that directly map to a Go type like
+	// list<integer> it should return []int(nil) but for complex types like a
+	// tuple<integer, boolean> it should be []interface{}{int(0), bool(false)}.
+	Zero() interface{}
+
+	// Marshal should marshal the value for the given TypeInfo into a byte slice
+	Marshal(value interface{}) ([]byte, error)
+
+	// Unmarshal should unmarshal the byte slice into the value for the given
+	// TypeInfo.
+	Unmarshal(data []byte, value interface{}) error
+}
+
+// RegisteredTypes is a collection of CQL types
+type RegisteredTypes struct {
+	byType   map[Type]CQLType
+	simples  map[Type]TypeInfo
+	byString map[string]Type
+	custom   map[string]CQLType
+
+	// this mutex is only used for registration and after that it's assumed that
+	// the types are immutable
+	mut         sync.Mutex
+	initialized sync.Once
+}
+
+func (r *RegisteredTypes) init() {
+	r.initialized.Do(func() {
+		if r.byType == nil {
+			r.byType = map[Type]CQLType{}
+		}
+		if r.simples == nil {
+			r.simples = map[Type]TypeInfo{}
+		}
+		if r.byString == nil {
+			r.byString = map[string]Type{}
+		}
+		if r.custom == nil {
+			r.custom = map[string]CQLType{}
+		}
+	})
+}
+
+func (r *RegisteredTypes) addDefaultTypes() {
+	r.init()
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	r.mustRegisterType(TypeAscii, "ascii", SimpleCQLType{varcharLikeTypeInfo{
+		typ: TypeAscii,
+	}})
+	r.mustRegisterAlias("AsciiType", "ascii")
+
+	r.mustRegisterType(TypeBigInt, "bigint", SimpleCQLType{bigIntLikeTypeInfo{
+		typ: TypeBigInt,
+	}})
+	r.mustRegisterAlias("LongType", "bigint")
+
+	r.mustRegisterType(TypeBlob, "blob", SimpleCQLType{varcharLikeTypeInfo{
+		typ: TypeBlob,
+	}})
+	r.mustRegisterAlias("BytesType", "blob")
+
+	r.mustRegisterType(TypeBoolean, "boolean", SimpleCQLType{booleanTypeInfo{}})
+	r.mustRegisterAlias("BooleanType", "boolean")
+
+	r.mustRegisterType(TypeCounter, "counter", SimpleCQLType{bigIntLikeTypeInfo{
+		typ: TypeCounter,
+	}})
+	r.mustRegisterAlias("CounterColumnType", "counter")
+
+	r.mustRegisterType(TypeDate, "date", SimpleCQLType{dateTypeInfo{}})
+	r.mustRegisterAlias("SimpleDateType", "date")
+
+	r.mustRegisterType(TypeDecimal, "decimal", SimpleCQLType{decimalTypeInfo{}})
+	r.mustRegisterAlias("DecimalType", "decimal")
+
+	r.mustRegisterType(TypeDouble, "double", SimpleCQLType{doubleTypeInfo{}})
+	r.mustRegisterAlias("DoubleType", "double")
+
+	r.mustRegisterType(TypeDuration, "duration", SimpleCQLType{durationTypeInfo{}})
+	r.mustRegisterAlias("DurationType", "duration")
+
+	r.mustRegisterType(TypeFloat, "float", SimpleCQLType{floatTypeInfo{}})
+	r.mustRegisterAlias("FloatType", "float")
+
+	r.mustRegisterType(TypeInet, "inet", SimpleCQLType{inetType{}})
+	r.mustRegisterAlias("InetAddressType", "inet")
+
+	r.mustRegisterType(TypeInt, "int", SimpleCQLType{intTypeInfo{}})
+	r.mustRegisterAlias("Int32Type", "int")
+
+	r.mustRegisterType(TypeSmallInt, "smallint", SimpleCQLType{smallIntTypeInfo{}})
+	r.mustRegisterAlias("ShortType", "smallint")
+
+	r.mustRegisterType(TypeText, "text", SimpleCQLType{varcharLikeTypeInfo{
+		typ: TypeText,
+	}})
+
+	r.mustRegisterType(TypeTime, "time", SimpleCQLType{timeTypeInfo{}})
+	r.mustRegisterAlias("TimeType", "time")
+
+	r.mustRegisterType(TypeTimestamp, "timestamp", SimpleCQLType{timestampTypeInfo{}})
+	r.mustRegisterAlias("TimestampType", "timestamp")
+	// DateType was a timestamp when date didn't exist
+	r.mustRegisterAlias("DateType", "timestamp")
+
+	r.mustRegisterType(TypeTimeUUID, "timeuuid", SimpleCQLType{timeUUIDType{}})
+	r.mustRegisterAlias("TimeUUIDType", "timeuuid")
+
+	r.mustRegisterType(TypeTinyInt, "tinyint", SimpleCQLType{tinyIntTypeInfo{}})
+	r.mustRegisterAlias("ByteType", "tinyint")
+
+	r.mustRegisterType(TypeUUID, "uuid", SimpleCQLType{uuidType{}})
+	r.mustRegisterAlias("UUIDType", "uuid")
+	r.mustRegisterAlias("LexicalUUIDType", "uuid")
+
+	r.mustRegisterType(TypeVarchar, "varchar", SimpleCQLType{varcharLikeTypeInfo{
+		typ: TypeVarchar,
+	}})
+	r.mustRegisterAlias("UTF8Type", "varchar")
+
+	r.mustRegisterType(TypeVarint, "varint", SimpleCQLType{varintTypeInfo{}})
+	r.mustRegisterAlias("IntegerType", "varint")
+
+	// these types need references to the registered types
+	r.mustRegisterType(TypeList, "list", listSetCQLType{
+		typ:   TypeList,
+		types: r,
+	})
+	r.mustRegisterAlias("ListType", "list")
+
+	r.mustRegisterType(TypeSet, "set", listSetCQLType{
+		typ:   TypeSet,
+		types: r,
+	})
+	r.mustRegisterAlias("SetType", "set")
+
+	r.mustRegisterType(TypeMap, "map", mapCQLType{
+		types: r,
+	})
+	r.mustRegisterAlias("MapType", "map")
+
+	r.mustRegisterType(TypeTuple, "tuple", tupleCQLType{
+		types: r,
+	})
+	r.mustRegisterAlias("TupleType", "tuple")
+
+	r.mustRegisterType(TypeUDT, "udt", udtCQLType{
+		types: r,
+	})
+	r.mustRegisterAlias("UserType", "udt")
+
+	r.mustRegisterCustom("vector", vectorCQLType{
+		types: r,
+	})
+	r.mustRegisterAlias("VectorType", "vector")
+}
+
+// RegisterType registers a new CQL data type. Type should be the CQL id for
+// the type. Name is the name of the type as returned in the metadata for the
+// column. CQLType is the implementation of the type.
+// This function must not be called after a session has been created.
+func (r *RegisteredTypes) RegisterType(typ Type, name string, t CQLType) error {
+	r.init()
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	return r.registerType(typ, name, t)
+}
+
+func (r *RegisteredTypes) registerType(typ Type, name string, t CQLType) error {
+	if typ == TypeCustom {
+		return errors.New("custom types must be registered with RegisterCustom")
+	}
+
+	if _, ok := r.byType[typ]; ok {
+		return fmt.Errorf("type %d already registered", typ)
+	}
+	if _, ok := r.byString[name]; ok {
+		return fmt.Errorf("type name %s already registered", name)
+	}
+	r.byType[typ] = t
+	if s, ok := t.(SimpleCQLType); ok {
+		r.simples[typ] = s.TypeInfo
+	}
+	r.byString[name] = typ
+	return nil
+}
+
+func (r *RegisteredTypes) mustRegisterType(typ Type, name string, t CQLType) {
+	if err := r.registerType(typ, name, t); err != nil {
+		panic(err)
+	}
+}
+
+// RegisterCustom registers a new custom CQL type. Name is the name of the type
+// as returned in the metadata for the column. CQLType is the implementation of
+// the type.
+// This function must not be called after a session has been created.
+func (r *RegisteredTypes) RegisterCustom(name string, t CQLType) error {
+	r.init()
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	return r.registerCustom(name, t)
+}
+
+func (r *RegisteredTypes) registerCustom(name string, t CQLType) error {
+	if r.custom == nil {
+		r.custom = map[string]CQLType{}
+	}
+	if _, ok := r.custom[name]; ok {
+		return fmt.Errorf("custom type %s already registered", name)
+	}
+	if _, ok := r.byString[name]; ok {
+		return fmt.Errorf("type name %s already registered", name)
+	}
+
+	r.custom[name] = t
+	r.byString[name] = TypeCustom
+	return nil
+}
+
+func (r *RegisteredTypes) mustRegisterCustom(name string, t CQLType) {
+	if err := r.registerCustom(name, t); err != nil {
+		panic(err)
+	}
+}
+
+// AddAlias adds an alias for an already registered type. If you expect a type
+// to be referenced as multiple different types or if you need to add the Java
+// marshal class for a type you should call this method.
+// This function must not be called after a session has been created.
+func (r *RegisteredTypes) AddAlias(name, as string) error {
+	r.init()
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	return r.registerAlias(name, as)
+}
+
+func (r *RegisteredTypes) registerAlias(name, as string) error {
+	if strings.HasPrefix(name, apacheCassandraTypePrefix) {
+		name = strings.TrimPrefix(name, apacheCassandraTypePrefix)
+	}
+	if strings.HasPrefix(as, apacheCassandraTypePrefix) {
+		as = strings.TrimPrefix(as, apacheCassandraTypePrefix)
+	}
+	if _, ok := r.byString[name]; ok {
+		return fmt.Errorf("type name %s already registered", name)
+	}
+	if _, ok := r.byString[as]; !ok {
+		return fmt.Errorf("type name %s was not registered", as)
+	}
+	if _, ok := r.custom[as]; ok {
+		r.custom[name] = r.custom[as]
+	}
+	r.byString[name] = r.byString[as]
+	return nil
+}
+
+func (r *RegisteredTypes) mustRegisterAlias(name, as string) {
+	if err := r.registerAlias(name, as); err != nil {
+		panic(err)
+	}
+}
+
+func (r *RegisteredTypes) typeInfoFromJavaString(proto int, fullName string) (TypeInfo, error) {
+	name := strings.TrimPrefix(fullName, apacheCassandraTypePrefix)
+	compositeNameIdx := strings.Index(name, "(")
+	var params string
+	if compositeNameIdx != -1 {
+		compositeParamsEndIdx := strings.LastIndex(name, ")")
+		if compositeParamsEndIdx == -1 {
+			return nil, fmt.Errorf("invalid type string %v", fullName)
+		}
+		params = name[compositeNameIdx+1 : compositeParamsEndIdx]
+		name = name[:compositeNameIdx]
+	}
+	t, ok := r.getType(name)
+	if !ok {
+		return nil, unknownTypeError(fullName)
+	}
+	return t.TypeInfoFromString(proto, params)
+}
+
+func (r *RegisteredTypes) typeInfoFromString(proto int, name string) (TypeInfo, error) {
+	// check for java long-form type
+	if strings.HasPrefix(name, apacheCassandraTypePrefix) {
+		return r.typeInfoFromJavaString(proto, name)
+	}
+
+	compositeNameIdx := strings.Index(name, "<")
+	var params string
+	if compositeNameIdx != -1 {
+		compositeParamsEndIdx := strings.LastIndex(name, ">")
+		if compositeParamsEndIdx == -1 {
+			return nil, fmt.Errorf("invalid type string %v", name)
+		}
+		params = name[compositeNameIdx+1 : compositeParamsEndIdx]
+		name = name[:compositeNameIdx]
+		// frozen is a special case
+		if name == "frozen" {
+			return r.typeInfoFromString(proto, params)
+		}
+	} else if strings.Contains(name, "(") {
+		// most likely a java long-form type
+		return r.typeInfoFromJavaString(proto, name)
+	}
+
+	t, ok := r.getType(name)
+	if !ok {
+		return nil, unknownTypeError(name)
+	}
+	return t.TypeInfoFromString(proto, params)
+}
+
+func splitCompositeTypes(name string) []string {
+	// check for the simple case without any composite types
+	if !strings.Contains(name, "(") && !strings.Contains(name, "<") {
+		parts := strings.Split(name, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		return parts
+	}
+	var parts []string
+	lessCount := 0
+	segment := ""
+	var openChar, closeChar rune
+	for _, char := range name {
+		if char == ',' && lessCount == 0 {
+			if segment != "" {
+				parts = append(parts, strings.TrimSpace(segment))
+			}
+			segment = ""
+			continue
+		}
+		segment += string(char)
+		// determine which open/close characters to use
+		if openChar == 0 {
+			if char == '<' {
+				openChar = '<'
+				closeChar = '>'
+				lessCount++
+			} else if char == '(' {
+				openChar = '('
+				closeChar = ')'
+				lessCount++
+			}
+		} else if char == openChar {
+			lessCount++
+		} else if char == closeChar {
+			lessCount--
+		}
+	}
+	if segment != "" {
+		parts = append(parts, strings.TrimSpace(segment))
+	}
+	return parts
+}
+
+func (r *RegisteredTypes) getType(classOrName string) (CQLType, bool) {
+	classOrName = strings.TrimPrefix(classOrName, apacheCassandraTypePrefix)
+	typ, ok := r.byString[classOrName]
+	if !ok {
+		// it could also be a UDT but this is what we've always done
+		typ = TypeCustom
+	}
+	var t CQLType
+	if typ == TypeCustom {
+		t, ok = r.custom[classOrName]
+	} else {
+		t = r.fastRegisteredTypeLookup(typ)
+		ok = t != nil
+	}
+	return t, ok
+}
+
+func (r *RegisteredTypes) fastTypeInfoLookup(typ Type) TypeInfo {
+	switch typ {
+	case TypeAscii:
+		return varcharLikeTypeInfo{
+			typ: TypeAscii,
+		}
+	case TypeBigInt:
+		return bigIntLikeTypeInfo{
+			typ: TypeBigInt,
+		}
+	case TypeBlob:
+		return varcharLikeTypeInfo{
+			typ: TypeBlob,
+		}
+	case TypeBoolean:
+		return booleanTypeInfo{}
+	case TypeCounter:
+		return bigIntLikeTypeInfo{
+			typ: TypeCounter,
+		}
+	case TypeDate:
+		return dateTypeInfo{}
+	case TypeDecimal:
+		return decimalTypeInfo{}
+	case TypeDouble:
+		return doubleTypeInfo{}
+	case TypeDuration:
+		return durationTypeInfo{}
+	case TypeFloat:
+		return floatTypeInfo{}
+	case TypeInet:
+		return inetType{}
+	case TypeInt:
+		return intTypeInfo{}
+	case TypeSmallInt:
+		return smallIntTypeInfo{}
+	case TypeText:
+		return varcharLikeTypeInfo{
+			typ: TypeText,
+		}
+	case TypeTime:
+		return timeTypeInfo{}
+	case TypeTimestamp:
+		return timestampTypeInfo{}
+	case TypeTimeUUID:
+		return timeUUIDType{}
+	case TypeTinyInt:
+		return tinyIntTypeInfo{}
+	case TypeUUID:
+		return uuidType{}
+	case TypeVarchar:
+		return varcharLikeTypeInfo{
+			typ: TypeVarchar,
+		}
+	case TypeVarint:
+		return varintTypeInfo{}
+	default:
+		return r.simples[typ]
+	}
+}
+
+// fastRegisteredTypeLookup is a fast lookup for the registered type that avoids
+// the need for a map lookup which was shown to be significant
+// in cases where it's necessary you should consider manually inlining this method
+func (r *RegisteredTypes) fastRegisteredTypeLookup(typ Type) CQLType {
+	switch typ {
+	case TypeAscii:
+		return SimpleCQLType{varcharLikeTypeInfo{
+			typ: TypeAscii,
+		}}
+	case TypeBigInt:
+		return SimpleCQLType{bigIntLikeTypeInfo{
+			typ: TypeBigInt,
+		}}
+	case TypeBlob:
+		return SimpleCQLType{varcharLikeTypeInfo{
+			typ: TypeBlob,
+		}}
+	case TypeBoolean:
+		return SimpleCQLType{booleanTypeInfo{}}
+	case TypeCounter:
+		return SimpleCQLType{bigIntLikeTypeInfo{
+			typ: TypeCounter,
+		}}
+	case TypeDate:
+		return SimpleCQLType{dateTypeInfo{}}
+	case TypeDecimal:
+		return SimpleCQLType{decimalTypeInfo{}}
+	case TypeDouble:
+		return SimpleCQLType{doubleTypeInfo{}}
+	case TypeDuration:
+		return SimpleCQLType{durationTypeInfo{}}
+	case TypeFloat:
+		return SimpleCQLType{floatTypeInfo{}}
+	case TypeInet:
+		return SimpleCQLType{inetType{}}
+	case TypeInt:
+		return SimpleCQLType{intTypeInfo{}}
+	case TypeSmallInt:
+		return SimpleCQLType{smallIntTypeInfo{}}
+	case TypeText:
+		return SimpleCQLType{varcharLikeTypeInfo{
+			typ: TypeText,
+		}}
+	case TypeTime:
+		return SimpleCQLType{timeTypeInfo{}}
+	case TypeTimestamp:
+		return SimpleCQLType{timestampTypeInfo{}}
+	case TypeTimeUUID:
+		return SimpleCQLType{timeUUIDType{}}
+	case TypeTinyInt:
+		return SimpleCQLType{tinyIntTypeInfo{}}
+	case TypeUUID:
+		return SimpleCQLType{uuidType{}}
+	case TypeVarchar:
+		return SimpleCQLType{varcharLikeTypeInfo{
+			typ: TypeVarchar,
+		}}
+	case TypeVarint:
+		return SimpleCQLType{varintTypeInfo{}}
+	case TypeCustom:
+		// this should never happen
+		panic("custom types cannot be returned from fastRegisteredTypeLookup")
+	default:
+		return r.byType[typ]
+	}
+}
+
+// Copy returns a new shallow copy of the RegisteredTypes
+func (r *RegisteredTypes) Copy() *RegisteredTypes {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	copy := &RegisteredTypes{}
+	copy.init()
+	for typ, t := range r.byType {
+		copy.byType[typ] = t
+	}
+	for typ, t := range r.simples {
+		copy.simples[typ] = t
+	}
+	for name, typ := range r.byString {
+		copy.byString[name] = typ
+	}
+	for name, t := range r.custom {
+		copy.custom[name] = t
+	}
+	return copy
+}
+
+// GlobalTypes is the set of types that are registered globally and are copied
+// by all sessions that don't define their own RegisteredTypes in ClusterConfig.
+// Since a new session copies this, you should be modifying this or creating your
+// own before a session is created.
+var GlobalTypes = func() *RegisteredTypes {
+	r := &RegisteredTypes{}
+	// we init because we end up calling GlobalTypes in tests and other spots before
+	// init would get called
+	r.init()
+	r.addDefaultTypes()
+	return r
+}()
+
+// Type is the identifier of a Cassandra internal datatype.
+type Type int
+
+const (
+	TypeCustom    Type = 0x0000
+	TypeAscii     Type = 0x0001
+	TypeBigInt    Type = 0x0002
+	TypeBlob      Type = 0x0003
+	TypeBoolean   Type = 0x0004
+	TypeCounter   Type = 0x0005
+	TypeDecimal   Type = 0x0006
+	TypeDouble    Type = 0x0007
+	TypeFloat     Type = 0x0008
+	TypeInt       Type = 0x0009
+	TypeText      Type = 0x000A
+	TypeTimestamp Type = 0x000B
+	TypeUUID      Type = 0x000C
+	TypeVarchar   Type = 0x000D
+	TypeVarint    Type = 0x000E
+	TypeTimeUUID  Type = 0x000F
+	TypeInet      Type = 0x0010
+	TypeDate      Type = 0x0011
+	TypeTime      Type = 0x0012
+	TypeSmallInt  Type = 0x0013
+	TypeTinyInt   Type = 0x0014
+	TypeDuration  Type = 0x0015
+	TypeList      Type = 0x0020
+	TypeMap       Type = 0x0021
+	TypeSet       Type = 0x0022
+	TypeUDT       Type = 0x0030
+	TypeTuple     Type = 0x0031
+)
+
+// NewNativeType returns a TypeInfo from the global registered types.
+// Deprecated.
+func NewNativeType(proto byte, typ Type, custom string) TypeInfo {
+	if typ == TypeCustom {
+		t, err := GlobalTypes.typeInfoFromString(int(proto), custom)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+	rt := GlobalTypes.fastRegisteredTypeLookup(typ)
+	if rt == nil {
+		return unknownTypeInfo(fmt.Sprintf("%d", typ))
+	}
+	// most of the time this will do nothing because it's a SimpleCQLType but if
+	// it's not then we don't have anything to pass but custom
+	t, err := rt.TypeInfoFromString(int(proto), custom)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+type unknownTypeInfo string
+
+func (unknownTypeInfo) Type() Type {
+	return TypeCustom
+}
+
+// Zero returns the zero value for the unknown custom type.
+func (unknownTypeInfo) Zero() interface{} {
+	return nil
+}
+
+func (u unknownTypeInfo) Marshal(value interface{}) ([]byte, error) {
+	return nil, fmt.Errorf("can not marshal %T into %s", value, string(u))
+}
+
+func (u unknownTypeInfo) Unmarshal(_ []byte, value interface{}) error {
+	return fmt.Errorf("can not unmarshal %s into %T", string(u), value)
+}
+
+type unknownTypeError string
+
+func (e unknownTypeError) Error() string {
+	return fmt.Sprintf("unknown type %v", string(e))
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,120 @@
+//go:build all || unit
+// +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2016, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
+package gocql
+
+import (
+	"reflect"
+	"testing"
+)
+
+var defaultLongTypes = []struct {
+	TypeName string
+}{
+	{"AsciiType"},
+	{"LongType"},
+	{"BytesType"},
+	{"BooleanType"},
+	{"CounterColumnType"},
+	{"DecimalType"},
+	{"DoubleType"},
+	{"FloatType"},
+	{"Int32Type"},
+	{"DateType"},
+	{"TimestampType"},
+	{"UUIDType"},
+	{"UTF8Type"},
+	{"IntegerType"},
+	{"TimeUUIDType"},
+	{"InetAddressType"},
+	{"MapType"},
+	{"ListType"},
+	{"SetType"},
+	{"ShortType"},
+	{"ByteType"},
+	{"TupleType"},
+	{"UserType"},
+	{"VectorType"},
+}
+
+func testType(t *testing.T, str string) {
+	_, ok := GlobalTypes.getType(apacheCassandraTypePrefix + str)
+	if !ok {
+		t.Errorf("failed to get type for %v", apacheCassandraTypePrefix+str)
+	}
+}
+
+func TestDefaultLongTypes(t *testing.T) {
+	for _, lookupTest := range defaultLongTypes {
+		testType(t, lookupTest.TypeName)
+	}
+}
+
+func TestSplitCompositeTypes(t *testing.T) {
+	var testCases = []struct {
+		Name  string
+		Split []string
+	}{
+		{
+			Name:  "boolean",
+			Split: []string{"boolean"},
+		},
+		{
+			Name:  "boolean, int",
+			Split: []string{"boolean", "int"},
+		},
+		{
+			Name:  apacheCassandraTypePrefix + "TupleType(a, b)",
+			Split: []string{apacheCassandraTypePrefix + "TupleType(a, b)"},
+		},
+		{
+			Name:  "tuple<a,b>",
+			Split: []string{"tuple<a,b>"},
+		},
+		{
+			Name:  "tuple<tuple<a>,b>",
+			Split: []string{"tuple<tuple<a>,b>"},
+		},
+		{
+			Name:  "tuple<tuple<a>,b>, int",
+			Split: []string{"tuple<tuple<a>,b>", "int"},
+		},
+		{
+			Name: apacheCassandraTypePrefix + "TupleType(a, b), " + apacheCassandraTypePrefix + "IntType",
+			Split: []string{
+				apacheCassandraTypePrefix + "TupleType(a, b)",
+				apacheCassandraTypePrefix + "IntType",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		split := splitCompositeTypes(tc.Name)
+		if !reflect.DeepEqual(split, tc.Split) {
+			t.Errorf("[%v] expected %v, got %v", tc.Name, tc.Split, split)
+		}
+	}
+}

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/bits"
+	"reflect"
+	"strconv"
+)
+
+type vectorCQLType struct {
+	types *RegisteredTypes
+}
+
+// Params returns nil
+func (vectorCQLType) Params(int) []interface{} {
+	// we don't support frame params for custom types
+	return nil
+}
+
+// TypeInfoFromParams builds a TypeInfo implementation for the composite type with
+// the given parameters.
+func (vectorCQLType) TypeInfoFromParams(int, []interface{}) (TypeInfo, error) {
+	return nil, errors.New("unsupported for vector")
+}
+
+// TypeInfoFromString builds the VectorType from the given string.
+func (v vectorCQLType) TypeInfoFromString(proto int, name string) (TypeInfo, error) {
+	params := splitCompositeTypes(name)
+	if len(params) != 2 {
+		return nil, fmt.Errorf("expected 2 params for vector, got %d", len(params))
+	}
+	subType, err := v.types.typeInfoFromString(proto, params[0])
+	if err != nil {
+		return nil, err
+	}
+	dim, _ := strconv.Atoi(params[1])
+	return VectorType{
+		SubType:    subType,
+		Dimensions: dim,
+	}, nil
+}
+
+type VectorType struct {
+	SubType    TypeInfo
+	Dimensions int
+}
+
+func (VectorType) Type() Type {
+	return TypeCustom
+}
+
+// Zero returns the zero value for the vector CQL type.
+func (v VectorType) Zero() interface{} {
+	return reflect.Zero(reflect.SliceOf(reflect.TypeOf(v.SubType.Zero()))).Interface()
+}
+
+func (t VectorType) String() string {
+	return fmt.Sprintf("vector(%s, %d)", t.SubType, t.Dimensions)
+}
+
+// Marshal marshals the value into a byte slice.
+func (v VectorType) Marshal(value interface{}) ([]byte, error) {
+	if value == nil {
+		return nil, nil
+	} else if _, ok := value.(unsetColumn); ok {
+		return nil, nil
+	}
+
+	rv := reflect.ValueOf(value)
+	t := rv.Type()
+	k := t.Kind()
+	if k == reflect.Slice && rv.IsNil() {
+		return nil, nil
+	}
+
+	switch k {
+	case reflect.Slice, reflect.Array:
+		buf := &bytes.Buffer{}
+		n := rv.Len()
+		if n != v.Dimensions {
+			return nil, marshalErrorf("expected vector with %d dimensions, received %d", v.Dimensions, n)
+		}
+
+		for i := 0; i < n; i++ {
+			item, err := Marshal(v.SubType, rv.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			if isVectorVariableLengthType(v.SubType) {
+				writeUnsignedVInt(buf, uint64(len(item)))
+			}
+			buf.Write(item)
+		}
+		return buf.Bytes(), nil
+	}
+	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, v)
+}
+
+// Unmarshal unmarshals the byte slice into the value.
+func (v VectorType) Unmarshal(data []byte, value interface{}) error {
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Ptr {
+		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
+	}
+	rv = rv.Elem()
+	t := rv.Type()
+	k := t.Kind()
+	switch k {
+	case reflect.Slice, reflect.Array:
+		if data == nil {
+			if k == reflect.Array {
+				return unmarshalErrorf("unmarshal vector: can not store nil in array value")
+			}
+			if rv.IsNil() {
+				return nil
+			}
+			rv.Set(reflect.Zero(t))
+			return nil
+		}
+		if k == reflect.Array {
+			if rv.Len() != v.Dimensions {
+				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), v.Dimensions)
+			}
+		} else {
+			rv.Set(reflect.MakeSlice(t, v.Dimensions, v.Dimensions))
+		}
+		elemSize := len(data) / v.Dimensions
+		for i := 0; i < v.Dimensions; i++ {
+			offset := 0
+			if isVectorVariableLengthType(v.SubType) {
+				m, p, err := readUnsignedVInt(data)
+				if err != nil {
+					return err
+				}
+				elemSize = int(m)
+				offset = p
+			}
+			if offset > 0 {
+				data = data[offset:]
+			}
+			var unmarshalData []byte
+			if elemSize >= 0 {
+				if len(data) < elemSize {
+					return unmarshalErrorf("unmarshal vector: unexpected eof")
+				}
+				unmarshalData = data[:elemSize]
+				data = data[elemSize:]
+			}
+			err := Unmarshal(v.SubType, unmarshalData, rv.Index(i).Addr().Interface())
+			if err != nil {
+				return unmarshalErrorf("failed to unmarshal %s into %T: %s", v.SubType, unmarshalData, err.Error())
+			}
+		}
+		return nil
+	}
+	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: slice, array.", v, value)
+}
+
+// isVectorVariableLengthType determines if a type requires explicit length serialization within a vector.
+// Variable-length types need their length encoded before the actual data to allow proper deserialization.
+// Fixed-length types, on the other hand, don't require this kind of length prefix.
+func isVectorVariableLengthType(elemType TypeInfo) bool {
+	switch elemType.Type() {
+	case TypeBigInt, TypeBoolean, TypeTimestamp, TypeDouble, TypeFloat, TypeInt,
+		TypeTimeUUID, TypeUUID:
+		return false
+	case TypeCustom:
+		// vectors are special in that they rely on the underlying type
+		if vecType, ok := elemType.(VectorType); ok {
+			return isVectorVariableLengthType(vecType.SubType)
+		}
+	}
+	return true
+}
+
+func writeUnsignedVInt(buf *bytes.Buffer, v uint64) {
+	numBytes := computeUnsignedVIntSize(v)
+	if numBytes <= 1 {
+		buf.WriteByte(byte(v))
+		return
+	}
+
+	extraBytes := numBytes - 1
+	var tmp = make([]byte, numBytes)
+	for i := extraBytes; i >= 0; i-- {
+		tmp[i] = byte(v)
+		v >>= 8
+	}
+	tmp[0] |= byte(^(0xff >> uint(extraBytes)))
+	buf.Write(tmp)
+}
+
+func readUnsignedVInt(data []byte) (uint64, int, error) {
+	if len(data) <= 0 {
+		return 0, 0, errors.New("unexpected eof")
+	}
+	firstByte := data[0]
+	if firstByte&0x80 == 0 {
+		return uint64(firstByte), 1, nil
+	}
+	numBytes := bits.LeadingZeros32(uint32(^firstByte)) - 24
+	ret := uint64(firstByte & (0xff >> uint(numBytes)))
+	if len(data) < numBytes+1 {
+		return 0, 0, fmt.Errorf("data expect to have %d bytes, but it has only %d", numBytes+1, len(data))
+	}
+	for i := 0; i < numBytes; i++ {
+		ret <<= 8
+		ret |= uint64(data[i+1] & 0xff)
+	}
+	return ret, numBytes + 1, nil
+}
+
+func computeUnsignedVIntSize(v uint64) int {
+	lead0 := bits.LeadingZeros64(v)
+	return (639 - lead0*9) >> 6
+}

--- a/vector_test.go
+++ b/vector_test.go
@@ -29,12 +29,13 @@ package gocql
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/inf.v0"
 	"net"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/inf.v0"
 )
 
 type person struct {
@@ -107,9 +108,9 @@ func TestVector_Types(t *testing.T) {
 	date2, _ := time.Parse("2006-01-02", "2022-03-14")
 	date3, _ := time.Parse("2006-01-02", "2024-12-31")
 
-	time1, _ := time.Parse("15:04:05", "01:00:00")
-	time2, _ := time.Parse("15:04:05", "15:23:59")
-	time3, _ := time.Parse("15:04:05.000", "10:31:45.987")
+	time1 := time.Duration(time.Hour)
+	time2 := time.Duration(15*time.Hour + 23*time.Minute + 59*time.Second)
+	time3 := time.Duration(10*time.Hour + 31*time.Minute + 45*time.Second + 987*time.Millisecond)
 
 	duration1 := Duration{0, 1, 1920000000000}
 	duration2 := Duration{1, 1, 1920000000000}
@@ -129,24 +130,24 @@ func TestVector_Types(t *testing.T) {
 		value      interface{}
 		comparator func(interface{}, interface{})
 	}{
-		{name: "ascii", cqlType: TypeAscii.String(), value: []string{"a", "1", "Z"}},
-		{name: "bigint", cqlType: TypeBigInt.String(), value: []int64{1, 2, 3}},
-		{name: "blob", cqlType: TypeBlob.String(), value: [][]byte{[]byte{1, 2, 3}, []byte{4, 5, 6, 7}, []byte{8, 9}}},
-		{name: "boolean", cqlType: TypeBoolean.String(), value: []bool{true, false, true}},
-		{name: "counter", cqlType: TypeCounter.String(), value: []int64{5, 6, 7}},
-		{name: "decimal", cqlType: TypeDecimal.String(), value: []inf.Dec{*inf.NewDec(1, 0), *inf.NewDec(2, 1), *inf.NewDec(-3, 2)}},
-		{name: "double", cqlType: TypeDouble.String(), value: []float64{0.1, -1.2, 3}},
-		{name: "float", cqlType: TypeFloat.String(), value: []float32{0.1, -1.2, 3}},
-		{name: "int", cqlType: TypeInt.String(), value: []int32{1, 2, 3}},
-		{name: "text", cqlType: TypeText.String(), value: []string{"a", "b", "c"}},
-		{name: "timestamp", cqlType: TypeTimestamp.String(), value: []time.Time{timestamp1, timestamp2, timestamp3}},
-		{name: "uuid", cqlType: TypeUUID.String(), value: []UUID{MustRandomUUID(), MustRandomUUID(), MustRandomUUID()}},
-		{name: "varchar", cqlType: TypeVarchar.String(), value: []string{"abc", "def", "ghi"}},
-		{name: "varint", cqlType: TypeVarint.String(), value: []uint64{uint64(1234), uint64(123498765), uint64(18446744073709551615)}},
-		{name: "timeuuid", cqlType: TypeTimeUUID.String(), value: []UUID{TimeUUID(), TimeUUID(), TimeUUID()}},
+		{name: "ascii", cqlType: "ascii", value: []string{"a", "1", "Z"}},
+		{name: "bigint", cqlType: "bigint", value: []int64{1, 2, 3}},
+		{name: "blob", cqlType: "blob", value: [][]byte{[]byte{1, 2, 3}, []byte{4, 5, 6, 7}, []byte{8, 9}}},
+		{name: "boolean", cqlType: "boolean", value: []bool{true, false, true}},
+		{name: "counter", cqlType: "counter", value: []int64{5, 6, 7}},
+		{name: "decimal", cqlType: "decimal", value: []inf.Dec{*inf.NewDec(1, 0), *inf.NewDec(2, 1), *inf.NewDec(-3, 2)}},
+		{name: "double", cqlType: "double", value: []float64{0.1, -1.2, 3}},
+		{name: "float", cqlType: "float", value: []float32{0.1, -1.2, 3}},
+		{name: "int", cqlType: "int", value: []int32{1, 2, 3}},
+		{name: "text", cqlType: "text", value: []string{"a", "b", "c"}},
+		{name: "timestamp", cqlType: "timestamp", value: []time.Time{timestamp1, timestamp2, timestamp3}},
+		{name: "uuid", cqlType: "uuid", value: []UUID{MustRandomUUID(), MustRandomUUID(), MustRandomUUID()}},
+		{name: "varchar", cqlType: "varchar", value: []string{"abc", "def", "ghi"}},
+		{name: "varint", cqlType: "varint", value: []uint64{uint64(1234), uint64(123498765), uint64(18446744073709551615)}},
+		{name: "timeuuid", cqlType: "timeuuid", value: []UUID{TimeUUID(), TimeUUID(), TimeUUID()}},
 		{
 			name:    "inet",
-			cqlType: TypeInet.String(),
+			cqlType: "inet",
 			value:   []net.IP{net.IPv4(127, 0, 0, 1), net.IPv4(192, 168, 1, 1), net.IPv4(8, 8, 8, 8)},
 			comparator: func(e interface{}, a interface{}) {
 				expected := e.([]net.IP)
@@ -157,11 +158,11 @@ func TestVector_Types(t *testing.T) {
 				}
 			},
 		},
-		{name: "date", cqlType: TypeDate.String(), value: []time.Time{date1, date2, date3}},
-		{name: "time", cqlType: TypeTimestamp.String(), value: []time.Time{time1, time2, time3}},
-		{name: "smallint", cqlType: TypeSmallInt.String(), value: []int16{127, 256, -1234}},
-		{name: "tinyint", cqlType: TypeTinyInt.String(), value: []int8{127, 9, -123}},
-		{name: "duration", cqlType: TypeDuration.String(), value: []Duration{duration1, duration2, duration3}},
+		{name: "date", cqlType: "date", value: []time.Time{date1, date2, date3}},
+		{name: "time", cqlType: "time", value: []time.Duration{time1, time2, time3}},
+		{name: "smallint", cqlType: "smallint", value: []int16{127, 256, -1234}},
+		{name: "tinyint", cqlType: "tinyint", value: []int8{127, 9, -123}},
+		{name: "duration", cqlType: "duration", value: []Duration{duration1, duration2, duration3}},
 		{name: "vector_vector_float", cqlType: "vector<float, 5>", value: [][]float32{{0.1, -1.2, 3, 5, 5}, {10.1, -122222.0002, 35.0, 1, 1}, {0, 0, 0, 0, 0}}},
 		{name: "vector_vector_set_float", cqlType: "vector<set<float>, 5>", value: [][][]float32{
 			{{1, 2}, {2, -1}, {3}, {0}, {-1.3}},
@@ -307,95 +308,33 @@ func TestVector_MissingDimension(t *testing.T) {
 	require.Error(t, err, "expected vector with 3 dimensions, received 4")
 }
 
-func TestVector_SubTypeParsing(t *testing.T) {
+func TestReadUnsignedVInt(t *testing.T) {
 	tests := []struct {
-		name     string
-		custom   string
-		expected TypeInfo
+		decodedInt  uint64
+		encodedVint []byte
 	}{
-		{name: "text", custom: "org.apache.cassandra.db.marshal.UTF8Type", expected: NativeType{typ: TypeVarchar}},
-		{name: "set_int", custom: "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.Int32Type)", expected: CollectionType{NativeType{typ: TypeSet}, nil, NativeType{typ: TypeInt}}},
 		{
-			name:   "udt",
-			custom: "org.apache.cassandra.db.marshal.UserType(gocql_test,706572736f6e,66697273745f6e616d65:org.apache.cassandra.db.marshal.UTF8Type,6c6173745f6e616d65:org.apache.cassandra.db.marshal.UTF8Type,616765:org.apache.cassandra.db.marshal.Int32Type)",
-			expected: UDTTypeInfo{
-				NativeType{typ: TypeUDT},
-				"gocql_test",
-				"person",
-				[]UDTField{
-					UDTField{"first_name", NativeType{typ: TypeVarchar}},
-					UDTField{"last_name", NativeType{typ: TypeVarchar}},
-					UDTField{"age", NativeType{typ: TypeInt}},
-				},
-			},
+			decodedInt:  0,
+			encodedVint: []byte{0},
 		},
 		{
-			name:   "tuple",
-			custom: "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)",
-			expected: TupleTypeInfo{
-				NativeType{typ: TypeTuple},
-				[]TypeInfo{
-					NativeType{typ: TypeVarchar},
-					NativeType{typ: TypeInt},
-					NativeType{typ: TypeVarchar},
-				},
-			},
+			decodedInt:  100,
+			encodedVint: []byte{100},
 		},
 		{
-			name:   "vector_vector_inet",
-			custom: "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.InetAddressType, 2), 3)",
-			expected: VectorType{
-				NativeType{typ: TypeCustom, custom: VECTOR_TYPE},
-				VectorType{
-					NativeType{typ: TypeCustom, custom: VECTOR_TYPE},
-					NativeType{typ: TypeInet},
-					2,
-				},
-				3,
-			},
-		},
-		{
-			name:   "map_int_vector_text",
-			custom: "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.UTF8Type, 10))",
-			expected: CollectionType{
-				NativeType{typ: TypeMap},
-				NativeType{typ: TypeInt},
-				VectorType{
-					NativeType{typ: TypeCustom, custom: VECTOR_TYPE},
-					NativeType{typ: TypeVarchar},
-					10,
-				},
-			},
-		},
-		{
-			name:   "set_map_vector_text_text",
-			custom: "org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.Int32Type, 10),org.apache.cassandra.db.marshal.UTF8Type))",
-			expected: CollectionType{
-				NativeType{typ: TypeSet},
-				nil,
-				CollectionType{
-					NativeType{typ: TypeMap},
-					VectorType{
-						NativeType{typ: TypeCustom, custom: VECTOR_TYPE},
-						NativeType{typ: TypeInt},
-						10,
-					},
-					NativeType{typ: TypeVarchar},
-				},
-			},
+			decodedInt:  256000,
+			encodedVint: []byte{195, 232, 0},
 		},
 	}
-
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			f := newFramer(nil, 0)
-			f.writeShort(0)
-			f.writeString(fmt.Sprintf("org.apache.cassandra.db.marshal.VectorType(%s, 2)", test.custom))
-			parsedType := f.readTypeInfo()
-			require.IsType(t, parsedType, VectorType{})
-			vectorType := parsedType.(VectorType)
-			assertEqual(t, "dimensions", 2, vectorType.Dimensions)
-			assertDeepEqual(t, "vector", test.expected, vectorType.SubType)
+		t.Run(fmt.Sprintf("%d", test.decodedInt), func(t *testing.T) {
+			actual, _, err := readUnsignedVInt(test.encodedVint)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			if actual != test.decodedInt {
+				t.Fatalf("Expected %d, but got %d", test.decodedInt, actual)
+			}
 		})
 	}
 }


### PR DESCRIPTION
CASSGO-43: externally-defined type registration
The new RegisteredTypes struct can be used to register externally-defined
types. You'll need to define your own marshalling and unmarshalling code
as well as a TypeInfo implementation. The name and id MUST not collide
with existing and future native CQL types.

A lot of the type handling was refactored to use the new format for
types.

inet columns are now unmarshaled as net.IP which is a breaking change.

```
goos: linux
goarch: amd64
pkg: github.com/gocql/gocql
cpu: AMD EPYC 7B13
                             │    old.txt    │                new3.txt                │
                             │    sec/op     │    sec/op     vs base                  │
SingleConn-16                   25.87µ ±  2%   26.49µ ±  1%   +2.40% (p=0.000 n=10)
ParseRowsFrame-16               870.5n ±  3%   683.1n ±  4%  -21.52% (p=0.000 n=10)
UnmarshalVarchar-16             47.29n ±  2%
UnmarshalUUID-16                3.161n ±  2%
Unmarshal_BigInt-16             17.61n ±  9%   13.47n ±  0%  -23.48% (p=0.000 n=10)
Unmarshal_Blob-16               19.19n ±  0%   14.79n ±  2%  -22.88% (p=0.000 n=10)
Unmarshal_Boolean-16            15.71n ±  0%   12.20n ±  1%  -22.32% (p=0.000 n=10)
Unmarshal_Date-16               18.53n ±  1%   15.98n ±  0%  -13.73% (p=0.000 n=10)
Unmarshal_Decimal-16           172.15n ±  2%   96.55n ±  1%  -43.92% (p=0.000 n=10)
Unmarshal_Double-16             16.33n ±  1%   12.21n ±  0%  -25.20% (p=0.000 n=10)
Unmarshal_Duration-16           26.03n ±  1%   22.30n ±  1%  -14.33% (p=0.000 n=10)
Unmarshal_Float-16              15.70n ±  0%   12.21n ±  0%  -22.17% (p=0.000 n=10)
Unmarshal_Int-16                17.80n ±  1%   14.43n ±  0%  -18.96% (p=0.000 n=10)
Unmarshal_Inet-16               28.68n ±  1%   25.25n ±  1%  -11.96% (p=0.000 n=10)
Unmarshal_SmallInt-16           17.92n ±  1%   14.45n ±  1%  -19.37% (p=0.000 n=10)
Unmarshal_Time-16               16.00n ±  1%   12.25n ±  3%  -23.47% (p=0.000 n=10)
Unmarshal_Timestamp-16          16.00n ±  2%   12.23n ±  0%  -23.62% (p=0.000 n=10)
Unmarshal_TinyInt-16            16.38n ±  3%   14.40n ±  1%  -12.09% (p=0.000 n=10)
Unmarshal_UUID-16               16.05n ±  1%   12.56n ±  1%  -21.77% (p=0.000 n=10)
Unmarshal_Varchar-16            18.86n ±  1%   14.81n ±  1%  -21.43% (p=0.000 n=10)
Unmarshal_List-16               176.2n ±  4%   172.9n ±  1%   -1.90% (p=0.002 n=10)
Unmarshal_Set-16                177.7n ±  1%   172.9n ±  0%   -2.67% (p=0.000 n=10)
Unmarshal_Map-16                374.0n ±  5%   348.0n ±  2%   -6.94% (p=0.000 n=10)
Unmarshal_TupleStrings-16       387.9n ±  1%   206.1n ±  1%  -46.85% (p=0.000 n=10)
Unmarshal_TupleInterfaces-16    485.4n ±  2%   289.6n ±  3%  -40.34% (p=0.000 n=10)
FramerReadTypeInfo-16           207.8n ±  3%   168.6n ±  5%  -18.89% (p=0.000 n=10)
ConnStress-16                   14.10µ ± 16%   16.05µ ± 19%        ~ (p=0.363 n=10)
ConnRoutingKey-16               275.3n ±  4%   276.9n ±  2%        ~ (p=0.869 n=10)
WikiCreateSchema-16             515.9m ±  3%   484.9m ±  3%   -6.02% (p=0.000 n=10)
WikiCreatePages-16              1.534m ±  1%   1.469m ±  1%   -4.21% (p=0.000 n=10)
WikiSelectAllPages-16           1.982m ±  3%   1.900m ±  1%   -4.13% (p=0.000 n=10)
WikiSelectSinglePage-16         1.529m ±  2%   1.472m ±  0%   -3.72% (p=0.000 n=10)
WikiSelectPageCount-16          1.691m ±  2%   1.629m ±  2%   -3.67% (p=0.000 n=10)
FramerReadCol-16                107.7n ±  3%   124.6n ±  1%  +15.79% (p=0.000 n=10)
geomean                         375.5n         391.1n        -15.90%                ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                             │    old.txt     │                 new3.txt                 │
                             │      B/op      │     B/op      vs base                    │
SingleConn-16                  3.155Ki ± 0%     3.157Ki ± 0%   +0.06% (p=0.000 n=10)
ParseRowsFrame-16               1128.0 ± 0%       872.0 ± 0%  -22.70% (p=0.000 n=10)
UnmarshalVarchar-16              32.00 ± 0%
UnmarshalUUID-16                 0.000 ± 0%
Unmarshal_BigInt-16              0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Blob-16                0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Boolean-16             0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Date-16                0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Decimal-16             96.00 ± 0%       48.00 ± 0%  -50.00% (p=0.000 n=10)
Unmarshal_Double-16              0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Duration-16            0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Float-16               0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Int-16                 0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Inet-16                4.000 ± 0%       4.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_SmallInt-16            0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Time-16                0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Timestamp-16           0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_TinyInt-16             0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_UUID-16                0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Varchar-16             0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_List-16                32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Set-16                 32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Map-16                 280.0 ± 0%       280.0 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_TupleStrings-16       158.00 ± 0%       62.00 ± 0%  -60.76% (p=0.000 n=10)
Unmarshal_TupleInterfaces-16    190.00 ± 0%       94.00 ± 0%  -50.53% (p=0.000 n=10)
FramerReadTypeInfo-16           160.00 ± 0%       96.00 ± 0%  -40.00% (p=0.000 n=10)
ConnStress-16                  2.956Ki ± 0%     2.958Ki ± 0%        ~ (p=0.238 n=10)
ConnRoutingKey-16                96.00 ± 0%       96.00 ± 0%        ~ (p=1.000 n=10) ¹
WikiCreateSchema-16            59.90Ki ± 3%     57.90Ki ± 1%   -3.34% (p=0.004 n=10)
WikiCreatePages-16             4.357Ki ± 0%     4.355Ki ± 0%        ~ (p=0.236 n=10)
WikiSelectAllPages-16          38.32Ki ± 0%     38.32Ki ± 0%        ~ (p=0.322 n=10)
WikiSelectSinglePage-16        3.783Ki ± 0%     3.781Ki ± 0%        ~ (p=0.239 n=10)
WikiSelectPageCount-16         3.215Ki ± 0%     3.212Ki ± 0%        ~ (p=0.232 n=10)
FramerReadCol-16                 99.00 ± 0%       67.00 ± 0%  -32.32% (p=0.000 n=10)
geomean                                     ²                 -10.43%                ³ ²
¹ all samples are equal
² summaries must be >0 to compute geomean
³ benchmark set differs from baseline; geomeans may not be comparable

                             │    old.txt    │                new3.txt                │
                             │   allocs/op   │ allocs/op   vs base                    │
SingleConn-16                   37.00 ± 0%     37.00 ± 0%        ~ (p=1.000 n=10) ¹
ParseRowsFrame-16               21.00 ± 0%     13.00 ± 0%  -38.10% (p=0.000 n=10)
UnmarshalVarchar-16             1.000 ± 0%
UnmarshalUUID-16                0.000 ± 0%
Unmarshal_BigInt-16             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Blob-16               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Boolean-16            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Date-16               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Decimal-16            4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.000 n=10)
Unmarshal_Double-16             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Duration-16           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Float-16              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Int-16                0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Inet-16               1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_SmallInt-16           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Time-16               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Timestamp-16          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_TinyInt-16            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_UUID-16               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Varchar-16            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_List-16               2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Set-16                2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_Map-16                5.000 ± 0%     5.000 ± 0%        ~ (p=1.000 n=10) ¹
Unmarshal_TupleStrings-16       8.000 ± 0%     4.000 ± 0%  -50.00% (p=0.000 n=10)
Unmarshal_TupleInterfaces-16   10.000 ± 0%     6.000 ± 0%  -40.00% (p=0.000 n=10)
FramerReadTypeInfo-16           4.000 ± 0%     4.000 ± 0%        ~ (p=1.000 n=10) ¹
ConnStress-16                   35.00 ± 0%     35.00 ± 0%        ~ (p=1.000 n=10)
ConnRoutingKey-16               4.000 ± 0%     4.000 ± 0%        ~ (p=1.000 n=10) ¹
WikiCreateSchema-16             858.0 ± 3%     746.0 ± 1%  -13.05% (p=0.000 n=10)
WikiCreatePages-16              56.00 ± 2%     56.00 ± 2%        ~ (p=1.000 n=10)
WikiSelectAllPages-16           343.0 ± 0%     343.0 ± 0%        ~ (p=1.000 n=10) ¹
WikiSelectSinglePage-16         50.00 ± 0%     50.00 ± 0%        ~ (p=1.000 n=10) ¹
WikiSelectPageCount-16          45.00 ± 0%     45.00 ± 0%        ~ (p=1.000 n=10) ¹
FramerReadCol-16                3.000 ± 0%     3.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                    ²                -6.38%                ³ ²
¹ all samples are equal
² summaries must be >0 to compute geomean
³ benchmark set differs from baseline; geomeans may not be comparable
```