### PR TITLE
CASSGO-72 Fix connection issue in Amazon Keyspaces

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -722,7 +722,21 @@ func (r *ringDescriber) GetHosts() ([]*HostInfo, string, error) {
 		return r.prevHosts, r.prevPartitioner, err
 	}
 
-	hosts := append([]*HostInfo{localHost}, peerHosts...)
+	// if the same HostID exists in peerHosts, localHost needs to be excluded to work properly with Amazon Keyspaces (CASSGO-72, #1873)
+	var hasSameHostID bool
+	for _, h := range peerHosts {
+		if h.HostID() == localHost.HostID() {
+			hasSameHostID = true
+		}
+	}
+
+	var hosts []*HostInfo
+	if hasSameHostID {
+		hosts = peerHosts
+	} else {
+		hosts = append([]*HostInfo{localHost}, peerHosts...)
+	}
+
 	var partitioner string
 	if len(hosts) > 0 {
 		partitioner = hosts[0].Partitioner()


### PR DESCRIPTION
This PR fixes #1873 

In Amazon Keyspaces, system.local returns the localhost address and system.peers returns a host that contains the same hostID as localhost. This causes the connection issue in refreshRing(), where host address is overwritten with the localhost address and a host with the same hostID results in the "cannot find host" error.

This commit fixes the issue by making map from a slice of hosts. This approach is also used in `func (s *Session) init()` https://github.com/apache/cassandra-gocql-driver/blob/trunk/session.go#L272-L275