### PR TITLE
CASSGO-85 Change master to trunk in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - trunk
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
The driver donation resulted in a change of the main branch name but this change wasn't made in the github workflow. This patch fixes that.
