### PR TITLE
CASSGO-50 Endless query execution fix proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't panic in MapExecuteBatchCAS if no `[applied]` column is returned (CASSGO-42)
 
+- Endless query execution fix (CASSGO-50)
+
 ## [1.7.0] - 2024-09-23
 
 This release is the first after the donation of gocql to the Apache Software Foundation (ASF)

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -104,7 +104,7 @@ func TestEventNodeDownControl(t *testing.T) {
 	}
 	session.pool.mu.RUnlock()
 
-	host := session.ring.getHost(node.Addr)
+	host, _ := session.ring.getHost(node.Addr)
 	if host == nil {
 		t.Fatal("node not in metadata ring")
 	} else if host.IsUp() {
@@ -146,7 +146,7 @@ func TestEventNodeDown(t *testing.T) {
 		t.Fatal("node not removed after remove event")
 	}
 
-	host := session.ring.getHost(node.Addr)
+	host, _ := session.ring.getHost(node.Addr)
 	if host == nil {
 		t.Fatal("node not in metadata ring")
 	} else if host.IsUp() {
@@ -203,7 +203,7 @@ func TestEventNodeUp(t *testing.T) {
 		t.Fatal("node not added after node added event")
 	}
 
-	host := session.ring.getHost(node.Addr)
+	host, _ := session.ring.getHost(node.Addr)
 	if host == nil {
 		t.Fatal("node not in metadata ring")
 	} else if !host.IsUp() {

--- a/policies.go
+++ b/policies.go
@@ -323,6 +323,7 @@ func (host *selectedHost) Info() *HostInfo {
 func (host *selectedHost) Mark(err error) {}
 
 // NextHost is an iteration function over picked hosts
+// Should return nil eventually to prevent endless query execution.
 type NextHost func() SelectedHost
 
 // RoundRobinHostPolicy is a round-robin load balancing policy, where each host

--- a/ring.go
+++ b/ring.go
@@ -67,11 +67,11 @@ func (r *ring) getHostByIP(ip string) (*HostInfo, bool) {
 	return r.hosts[hi], ok
 }
 
-func (r *ring) getHost(hostID string) *HostInfo {
+func (r *ring) getHost(hostID string) (host *HostInfo, ok bool) {
 	r.mu.RLock()
-	host := r.hosts[hostID]
+	host, ok = r.hosts[hostID]
 	r.mu.RUnlock()
-	return host
+	return
 }
 
 func (r *ring) allHosts() []*HostInfo {


### PR DESCRIPTION
I've researched possible endless query execution when `HostSelectionPolicy` returns the same downed host ([CASSGO-50](https://issues.apache.org/jira/browse/CASSGO-50)) and propose three approaches to prevent it.

- Wrap `hostIter` to prevent it from returning downed host before executing the query. 
 e.g.
```
  hostIter = func() SelectedHost {
    checkIter := hostIter()
    if !checkIter.Info().IsUp() {
      return nil
    }
    return checkIter
  }
```
But that approach can cause breaking changes for applications which already relies on user-defined policies that can return downed hosts.

- Properly documented `type NextHost func()`:
Add a comment for `NextHost` type describing that `NextHost` should return not downedhost or return nil

- Add the threshold limit based on the number of hosts inside `(q *queryExecutor) do` which will prevent the endless execution without the breaking changes

Implementations of the threshold and documentation are presented in this PR.

