### PR TITLE
CASSGO-95: Fix Iter.RowData Values to point to concrete types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent panic with queries during session init (CASSGO-92)
+- Return correct values from RowData (CASSGO-95)
 
 ## [2.0.0]
 

--- a/helpers.go
+++ b/helpers.go
@@ -60,15 +60,14 @@ func (iter *Iter) RowData() (RowData, error) {
 
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
-			val := c.Zero()
+			val := reflect.New(reflect.TypeOf(column.TypeInfo.Zero()))
 			columns = append(columns, column.Name)
-			values = append(values, &val)
+			values = append(values, val.Interface())
 		} else {
 			for i, elem := range c.Elems {
 				columns = append(columns, TupleColumnName(column.Name, i))
-				var val interface{}
-				val = elem.Zero()
-				values = append(values, &val)
+				val := reflect.New(reflect.TypeOf(elem.Zero()))
+				values = append(values, val.Interface())
 			}
 		}
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -259,3 +259,50 @@ func TestGetCassandraTypeInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestIter_RowData(t *testing.T) {
+	iter := &Iter{
+		meta: resultMetadata{
+			columns: []ColumnInfo{
+				{Name: "id", TypeInfo: intTypeInfo{}},
+				{Name: "name", TypeInfo: varcharLikeTypeInfo{typ: TypeText}},
+				{Name: "coords", TypeInfo: TupleTypeInfo{
+					Elems: []TypeInfo{
+						floatTypeInfo{},
+						floatTypeInfo{},
+					},
+				}},
+				{Name: "active", TypeInfo: booleanTypeInfo{}},
+			},
+		},
+	}
+
+	rowData, err := iter.RowData()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedColumns := []string{"id", "name", "coords[0]", "coords[1]", "active"}
+	if !reflect.DeepEqual(rowData.Columns, expectedColumns) {
+		t.Fatalf("expected columns %v got %v", expectedColumns, rowData.Columns)
+	}
+
+	if len(rowData.Values) != len(expectedColumns) {
+		t.Fatalf("expected %d values got %d", len(expectedColumns), len(rowData.Values))
+	}
+
+	expectedTypes := []reflect.Type{
+		reflect.TypeOf((*int)(nil)),
+		reflect.TypeOf((*string)(nil)),
+		reflect.TypeOf((*float32)(nil)),
+		reflect.TypeOf((*float32)(nil)),
+		reflect.TypeOf((*bool)(nil)),
+	}
+
+	for i, val := range rowData.Values {
+		gotType := reflect.TypeOf(val)
+		if gotType != expectedTypes[i] {
+			t.Fatalf("value[%d]: expected type %v got %v", i, expectedTypes[i], gotType)
+		}
+	}
+}


### PR DESCRIPTION
There were multiple issues with the previous RowData method. First, it was returning invalid values because it called c.Zero() instead of Zero on column. Second, it would've returned an interface to a pointer to an interface which is frustrating to work with.

Now it restores the previous v1 behavior and returns pointers to the underlying types wrapped in an interface.

Added tests to ensure the behavior is as expected.

Patch by James Hartig for CASSGO-95