### PR TITLE
CASSGO-59 CASSGO-56 Test fix for hostpool package and newHostInfo() expose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
-      - run: go vet
+      - run: go vet ./...
       - name: Run unit tests
-        run: go test -v -tags unit -race
+        run: go test -v -tags unit -race ./...
   integration-cassandra:
     timeout-minutes: 15
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - gocql.Compressor interface changes to follow append-like design. Bumped Go version to 1.19 (CASSGO-1)
 
+- Refactoring hostpool package test and Expose HostInfo creation (CASSGO-59)
+
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)
 

--- a/conn.go
+++ b/conn.go
@@ -1914,7 +1914,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 		}
 
 		for _, row := range rows {
-			h, err := newHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
+			h, err := NewHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
 			if err != nil {
 				goto cont
 			}

--- a/control.go
+++ b/control.go
@@ -146,7 +146,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 
 	// Check if host is a literal IP address
 	if ip := net.ParseIP(host); ip != nil {
-		h, err := newHostInfo(ip, port)
+		h, err := NewHostInfo(ip, port)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 	}
 
 	for _, ip := range ips {
-		h, err := newHostInfo(ip, port)
+		h, err := NewHostInfo(ip, port)
 		if err != nil {
 			return nil, err
 		}

--- a/host_source.go
+++ b/host_source.go
@@ -181,7 +181,9 @@ type HostInfo struct {
 	tokens           []string
 }
 
-func newHostInfo(addr net.IP, port int) (*HostInfo, error) {
+// NewHostInfo creates HostInfo with provided connectAddress and port.
+// It returns an error if addr is invalid.
+func NewHostInfo(addr net.IP, port int) (*HostInfo, error) {
 	if !validIpAddr(addr) {
 		return nil, errors.New("invalid host address")
 	}

--- a/hostpool/hostpool_test.go
+++ b/hostpool/hostpool_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package hostpool
 
 import (
@@ -17,12 +20,18 @@ func TestHostPolicy_HostPool(t *testing.T) {
 	//	{hostId: "0", connectAddress: net.IPv4(10, 0, 0, 0)},
 	//	{hostId: "1", connectAddress: net.IPv4(10, 0, 0, 1)},
 	//}
-	firstHost := &gocql.HostInfo{}
+
+	firstHost, err := gocql.NewHostInfo(net.IPv4(10, 0, 0, 0), 9042)
+	if err != nil {
+		t.Errorf("Error creating first host: %v", err)
+	}
 	firstHost.SetHostID("0")
-	firstHost.SetConnectAddress(net.IPv4(10, 0, 0, 0))
-	secHost := &gocql.HostInfo{}
+
+	secHost, err := gocql.NewHostInfo(net.IPv4(10, 0, 0, 1), 9042)
+	if err != nil {
+		t.Errorf("Error creating second host: %v", err)
+	}
 	secHost.SetHostID("1")
-	secHost.SetConnectAddress(net.IPv4(10, 0, 0, 1))
 	hosts := []*gocql.HostInfo{firstHost, secHost}
 	// Using set host to control the ordering of the hosts as calling "AddHost" iterates the map
 	// which will result in an unpredictable ordering

--- a/internal/lru/lru_test.go
+++ b/internal/lru/lru_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 /*
 Copyright 2015 To gocql authors
 Copyright 2013 Google Inc.

--- a/internal/murmur/murmur_test.go
+++ b/internal/murmur/murmur_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/lz4/lz4_test.go
+++ b/lz4/lz4_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
hostpool package test was using recently removed `SetConnectAddress()` 
The test was refactored to create hostInfo by constructor func, and the `newHostInfo` constructor was exposed. 
Also fix for the CASSGO-56