### PR TITLE
CASSGO-71 Add way to create HostInfo objects for testing purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleanup of deprecated elements (CASSGO-12)
 - Remove global NewBatch function (CASSGO-15)
 - Remove deprecated global logger (CASSGO-24)
+- HostInfo.SetHostID is no longer exported (CASSGO-71)
 
 ### Added
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Query.SetKeyspace(), Query.WithNowInSeconds(), Batch.SetKeyspace(), Batch.WithNowInSeconds() (CASSGO-1)
 - Externally-defined type registration (CASSGO-43)
 - Add Query and Batch to ObservedQuery and ObservedBatch (CASSGO-73)
+- Add way to create HostInfo objects for testing purposes (CASSGO-71)
 
 ### Changed
 

--- a/conn.go
+++ b/conn.go
@@ -1938,11 +1938,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 
 		for _, row := range rows {
 			var host *HostInfo
-			host, err = NewHostInfo(c.host.ConnectAddress(), c.session.cfg.Port)
-			if err != nil {
-				goto cont
-			}
-			host, err = c.session.hostInfoFromMap(row, host)
+			host, err = c.session.newHostInfoFromMap(c.host.ConnectAddress(), c.session.cfg.Port, row)
 			if err != nil {
 				goto cont
 			}

--- a/control.go
+++ b/control.go
@@ -148,7 +148,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 
 	// Check if host is a literal IP address
 	if ip := net.ParseIP(host); ip != nil {
-		h, err := NewHostInfo(ip, port)
+		h, err := NewHostInfoFromAddrPort(ip, port)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func hostInfo(addr string, defaultPort int) ([]*HostInfo, error) {
 	}
 
 	for _, ip := range ips {
-		h, err := NewHostInfo(ip, port)
+		h, err := NewHostInfoFromAddrPort(ip, port)
 		if err != nil {
 			return nil, err
 		}

--- a/session.go
+++ b/session.go
@@ -268,7 +268,7 @@ func (s *Session) init() error {
 		// by internal logic.
 		// Associate random UUIDs here with all hosts missing this information.
 		if len(host.HostID()) == 0 {
-			host.SetHostID(MustRandomUUID().String())
+			host.setHostID(MustRandomUUID().String())
 		}
 	}
 
@@ -2143,7 +2143,7 @@ type ObservedQuery struct {
 	// Rows is not used in batch queries and remains at the default value
 	Rows int
 
-	// Host is the informations about the host that performed the query
+	// Host is the information about the host that performed the query
 	Host *HostInfo
 
 	// The metrics per this host


### PR DESCRIPTION
Also renamed NewHostInfo to NewHostInfoFromContactPoint, this isn't a breaking change because this function was exported recently and no release has gone out since then.

What is a breaking change is making `host.SetHostID` private, I don't see why we would let users modify the host id