### PR TITLE
CASSGO-108 fix framer dropped error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent setting a compression flag in a frame header when native proto v5 is being used (CASSGO-98)
 - Use protocol downgrading approach during protocol negotiation (CASSGO-97)
 - Prevent panic iin compileMetadata() when final func is not defined for an aggregate (CASSGO-105)
+- Framer drops error silently (CASSGO-108)
 
 ## [2.0.0]
 

--- a/frame.go
+++ b/frame.go
@@ -2229,6 +2229,9 @@ func (f *framer) readBytesMap() (map[string][]byte, error) {
 
 func (f *framer) readStringMultiMap() (map[string][]string, error) {
 	size, err := f.readShort()
+	if err != nil {
+		return nil, err
+	}
 	m := make(map[string][]string, size)
 	var k string
 	for i := 0; i < int(size); i++ {


### PR DESCRIPTION
This fixes a dropped `err` variable.