### PR TITLE
CASSGO-74: Closing a nil Session should not panic

### DIFF
--- a/session.go
+++ b/session.go
@@ -454,6 +454,10 @@ func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]interface{}, error))
 // Close closes all connections. The session is unusable after this
 // operation.
 func (s *Session) Close() {
+	// Closing a nil session is a non-event, return.
+	if s == nil {
+		return
+	}
 
 	s.sessionStateMu.Lock()
 	if s.isClosing {


### PR DESCRIPTION
Encountered this while using the library this week and iterating through some unit test cases. 

The `Session` type methods are not nil-guarded, and will panic in a number of situations including nil-pointer dereferences. As a matter of practice, Go libraries customarily try to save panicking for errors where the calling program absolutely cannot continue normally. While some operations on the `Session` do deserve a panic (or ideally, an error), closing a nil Session is non-destructive to the state of the program and does not prevent normal operations for the user of the library. 
