### PR TITLE
CASSGO-45 ConnectAddress() should not panic and HostInfo should not be created with invalid connect address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Standardized spelling of datacenter (CASSGO-35)
 
+- Refactor HostInfo creation and ConnectAddress() method (CASSGO-45)
+
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)
 

--- a/conn.go
+++ b/conn.go
@@ -1690,7 +1690,11 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 		}
 
 		for _, row := range rows {
-			host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.ConnectAddress(), port: c.session.cfg.Port})
+			h, err := newHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
+			if err != nil {
+				goto cont
+			}
+			host, err := c.session.hostInfoFromMap(row, h)
 			if err != nil {
 				goto cont
 			}

--- a/control.go
+++ b/control.go
@@ -146,7 +146,11 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 
 	// Check if host is a literal IP address
 	if ip := net.ParseIP(host); ip != nil {
-		hosts = append(hosts, &HostInfo{hostname: host, connectAddress: ip, port: port})
+		h, err := newHostInfo(ip, port)
+		if err != nil {
+			return nil, err
+		}
+		hosts = append(hosts, h)
 		return hosts, nil
 	}
 
@@ -172,7 +176,12 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 	}
 
 	for _, ip := range ips {
-		hosts = append(hosts, &HostInfo{hostname: host, connectAddress: ip, port: port})
+		h, err := newHostInfo(ip, port)
+		if err != nil {
+			return nil, err
+		}
+
+		hosts = append(hosts, h)
 	}
 
 	return hosts, nil


### PR DESCRIPTION
Fix for the #1370

Panic from the `ConnectAddress()` was removed.
`HostInfo` struct creation was refactored to create via constructor to make sure the address is valid.
