### PR TITLE
CASSGO-62 Check the at least one host passed on initial host lookup 

### DIFF
--- a/session.go
+++ b/session.go
@@ -250,6 +250,9 @@ func (s *Session) init() error {
 					filteredHosts = append(filteredHosts, host)
 				}
 			}
+			if len(filteredHosts) < 1 {
+				return errors.New("expected at least one host will pass the filter")
+			}
 
 			hosts = filteredHosts
 		}


### PR DESCRIPTION
This PR provides a check to ensure that at least one host passes filter during the initial host lookup.
Resolves: #738 