### PR TITLE
CASSGO-47 Enable Session.ExecuteBatchCAS() to return underlying scan errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Retry policy now takes into account query idempotency (CASSGO-27)
 - Don't return error to caller with RetryType Ignore (CASSGO-28)
+- Enable Session.ExecuteBatchCAS() to return underlying scan errors (CASSGO-47)
 
 ## [1.7.0] - 2024-09-23
 

--- a/session.go
+++ b/session.go
@@ -769,7 +769,7 @@ func (s *Session) ExecuteBatch(batch *Batch) error {
 // ExecuteBatchCAS executes a batch operation and returns true if successful and
 // an iterator (to scan additional rows if more than one conditional statement)
 // was sent.
-// Further scans on the interator must also remember to include
+// Further scans on the iterator must also remember to include
 // the applied boolean as the first argument to *Iter.Scan
 func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bool, iter *Iter, err error) {
 	iter = s.executeBatch(batch)
@@ -785,7 +785,7 @@ func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bo
 		iter.Scan(&applied)
 	}
 
-	return applied, iter, nil
+	return applied, iter, iter.err
 }
 
 // MapExecuteBatchCAS executes a batch operation much like ExecuteBatchCAS,


### PR DESCRIPTION
The patch enables Session.ExecuteBatchCAS() to return an error that may happen during rows scanning.

Patch by Bohdan Siryk; reviewed by <> for CASSGO-47

Originally raised in #1746