### PR TITLE
CASSGO-23 Make Session immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move "execute batch" methods to Batch type (CASSGO-57)
 
+- Make `Session` immutable by removing setters and associated mutex (CASSGO-23)
+
 ### Fixed
 - Cassandra version unmarshal fix (CASSGO-49)
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -152,11 +152,10 @@ func TestTracing(t *testing.T) {
 	}
 
 	// also works from session tracer
-	session.SetTrace(trace)
 	trace.mu.Lock()
 	buf.Reset()
 	trace.mu.Unlock()
-	if err := session.Query(`SELECT id FROM trace WHERE id = ?`, 42).Scan(&value); err != nil {
+	if err := session.Query(`SELECT id FROM trace WHERE id = ?`, 42).Trace(trace).Scan(&value); err != nil {
 		t.Fatal("select:", err)
 	}
 	if buf.Len() == 0 {

--- a/cluster.go
+++ b/cluster.go
@@ -263,6 +263,17 @@ type ClusterConfig struct {
 	// If not specified, defaults to the gocql.defaultLogger.
 	Logger StdLogger
 
+	// Tracer will be used for all queries. Alternatively it can be set of on a
+	// per query basis.
+	// default: nil
+	Tracer Tracer
+
+	// NextPagePrefetch sets the default threshold for pre-fetching new pages. If
+	// there are only p*pageSize rows remaining, the next page will be requested
+	// automatically. This value can also be changed on a per-query basis.
+	// default: 0.25.
+	NextPagePrefetch float64
+
 	// internal config for testing
 	disableControlConn bool
 }
@@ -298,6 +309,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
+		NextPagePrefetch:       0.25,
 	}
 	return cfg
 }

--- a/doc.go
+++ b/doc.go
@@ -271,7 +271,7 @@
 //
 // # Paging
 //
-// The driver supports paging of results with automatic prefetch, see ClusterConfig.PageSize, Session.SetPrefetch,
+// The driver supports paging of results with automatic prefetch, see ClusterConfig.PageSize,
 // Query.PageSize, and Query.Prefetch.
 //
 // It is also possible to control the paging manually with Query.PageState (this disables automatic prefetch).

--- a/session_test.go
+++ b/session_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestSessionAPI(t *testing.T) {
-	cfg := &ClusterConfig{}
+	cfg := NewCluster()
 
 	s := &Session{
 		cfg:    *cfg,
@@ -43,34 +43,12 @@ func TestSessionAPI(t *testing.T) {
 		policy: RoundRobinHostPolicy(),
 		logger: cfg.logger(),
 	}
+	defer s.Close()
 
 	s.pool = cfg.PoolConfig.buildPool(s)
 	s.executor = &queryExecutor{
 		pool:   s.pool,
 		policy: s.policy,
-	}
-	defer s.Close()
-
-	s.SetConsistency(All)
-	if s.cons != All {
-		t.Fatalf("expected consistency 'All', got '%v'", s.cons)
-	}
-
-	s.SetPageSize(100)
-	if s.pageSize != 100 {
-		t.Fatalf("expected pageSize 100, got %v", s.pageSize)
-	}
-
-	s.SetPrefetch(0.75)
-	if s.prefetch != 0.75 {
-		t.Fatalf("expceted prefetch 0.75, got %v", s.prefetch)
-	}
-
-	trace := &traceWriter{}
-
-	s.SetTrace(trace)
-	if s.trace != trace {
-		t.Fatalf("expected traceWriter '%v',got '%v'", trace, s.trace)
 	}
 
 	qry := s.Query("test", 1)


### PR DESCRIPTION
Closes https://github.com/apache/cassandra-gocql-driver/issues/357

The previous design allowed modifying Session properties through setters. This added unnecessary overhead, as a mutex had to be acquired for every query execution. Additionally, as demonstrated in [#1473](https://github.com/apache/cassandra-gocql-driver/issues/1473) this mutability could lead to race conditions. By making Session immutable, we:  
1. Eliminate race condition.  
1. Eliminate the performance overhead of mutex acquisition  
2. Simplify the concurrency model  
3. Making cleaner configuration

This PR removing those setters and eliminating the need for the mutex. Configuration of refactored properties (i.e. consistency, trace etc.) is now handled at session creation through `ClusterConfig` and/or at execution time through **per-query** methods.