### PR TITLE
CASSGO-57 Deprecate Session.ExecuteBatch() and move "execute batch" methods to Batch type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactoring hostpool package test and Expose HostInfo creation (CASSGO-59)
 
+- Move "execute batch" methods to Batch type (CASSGO-57)
+
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)
 

--- a/doc.go
+++ b/doc.go
@@ -311,7 +311,7 @@
 //
 // The CQL protocol supports sending batches of DML statements (INSERT/UPDATE/DELETE) and so does gocql.
 // Use Session.Batch to create a new batch and then fill-in details of individual queries.
-// Then execute the batch with Session.ExecuteBatch.
+// Then execute the batch with Batch.Exec.
 //
 // Logged batches ensure atomicity, either all or none of the operations in the batch will succeed, but they have
 // overhead to ensure this property.
@@ -329,8 +329,8 @@
 // It is also possible to pass entire BEGIN BATCH .. APPLY BATCH statement to Query.Exec.
 // There are differences how those are executed.
 // BEGIN BATCH statement passed to Query.Exec is prepared as a whole in a single statement.
-// Session.ExecuteBatch prepares individual statements in the batch.
-// If you have variable-length batches using the same statement, using Session.ExecuteBatch is more efficient.
+// Batch.Exec prepares individual statements in the batch.
+// If you have variable-length batches using the same statement, using Batch.Exec is more efficient.
 //
 // See Example_batch for an example.
 //
@@ -340,9 +340,9 @@
 // INSERT/UPDATE .. IF statement) and reading its result. See example for Query.MapScanCAS.
 //
 // Multiple-statement lightweight transactions can be executed as a logged batch that contains at least one conditional
-// statement. All the conditions must return true for the batch to be applied. You can use Session.ExecuteBatchCAS and
-// Session.MapExecuteBatchCAS when executing the batch to learn about the result of the LWT. See example for
-// Session.MapExecuteBatchCAS.
+// statement. All the conditions must return true for the batch to be applied. You can use Batch.ExecCAS and
+// Batch.MapExecCAS when executing the batch to learn about the result of the LWT. See example for
+// Batch.MapExecCAS.
 //
 // # Retries and speculative execution
 //

--- a/example_batch_test.go
+++ b/example_batch_test.go
@@ -61,7 +61,7 @@ func Example_batch() {
 		Idempotent: true,
 	})
 
-	err = session.ExecuteBatch(b)
+	err = b.Exec()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -72,7 +72,7 @@ func ExampleSession_MapExecuteBatchCAS() {
 			Args: []interface{}{"B", "pk1", "ck2", ck2Version},
 		})
 		m := make(map[string]interface{})
-		applied, iter, err := session.MapExecuteBatchCAS(b.WithContext(ctx), m)
+		applied, iter, err := b.WithContext(ctx).MapExecCAS(m)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -221,7 +221,7 @@ func TestCustomPayloadMessages(t *testing.T) {
 	b := session.Batch(LoggedBatch)
 	b.CustomPayload = customPayload
 	b.Query("INSERT INTO testCustomPayloadMessages(id,value) VALUES(1, 1)")
-	if err := session.ExecuteBatch(b); err != nil {
+	if err := b.Exec(); err != nil {
 		t.Fatalf("query failed. %v", err)
 	}
 }

--- a/session.go
+++ b/session.go
@@ -775,6 +775,7 @@ func (s *Session) executeBatch(batch *Batch) *Iter {
 	return iter
 }
 
+// Deprecated: use Batch.Exec instead.
 // ExecuteBatch executes a batch operation and returns nil if successful
 // otherwise an error is returned describing the failure.
 func (s *Session) ExecuteBatch(batch *Batch) error {
@@ -782,13 +783,23 @@ func (s *Session) ExecuteBatch(batch *Batch) error {
 	return iter.Close()
 }
 
+// Deprecated: use Batch.ExecCAS instead
 // ExecuteBatchCAS executes a batch operation and returns true if successful and
 // an iterator (to scan additional rows if more than one conditional statement)
 // was sent.
 // Further scans on the interator must also remember to include
 // the applied boolean as the first argument to *Iter.Scan
 func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bool, iter *Iter, err error) {
-	iter = s.executeBatch(batch)
+	return batch.ExecCAS(dest...)
+}
+
+// ExecCAS executes a batch operation and returns true if successful and
+// an iterator (to scan additional rows if more than one conditional statement)
+// was sent.
+// Further scans on the interator must also remember to include
+// the applied boolean as the first argument to *Iter.Scan
+func (b *Batch) ExecCAS(dest ...interface{}) (applied bool, iter *Iter, err error) {
+	iter = b.session.executeBatch(b)
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
 		return false, nil, err
@@ -804,11 +815,19 @@ func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bo
 	return applied, iter, iter.err
 }
 
+// Deprecated: use Batch.MapExecCAS instead
 // MapExecuteBatchCAS executes a batch operation much like ExecuteBatchCAS,
 // however it accepts a map rather than a list of arguments for the initial
 // scan.
 func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) (applied bool, iter *Iter, err error) {
-	iter = s.executeBatch(batch)
+	return batch.MapExecCAS(dest)
+}
+
+// MapExecCAS executes a batch operation much like ExecuteBatchCAS,
+// however it accepts a map rather than a list of arguments for the initial
+// scan.
+func (b *Batch) MapExecCAS(dest map[string]interface{}) (applied bool, iter *Iter, err error) {
+	iter = b.session.executeBatch(b)
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
 		return false, nil, err
@@ -1828,9 +1847,8 @@ type Batch struct {
 	routingInfo *queryRoutingInfo
 }
 
+// Deprecated: use Session.Batch instead
 // NewBatch creates a new batch operation using defaults defined in the cluster
-//
-// Deprecated: use session.Batch instead
 func (s *Session) NewBatch(typ BatchType) *Batch {
 	return s.Batch(typ)
 }

--- a/session_test.go
+++ b/session_test.go
@@ -98,7 +98,7 @@ func TestSessionAPI(t *testing.T) {
 
 	testBatch := s.Batch(LoggedBatch)
 	testBatch.Query("test")
-	err := s.ExecuteBatch(testBatch)
+	err := testBatch.Exec()
 
 	if err != ErrNoConnections {
 		t.Fatalf("expected session.ExecuteBatch to return '%v', got '%v'", ErrNoConnections, err)
@@ -111,7 +111,7 @@ func TestSessionAPI(t *testing.T) {
 	//Should just return cleanly
 	s.Close()
 
-	err = s.ExecuteBatch(testBatch)
+	err = testBatch.Exec()
 	if err != ErrSessionClosed {
 		t.Fatalf("expected session.ExecuteBatch to return '%v', got '%v'", ErrSessionClosed, err)
 	}


### PR DESCRIPTION
This PR deprecates `Session.ExecuteBatch()` and others similar methods(`MapExecuteBatchCAS`,`ExecuteBatchCAS`)