### PR TITLE
Add options to shuffle replicas for token-aware policy and log warning when default is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for session ready, host state, topology change and schema changes custom listeners (CASSGO-101)
 - Add Session.AllKeyspaceMetadata() (CASSGO-109)
 
+### Changed
+
+- Use protocol downgrading approach during protocol negotiation (CASSGO-97)
+- TokenAwareHostPolicy now populates replica maps for non-default keyspaces (CASSGO-104)
+- Add options to shuffle replicas for token-aware policy and log warning when the default behavior is used (CASSGO-106)
+
 ### Fixed
 
 - Prevent panic with queries during session init (CASSGO-92)
 - Return correct values from RowData (CASSGO-95)
 - Prevent setting a compression flag in a frame header when native proto v5 is being used (CASSGO-98)
-- Use protocol downgrading approach during protocol negotiation (CASSGO-97)
 - Prevent panic iin compileMetadata() when final func is not defined for an aggregate (CASSGO-105)
 - Framer drops error silently (CASSGO-108)
-- TokenAwareHostPolicy now populates replica maps for non-default keyspaces (CASSGO-104)
 
 ## [2.0.0]
 

--- a/doc.go
+++ b/doc.go
@@ -359,7 +359,7 @@
 //	cluster := gocql.NewCluster("192.168.1.1", "192.168.1.2", "192.168.1.3")
 //	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.DCAwareRoundRobinPolicy("dc1"))
 //
-// Note that [TokenAwareHostPolicy] can take options such as [ShuffleReplicas] and [NonLocalReplicasFallback].
+// Note that [TokenAwareHostPolicy] can take options such as [ShuffleReplicas], [DoNotShuffleReplicas] and [NonLocalReplicasFallback].
 //
 // We recommend running with a token aware host policy in production for maximum performance.
 //

--- a/policies.go
+++ b/policies.go
@@ -396,9 +396,21 @@ func (r *roundRobinHostPolicy) HostDown(host *HostInfo) {
 	r.RemoveHost(host)
 }
 
+// ShuffleReplicas returns an option function to enable shuffling of replicas in token-aware host selection.
+// When enabled, the set of replicas for a partition key will be traversed in randomized order.
 func ShuffleReplicas() func(*tokenAwareHostPolicy) {
 	return func(t *tokenAwareHostPolicy) {
 		t.shuffleReplicas = true
+		t.shuffleDecisionExplicit = true
+	}
+}
+
+// DoNotShuffleReplicas returns an option function to disable shuffling of replicas in token-aware host selection.
+// When disabled, replicas are traversed in their natural (token ring) order.
+func DoNotShuffleReplicas() func(*tokenAwareHostPolicy) {
+	return func(t *tokenAwareHostPolicy) {
+		t.shuffleReplicas = false
+		t.shuffleDecisionExplicit = true
 	}
 }
 
@@ -412,6 +424,19 @@ func NonLocalReplicasFallback() func(policy *tokenAwareHostPolicy) {
 	return func(t *tokenAwareHostPolicy) {
 		t.nonLocalReplicasFallback = true
 	}
+}
+
+// ShuffledTokenAwareHostPolicy is a token aware host selection policy that shuffles replicas.
+func ShuffledTokenAwareHostPolicy(fallback HostSelectionPolicy, opts ...func(*tokenAwareHostPolicy)) HostSelectionPolicy {
+	p := &tokenAwareHostPolicy{
+		fallback:                fallback,
+		shuffleReplicas:         true,
+		shuffleDecisionExplicit: true,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 // TokenAwareHostPolicy is a token aware host selection policy, where hosts are
@@ -443,6 +468,7 @@ type tokenAwareHostPolicy struct {
 
 	shuffleReplicas          bool
 	nonLocalReplicasFallback bool
+	shuffleDecisionExplicit  bool
 
 	// mu protects writes to hosts, partitioner, metadata.
 	// reads can be unlocked as long as they are not used for updating state later.
@@ -466,6 +492,9 @@ func (t *tokenAwareHostPolicy) Init(s *Session) {
 	t.getKeyspaceName = func() string { return s.cfg.Keyspace }
 	t.getSchemaMeta = s.schemaDescriber.getSchemaMetaForRead
 	t.logger = s.logger
+	if !t.shuffleDecisionExplicit {
+		t.logger.Warning("By default, token aware policy doesn't shuffle the replicas which isn't recommended. If this is intentional, use the DoNotShuffleReplicas option to make this warning go away (e.g. TokenAwareHostPolicy(fallbackpolicy, DoNotShuffleReplicas))")
+	}
 }
 
 func (t *tokenAwareHostPolicy) IsLocal(host *HostInfo) bool {

--- a/policies_test.go
+++ b/policies_test.go
@@ -70,7 +70,7 @@ func TestRoundRobbin(t *testing.T) {
 // round-robin host selection policy fallback.
 func TestHostPolicy_TokenAware_SimpleStrategy(t *testing.T) {
 	const keyspace = "myKeyspace"
-	policy := TokenAwareHostPolicy(RoundRobinHostPolicy())
+	policy := TokenAwareHostPolicy(RoundRobinHostPolicy(), DoNotShuffleReplicas())
 	policyInternal := policy.(*tokenAwareHostPolicy)
 	policyInternal.getKeyspaceName = func() string { return keyspace }
 	keyspaceMeta := &KeyspaceMetadata{


### PR DESCRIPTION
Shuffling replicas produces much better load distribution for token-aware host selection, while leaving the previous (non-shuffled) behavior available for workloads that need it
(notably LWTs, which are voided if replicas are shuffled).

Also logs a warning if the default behavior is used since the default (non shuffled) is not optimal for the majority of applications. If non shuffled is the intended behavior then explicitly setting it will disable the log message.

patch by tejaslodayadd; reviewed by worryg0d, joao-r-reis for CASSGO-106