### PR TITLE
CASSGO-48 Bump actions/upload-artifact and actions/cache versions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gomod-cache
         with:
           path: ~/go/pkg/mod
@@ -113,9 +113,9 @@ jobs:
           go test -v -tags "${{ matrix.tags }} gocql_debug" -timeout=5m -race ${{ env.args }}
       - name: 'Save ccm logs'
         if: 'failure()'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ccm-cluster
+          name: ccm-cluster-cassandra-${{ matrix.cassandra_version }}-go-${{ matrix.go }}-tag-${{ matrix.tags }}
           path: /home/runner/.ccm/test
           retention-days: 5
   integration-auth-cassandra:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove deprecated global logger (CASSGO-24)
 
+- Bumped actions/upload-artifact and actions/cache versions to v4 in CI workflow (CASSGO-48)
+
 ### Fixed
 
 - Retry policy now takes into account query idempotency (CASSGO-27)


### PR DESCRIPTION
Bumped due to cancelation of running CI workflows with the deprecated version of actions/upload-artifact@v3 and in order to prevent future interruptions with deprecation of actions/cache@v2.

Patch by Bohdan Siryk; Reviewed by João Reis, Stanislav Bychkov for CASSGO-48
