### PR TITLE
CASSGO-22 CASSGO-73 Changes to Query and Batch to make them safely reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Native Protocol 5. Following protocol changes exposed new API
   Query.SetKeyspace(), Query.WithNowInSeconds(), Batch.SetKeyspace(), Batch.WithNowInSeconds() (CASSGO-1)
 - Externally-defined type registration (CASSGO-43)
+- Add Query and Batch to ObservedQuery and ObservedBatch (CASSGO-73)
 
 ### Changed
 
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - inet columns default to net.IP when using MapScan or SliceMap (CASSGO-43)
 - NativeType removed (CASSGO-43)
 - `New` and `NewWithError` removed and replaced with `Zero` (CASSGO-43)
+- Changes to Query and Batch to make them safely reusable (CASSGO-22)
 
 ### Fixed
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -28,9 +28,10 @@
 package gocql
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBatch_Errors(t *testing.T) {

--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -77,7 +77,7 @@ func TestShouldPrepareFunction(t *testing.T) {
 	}
 
 	for _, test := range shouldPrepareTests {
-		q := &Query{stmt: test.Stmt, routingInfo: &queryRoutingInfo{}}
+		q := &Query{stmt: test.Stmt}
 		if got := q.shouldPrepare(); got != test.Result {
 			t.Fatalf("%q: got %v, expected %v\n", test.Stmt, got, test.Result)
 		}

--- a/conn_test.go
+++ b/conn_test.go
@@ -392,12 +392,14 @@ func TestQueryRetry(t *testing.T) {
 	rt := &SimpleRetryPolicy{NumRetries: 1}
 
 	qry := db.Query("kill").RetryPolicy(rt)
-	if err := qry.Exec(); err == nil {
+	iter := qry.Iter()
+	err = iter.Close()
+	if err == nil {
 		t.Fatalf("expected error")
 	}
 
 	requests := atomic.LoadInt64(&srv.nKillReq)
-	attempts := qry.Attempts()
+	attempts := iter.Attempts()
 	if requests != int64(attempts) {
 		t.Fatalf("expected requests %v to match query attempts %v", requests, attempts)
 	}
@@ -439,13 +441,15 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 	rt := &SimpleRetryPolicy{NumRetries: 3}
 	observer := &testQueryObserver{metrics: make(map[string]*hostMetrics), verbose: false, logger: log}
 	qry := db.Query("kill").RetryPolicy(rt).Observer(observer).Idempotent(true)
-	if err := qry.Exec(); err == nil {
+	iter := qry.Iter()
+	err = iter.Close()
+	if err == nil {
 		t.Fatalf("expected error")
 	}
 
 	for i, ip := range addresses {
 		host := &HostInfo{connectAddress: net.ParseIP(ip)}
-		queryMetric := qry.metrics.hostMetrics(host)
+		queryMetric := iter.metrics.hostMetrics(host)
 		observedMetrics := observer.GetMetrics(host)
 
 		requests := int(atomic.LoadInt64(&nodes[i].nKillReq))
@@ -465,7 +469,7 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 		}
 	}
 	// the query will only be attempted once, but is being retried
-	attempts := qry.Attempts()
+	attempts := iter.Attempts()
 	if attempts != rt.NumRetries {
 		t.Fatalf("failed to retry the query %v time(s). Query executed %v times", rt.NumRetries, attempts)
 	}

--- a/hostpool/hostpool.go
+++ b/hostpool/hostpool.go
@@ -100,7 +100,7 @@ func (r *hostPoolHostPolicy) HostDown(host *gocql.HostInfo) {
 	r.RemoveHost(host)
 }
 
-func (r *hostPoolHostPolicy) Pick(qry gocql.ExecutableQuery) gocql.NextHost {
+func (r *hostPoolHostPolicy) Pick(qry gocql.ExecutableStatement) gocql.NextHost {
 	return func() gocql.SelectedHost {
 		r.mu.RLock()
 		defer r.mu.RUnlock()

--- a/lz4/lz4_test.go
+++ b/lz4/lz4_test.go
@@ -28,8 +28,9 @@
 package lz4
 
 import (
-	"github.com/pierrec/lz4/v4"
 	"testing"
+
+	"github.com/pierrec/lz4/v4"
 
 	"github.com/stretchr/testify/require"
 )

--- a/stress_test.go
+++ b/stress_test.go
@@ -29,7 +29,6 @@ package gocql
 
 import (
 	"sync/atomic"
-
 	"testing"
 )
 
@@ -82,7 +81,7 @@ func BenchmarkConnRoutingKey(b *testing.B) {
 		query := session.Query("insert into routing_key_stress (id) values (?)")
 
 		for pb.Next() {
-			if _, err := query.Bind(i * seed).GetRoutingKey(); err != nil {
+			if _, err := newInternalQuery(query.Bind(i*seed), nil).GetRoutingKey(); err != nil {
 				b.Error(err)
 				return
 			}


### PR DESCRIPTION
# API Changes

### `ExecutableQuery`

`ExecutableQuery` is currently an interface that `Query` and `Batch` implements (and is referenced by `HostSelectionPolicy`). However, it is also used in driver internals so the interface contains private methods which makes it impossible for users to "mock" the interface for testing purposes.

In this PR, `ExecutableQuery` is changed so it contains only public methods and is no longer implemented by `Query` and `Batch`. Now, `ExecutableQuery` is used exclusively as a "hook" in `HostSelectionPolicy`. This does mean that users can no longer attempt to cast an `ExecutableQuery` to `Query` or `Batch` but I've added a new method that provides this functionality (`Statement`).

```
type ExecutableQuery interface {
	GetRoutingKey() ([]byte, error)
	Keyspace() string
	Table() string
	IsIdempotent() bool
	Statement() Statement
}
```

### `Statement` 

This is the new interface that represents (and is implemented by) `Query` and `Batch`. In this PR it's only referenced by `ExecutableQuery`.

```
type Statement interface {
	Iter() *Iter
	Exec() error
}
```

### `internalRequest`

New interface that is used by driver internals to decouple the public API of Query/Batch from the internal API.
When creating an internal request object the driver now copies most if not all of the query/batch properties so that users can submit a Query/Batch for execution and then re-use immediately without having to be concerned about the object being modified by the driver execution. It also makes it less error prone because the driver is free to modify these properties (e.g. page state, consistency, query metrics) without causing a change on the objects that the users are using.

```
type internalRequest interface {
	execute(ctx context.Context, conn *Conn) *Iter
	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
	retryPolicy() RetryPolicy
	speculativeExecutionPolicy() SpeculativeExecutionPolicy
	getQueryMetrics() *queryMetrics
	RetryableQuery
	ExecutableQuery
}
```

### Query Metrics (i.e. `Query/Batch.Attempts()`, `Query/Batch.Latency()`)

This functionality makes the API a bit awkward because the user submits a query for execution and then inspects the query object to retrieve the side effects of that execution after it's done. It's a better design (imo) to have this kind of data available in the `Iter` object since this is the type that represents the return value of a query/batch.

Due to this, `AddAttempts()`, `Attempts()`, `Latency()` and `AddLatency()` have been removed from `Query` and `Batch`. `Latency()` and `Attempts()` have been added to `Iter` and a new `Batch.Iter()` method has been added so that users can obtain the `Iter` object when executing a batch (even though it doesn't make a lot of sense conceptually due to the name but `Iter` is what the driver uses to return data about a request so it's not just about "iterating").

### ```queryPool```

`Query` objects were allocated from a `sync.Pool` but I don't see the gain of keeping it especially now that `queryMetrics` have been moved to `Iter`. Also users can create these query objects once and store them if they are worried about memory/GC.

### ``` Query/Batch.GetRoutingKey() ```

Having this method as part of the public API of `Query` and `Batch` makes it difficult to manage from the driver maintainer POV, it's supposed to be an internal method that can be called by implementations of `HostSelectionPolicy` but since `ExecutableQuery` was implemented by `Query` and `Batch` this meant that these two types had to have this method on their public API as well.

With this PR, this method is deprecated on `Query` and `Batch` since these two types no longer implement `ExecutableQuery` so we can keep the `Query`/`Batch` API much simpler.