### PR TITLE
CASSGO-53 ObservedQuery.Consistency and ObservedBatch.Consistency fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ObservedQuery.Consistency` and `ObservedBatch.Consistency` fields (CASSGO-53)
+
 ### Changed
 
 - Don't restrict server authenticator unless PasswordAuthentictor.AllowedAuthenticators is provided (CASSGO-19)

--- a/session.go
+++ b/session.go
@@ -1130,16 +1130,17 @@ func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 
 	if q.observer != nil {
 		q.observer.ObserveQuery(q.Context(), ObservedQuery{
-			Keyspace:  keyspace,
-			Statement: q.stmt,
-			Values:    q.values,
-			Start:     start,
-			End:       end,
-			Rows:      iter.numRows,
-			Host:      host,
-			Metrics:   metricsForHost,
-			Err:       iter.err,
-			Attempt:   attempt,
+			Keyspace:    keyspace,
+			Statement:   q.stmt,
+			Values:      q.values,
+			Start:       start,
+			End:         end,
+			Rows:        iter.numRows,
+			Host:        host,
+			Metrics:     metricsForHost,
+			Err:         iter.err,
+			Attempt:     attempt,
+			Consistency: q.cons,
 		})
 	}
 }
@@ -1980,10 +1981,11 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		Start:      start,
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
-		Host:    host,
-		Metrics: metricsForHost,
-		Err:     iter.err,
-		Attempt: attempt,
+		Host:        host,
+		Metrics:     metricsForHost,
+		Err:         iter.err,
+		Attempt:     attempt,
+		Consistency: b.Cons,
 	})
 }
 
@@ -2218,6 +2220,9 @@ type ObservedQuery struct {
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
+
+	// Consistency is a consistency of the query which is being attempted.
+	Consistency Consistency
 }
 
 // QueryObserver is the interface implemented by query observers / stat collectors.
@@ -2255,6 +2260,9 @@ type ObservedBatch struct {
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
+
+	// Consistency is a consistency of the batch which is being attempted.
+	Consistency Consistency
 }
 
 // BatchObserver is the interface implemented by batch observers / stat collectors.


### PR DESCRIPTION
During retries, consistency of the query may be changed by retry policy implementations (e.g. DowngradingConsistencyRetryPolicy). To observe consistency changes new ObservedQuery.Consistency and ObservedBatch.Consistency fields were added.

Patch by Bohdan Siryk; Reviewed by <> for CASSGO-53

Closes #1798