### PR TITLE
<framer> optimization `setLength()` method

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -727,9 +727,9 @@ func (f *framer) writeHeader(flags byte, op frameOp, stream int) {
 }
 
 func (f *framer) setLength(length int) {
-	p := 4
-	if f.proto > protoVersion2 {
-		p = 5
+	p := 5
+	if f.proto <= protoVersion2 {
+		p = 4
 	}
 
 	f.buf[p+0] = byte(length >> 24)


### PR DESCRIPTION
Optimizes `setLength()` method of the `framer`

Usually used version more than 2, so it's better to change the code so that it handles this particular case first.
