### PR TITLE
CASSGO-111 Upgrade Github actions dependencies verisons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         go: [ '1.25', '1.26' ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: Run linting
@@ -43,26 +43,26 @@ jobs:
           - proto_version: "5"
             compressor: "snappy"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: Makefile
 
       - name: Set up cache for SDKMAN
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.sdkman
           key: ${{ runner.os }}-sdkman
 
       - name: Set up cache for CCM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.ccm/repository
           key: ${{ runner.os }}-ccm-${{ matrix.cassandra_version }}
@@ -108,25 +108,25 @@ jobs:
           - proto_version: "5"
             compressor: "snappy"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: Makefile
 
       - name: Set up cache for SDKMAN
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.sdkman
           key: ${{ runner.os }}-sdkman
 
       - name: Set up cache for CCM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.ccm/repository
           key: ${{ runner.os }}-ccm-${{ matrix.cassandra_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use protocol downgrading approach during protocol negotiation (CASSGO-97)
 - TokenAwareHostPolicy now populates replica maps for non-default keyspaces (CASSGO-104)
 - Add options to shuffle replicas for token-aware policy and log warning when the default behavior is used (CASSGO-106)
-
-### Changed
-
 - Bump Go version support from 1.22 and 1.23 to 1.25 and 1.26 (CASSGO-110)
+- Upgraded Github actions dependencies versions (CASSGO-111)
 
 ### Fixed
 


### PR DESCRIPTION
    Upgraded Github actions dependencies in ci workflow
    
    The patch upgrades a set of Github actions dependencies due to changes of
    the default Node.js - the next default one is 24.
    
    Dependencies that were upgraded:
    
    - actions/checkout to v6
    - actions/setup-go to v6
    - actions/setup-python to v6
    - actons/chache to v5
    
    Path by Bohdan Siryk; reviewed by <> for CASSGO-111