### PR TITLE
CASSGO-70 Change module name to github.com/apache/cassandra-gocql-driver/v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ formatters:
       local-prefixes:
         - github.com/gocql/gocql
         - github.com/apache/cassandra-gocql-driver
+        - github.com/apache/cassandra-gocql-driver/v2
     golines:
       max-len: 120
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved the Snappy compressor into its own separate package (CASSGO-33)
-
 - Move lz4 compressor to lz4 package within the gocql module (CASSGO-32)
 - Don't restrict server authenticator unless PasswordAuthentictor.AllowedAuthenticators is provided (CASSGO-19)
 - Detailed description for NumConns (CASSGO-3)
@@ -51,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes to Query and Batch to make them safely reusable (CASSGO-22)
 - Change logger interface so it supports structured logging and log levels (CASSGO-9)
 - Bump go version in go.mod to 1.19 (CASSGO-34)
+- Change module name to github.com/apache/cassandra-gocql-driver/v2 (CASSGO-70)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Apache Cassandra GoCQL Driver
 
 [!Join the chat at https://the-asf.slack.com/archives/C05LPRVNZV1](https://the-asf.slack.com/archives/C05LPRVNZV1)
 ![go build](https://github.com/apache/cassandra-gocql-driver/actions/workflows/main.yml/badge.svg)
-[![GoDoc](https://godoc.org/github.com/gocql/gocql?status.svg)](https://godoc.org/github.com/gocql/gocql)
+[![GoDoc](https://pkg.go.dev/github.com/apache/cassandra-gocql-driver/v2?status.svg)](https://pkg.go.dev/github.com/apache/cassandra-gocql-driver/v2)
 
 Package gocql implements a fast and robust Cassandra client for the
 Go programming language.
 
 Project Website: https://cassandra.apache.org<br>
-API documentation: https://godoc.org/github.com/gocql/gocql<br>
+API documentation: https://pkg.go.dev/github.com/apache/cassandra-gocql-driver/v2<br>
 Discussions: https://cassandra.apache.org/_/community.html#discussions
 
 Supported Versions
@@ -17,7 +17,7 @@ Supported Versions
 
 The following matrix shows the versions of Go and Cassandra that are tested with the integration test suite as part of the CI build:
 
-| Go/Cassandra | 4.0.x | 4.1.x | 
+| Go/Cassandra | 4.1.x | 5.0.x | 
 |--------------|-------|-------|
 | 1.22         | yes   | yes   |
 | 1.23         | yes   | yes   |
@@ -33,7 +33,7 @@ In general, the Cassandra community will focus on supporting the current and pre
 Installation
 ------------
 
-    go get github.com/gocql/gocql
+    go get github.com/apache/cassandra-gocql-driver/v2
 
 
 Features
@@ -115,7 +115,7 @@ statement.
 Example
 -------
 
-See [package documentation](https://pkg.go.dev/github.com/gocql/gocql#pkg-examples).
+See [package documentation](https://pkg.go.dev/github.com/apache/cassandra-gocql-driver/v2#pkg-examples).
 
 Data Binding
 ------------

--- a/common_test.go
+++ b/common_test.go
@@ -39,8 +39,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/lz4"
-	"github.com/gocql/gocql/snappy"
+	"github.com/apache/cassandra-gocql-driver/v2/lz4"
+	"github.com/apache/cassandra-gocql-driver/v2/snappy"
 )
 
 var (

--- a/conn.go
+++ b/conn.go
@@ -40,8 +40,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql/internal/lru"
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/lru"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/streams"
 )
 
 // approve the authenticator with the list of allowed authenticators. If the provided list is empty,

--- a/conn_test.go
+++ b/conn_test.go
@@ -50,7 +50,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/streams"
 )
 
 const (

--- a/control_ccm_test.go
+++ b/control_ccm_test.go
@@ -33,7 +33,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/ccm"
 )
 
 type TestHostFilter struct {

--- a/doc.go
+++ b/doc.go
@@ -387,4 +387,4 @@
 // system_traces.events tables. NewTraceWriter returns an implementation of Tracer that writes the events to a writer.
 // Gathering trace information might be essential for debugging and optimizing queries, but writing traces has overhead,
 // so this feature should not be used on production systems with very high load unless you know what you are doing.
-package gocql // import "github.com/gocql/gocql"
+package gocql // import "github.com/apache/cassandra-gocql-driver/v2"

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/ccm"
 )
 
 func TestEventDiscovery(t *testing.T) {

--- a/example_batch_test.go
+++ b/example_batch_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_batch demonstrates how to execute a batch of statements.

--- a/example_dynamic_columns_test.go
+++ b/example_dynamic_columns_test.go
@@ -32,7 +32,7 @@ import (
 	"reflect"
 	"text/tabwriter"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_dynamicColumns demonstrates how to handle dynamic column list.

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // ExampleSession_MapExecuteBatchCAS demonstrates how to execute a batch lightweight transaction.

--- a/example_lwt_test.go
+++ b/example_lwt_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.

--- a/example_marshaler_test.go
+++ b/example_marshaler_test.go
@@ -31,7 +31,7 @@ import (
 	"strconv"
 	"strings"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // MyMarshaler implements Marshaler and Unmarshaler.

--- a/example_nulls_test.go
+++ b/example_nulls_test.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_nulls demonstrates how to distinguish between null and zero value when needed.

--- a/example_paging_test.go
+++ b/example_paging_test.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_paging demonstrates how to manually fetch pages and use page state.

--- a/example_set_test.go
+++ b/example_set_test.go
@@ -29,7 +29,7 @@ import (
 	"log"
 	"sort"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_set demonstrates how to use sets.

--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 func Example() {

--- a/example_udt_map_test.go
+++ b/example_udt_map_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // Example_userDefinedTypesMap demonstrates how to work with user-defined types as maps.

--- a/example_udt_marshaler_test.go
+++ b/example_udt_marshaler_test.go
@@ -28,7 +28,7 @@ import (
 	"context"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // MyUDTMarshaler implements UDTMarshaler.

--- a/example_udt_struct_test.go
+++ b/example_udt_struct_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 type MyUDT struct {

--- a/example_udt_unmarshaler_test.go
+++ b/example_udt_unmarshaler_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // MyUDTUnmarshaler implements UDTUnmarshaler.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-module github.com/gocql/gocql
+module github.com/apache/cassandra-gocql-driver/v2
 
 require (
 	github.com/golang/snappy v0.0.3

--- a/gocqlzap/zap.go
+++ b/gocqlzap/zap.go
@@ -21,7 +21,7 @@ package gocqlzap
 import (
 	"go.uber.org/zap"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 const DefaultName = "gocql"

--- a/gocqlzap/zap_test.go
+++ b/gocqlzap/zap_test.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 const logLineEnding = "%%%\n%%%"

--- a/gocqlzerolog/zerolog.go
+++ b/gocqlzerolog/zerolog.go
@@ -21,7 +21,7 @@ package gocqlzerolog
 import (
 	"github.com/rs/zerolog"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 const DefaultName = "gocql"

--- a/gocqlzerolog/zerolog_test.go
+++ b/gocqlzerolog/zerolog_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 const logLineEnding = "%%%\n%%%"

--- a/host_source_gen.go
+++ b/host_source_gen.go
@@ -32,7 +32,7 @@ import (
 	"reflect"
 	"sync"
 
-	gocql "github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 func gen(clause, field string) {

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -453,7 +453,7 @@ func TestRefreshDebouncer_EventsAfterRefreshNow(t *testing.T) {
 	}
 }
 
-// https://github.com/gocql/gocql/issues/1752
+// https://github.com/apache/cassandra-gocql-driver/issues/1752
 func TestRefreshDebouncer_DeadlockOnStop(t *testing.T) {
 	// there's no way to guarantee this bug manifests because it depends on which `case` is picked from the `select`
 	// with 4 iterations of this test the deadlock would be hit pretty consistently

--- a/hostpool/hostpool.go
+++ b/hostpool/hostpool.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/hailocab/go-hostpool"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 // HostPoolHostPolicy is a host policy which uses the bitly/go-hostpool library

--- a/hostpool/hostpool_test.go
+++ b/hostpool/hostpool_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/hailocab/go-hostpool"
 
-	"github.com/gocql/gocql"
+	gocql "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 func TestHostPolicy_HostPool(t *testing.T) {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -28,7 +28,7 @@ import (
 	"bytes"
 	"sync"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/lru"
 )
 
 const defaultMaxPreparedStmts = 1000

--- a/session.go
+++ b/session.go
@@ -38,7 +38,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/lru"
 )
 
 // Session is the interface used by users to interact with the database.

--- a/snappy/compressor.go
+++ b/snappy/compressor.go
@@ -1,3 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2012, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
 package snappy
 
 import "github.com/golang/snappy"

--- a/token.go
+++ b/token.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gocql/gocql/internal/murmur"
+	"github.com/apache/cassandra-gocql-driver/v2/internal/murmur"
 )
 
 // a token partitioner

--- a/version.go
+++ b/version.go
@@ -33,7 +33,7 @@ const (
 	// current main package returned by runtime/debug below.  Also note the
 	// package name used here may change in a future (2.x) release; in that case
 	// this constant will be updated as well.
-	mainPackage = "github.com/gocql/gocql"
+	mainPackage = "github.com/apache/cassandra-gocql-driver/v2"
 )
 
 var driverName string


### PR DESCRIPTION
In preparation for the 2.0.0 release we need to change the module name to add the v2 suffix and we take this chance to update the module name according to the new repo location after the ASF donation.

Patch by João Reis; reviewed by TBD for CASSGO-70