### PR TITLE
CASSGO-77: Add golangci-lint integration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+version: "2"
+
+issues:
+  max-same-issues: 50
+
+formatters:
+  enable:
+    - goimports
+
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/gocql/gocql
+        - github.com/apache/cassandra-gocql-driver
+    golines:
+      max-len: 120
+
+linters:
+  default: none
+  enable:
+    - nolintlint
+    - govet
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - shadow
+        - fieldalignment
+
+    nolintlint:
+      allow-no-explanation: [ golines ]
+      require-explanation: true
+      require-specific: true

--- a/conn.go
+++ b/conn.go
@@ -1900,6 +1900,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 
 	var versions map[string]struct{}
 	var schemaVersion string
+	var rows []map[string]interface{}
 
 	endDeadline := time.Now().Add(c.session.cfg.MaxWaitSchemaAgreement)
 
@@ -1908,17 +1909,18 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 
 		versions = make(map[string]struct{})
 
-		rows, err := iter.SliceMap()
+		rows, err = iter.SliceMap()
 		if err != nil {
 			goto cont
 		}
 
 		for _, row := range rows {
-			h, err := NewHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
+			var host *HostInfo
+			host, err = NewHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
 			if err != nil {
 				goto cont
 			}
-			host, err := c.session.hostInfoFromMap(row, h)
+			host, err = c.session.hostInfoFromMap(row, host)
 			if err != nil {
 				goto cont
 			}

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -27,6 +27,7 @@ package lz4
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/pierrec/lz4/v4"
 )
 

--- a/marshal.go
+++ b/marshal.go
@@ -2603,7 +2603,7 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 		f, ok := fields[e.Name]
 		if !ok {
 			f = k.FieldByName(e.Name)
-			if f == emptyValue {
+			if f == emptyValue { //nolint:govet // there is no other way to compare with empty value
 				// skip fields which exist in the UDT but not in
 				// the struct passed in
 				continue


### PR DESCRIPTION
`golangci-lint` is standard de facto in golang community.
Using will help with:

- Having code uniformity
- Enforcing certain linting rules
- Prevent bugs
- Prevent unused variables, increasing driver efficiency
- Easy and speedup reviewing proceccess by detecting problems early

 
`govet/fieldalignment` stands out from rest of the linters, it will help to define structures in a way that will make them occupy less memory and provide better productivty as result.
 