### PR TITLE
CASSGO-81 Add missing Context variant methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Externally-defined type registration (CASSGO-43)
 - Add Query and Batch to ObservedQuery and ObservedBatch (CASSGO-73)
 - Add way to create HostInfo objects for testing purposes (CASSGO-71)
+- Add missing Context methods on Query and Batch (CASSGO-81)
 
 ### Changed
 


### PR DESCRIPTION
In #1868  we deprecated Query.WithContext and Batch.WithContext. We added ExecContext and IterContext as alternatives but we didn't add these alternatives for other ways to execute queries and batches like Query.Scan or Batch.ExecCAS.

We also didn't deprecate Query.Context() and we should have