### PR TITLE
Separate init and runtime timeout budgets, add per-request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,51 @@ Some tips for getting more performance from the driver:
 * Reading data from the network to unmarshal will incur a large amount of allocations, this can adversely affect the garbage collector, tune `GOGC`
 * Close iterators after use to recycle byte buffers
 
+Connection Timeouts
+-------------------
+
+The driver exposes several independent timeouts. They live on different layers
+(per-request budget vs. socket-level deadline) and serve different purposes — set
+them together, not "the smallest wins":
+
+| Field | Default | Layer | Purpose |
+|---|---|---|---|
+| `ClusterConfig.ConnectTimeout` | `11s` | Per-request, **init only** | Covers the entire connection setup: TCP dial, `STARTUP`/`AUTH`/`OPTIONS` handshake, initial `system.local` read, `USE keyspace`. Independent of `Timeout` — a low user `Timeout` will not break session creation. |
+| `ClusterConfig.Timeout` | `11s` | Per-request, **runtime** | Default client-side timeout for user `Query`/`Batch` (inherited at construction time, see below). Should be **greater** than server-side timeouts to avoid retry storms. |
+| `ClusterConfig.WriteTimeout` | `Timeout` | Socket write deadline | Operational write deadline after `finalizeConnection`. Defaults to `Timeout` if not set. Should be `<= Timeout`. |
+| `ClusterConfig.ReadTimeout` | `11s` | Socket read deadline | **Defensive net only** — fails the socket if the server stops sending bytes (TCP alive but silent). Renewed on every `Read()`. Does **not** cap a single request. Falls back to `ConnectTimeout` if unset. |
+| `ClusterConfig.Metadata.SystemRequestTimeout` | `60s` | Per-request, schema | Client-side timeout for schema/system queries (`system.local`, `system.peers[_v2]`, `system_schema.*`) and other internal control-conn frames. Independent of `Timeout` — schema reads on a large keyspace can legitimately outlive a regular user query. |
+| `Query.WithRequestTimeout(d)` / `SetRequestTimeout(d)` | `= Timeout` | Per-request override | Per-query override of `Timeout`. Inherited from `ClusterConfig.Timeout` on `Session.Query` / `Session.Bind`. `d == 0` disables the client-side timer (relies on `ctx` + `ReadTimeout`). |
+| `Batch.WithRequestTimeout(d)` / `SetRequestTimeout(d)` | `= Timeout` | Per-request override | Same, for a batch. Inherited from `ClusterConfig.Timeout` on `Session.Batch`. |
+
+**Connection lifecycle.**
+
+1. **Dial / init.** All read, write, and system-query budgets are pinned to
+   `ConnectTimeout`. `STARTUP`/`AUTH`/`OPTIONS`/`UseKeyspace` and the initial
+   `system.local` lookup all use `ConnectTimeout` as their per-request budget. A
+   low user `Timeout` (say, 100ms) will not prevent the session from coming up.
+2. **`finalizeConnection()`.** Called when the connection joins the pool or is
+   registered as the control connection. After this call:
+   - socket read deadline → `ReadTimeout`,
+   - socket write deadline → `WriteTimeout`,
+   - per-`Conn` `systemRequestTimeout` → `Metadata.SystemRequestTimeout`.
+3. **Runtime.** Per-request budgets (`Timeout`, `Metadata.SystemRequestTimeout`,
+   `Query.WithRequestTimeout`) fire through `callReq.timer` inside `Conn.exec` —
+   independently of the socket deadline. The socket `ReadTimeout` only fires
+   when the server is fully silent for the full window.
+
+**Picking values.**
+
+- Pick `ReadTimeout >= ConnectTimeout`. The init read deadline is `ConnectTimeout`;
+  a shorter `ReadTimeout` after finalize would tighten an already-validated
+  connection for no benefit and may misfire on idle waits.
+- Keep `Timeout > server-side timeout` (in `cassandra.yaml`, e.g. `read_request_timeout_in_ms`).
+- Use `Metadata.SystemRequestTimeout` (default `60s`) for schema discovery — it is
+  applied to control-conn writes and `system_schema.*` reads, and decoupled from
+  user query budget.
+- For occasional long queries, prefer `Query.WithRequestTimeout(d)` over raising
+  the global `Timeout`.
+
 Important Default Keyspace Changes
 ----------------------------------
 gocql no longer supports executing "use <keyspace>" statements to simplify the library. The user still has the

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1724,7 +1724,7 @@ func TestQueryInfo(t *testing.T) {
 	defer session.Close()
 
 	conn := getRandomConn(t, session)
-	info, err := conn.prepareStatement(context.Background(), "SELECT release_version, host_id FROM system.local WHERE key = ?", nil, conn.currentKeyspace)
+	info, err := conn.prepareStatement(context.Background(), "SELECT release_version, host_id FROM system.local WHERE key = ?", nil, conn.currentKeyspace, time.Second)
 
 	if err != nil {
 		t.Fatalf("Failed to execute query for preparing statement: %v", err)
@@ -3300,7 +3300,7 @@ func TestNegativeStream(t *testing.T) {
 		return f.finish()
 	})
 
-	frame, err := conn.exec(context.Background(), writer, nil)
+	frame, err := conn.exec(context.Background(), writer, nil, time.Second)
 	if err == nil {
 		t.Fatalf("expected to get an error on stream %d", stream)
 	} else if frame != nil {

--- a/cluster.go
+++ b/cluster.go
@@ -112,7 +112,11 @@ type ClusterConfig struct {
 	// Timeout limits the time spent on the client side while executing a query.
 	// Specifically, query or batch execution will return an error if the client does not receive a response
 	// from the server within the Timeout period.
-	// Timeout is also used to configure the read timeout on the underlying network connection.
+	// Timeout is the default per-request client-side budget for user Query/Batch
+	// (inherited at construction time by Query.requestTimeout / Batch.requestTimeout,
+	// overridable via WithRequestTimeout/SetRequestTimeout). It is enforced via the
+	// per-request callReq.timer inside Conn.exec, independently of the socket read
+	// deadline (which is configured via ReadTimeout, falling back to ConnectTimeout).
 	// Client Timeout should always be higher than the request timeouts configured on the server,
 	// so that retries don't overload the server.
 	// Timeout has a default value of 11 seconds, which is higher than default server timeout for most query types.
@@ -132,6 +136,22 @@ type ClusterConfig struct {
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
 	WriteTimeout time.Duration
+
+	// ReadTimeout — socket-level read deadline. Defensive net: if the server stops
+	// responding entirely (TCP alive but no data flowing), the socket must detect
+	// this and fail rather than blocking goroutines indefinitely. Does NOT cap a
+	// single request — that is the role of Timeout (default for user queries) and
+	// Metadata.SystemRequestTimeout (for system queries), enforced via the
+	// per-request callReq.timer.
+	//
+	// Only takes effect after finalizeConnection. During init the socket read
+	// deadline is pinned to ConnectTimeout, so a low ReadTimeout will not break
+	// connection establishment — but it will tighten an already-validated
+	// connection at runtime and may misfire on idle waits. Pick
+	// ReadTimeout >= ConnectTimeout. If unset (0), ConnectTimeout is used.
+	//
+	// Default: 11s.
+	ReadTimeout time.Duration
 
 	// Port used when dialing.
 	// Default: 9042
@@ -353,6 +373,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		CQLVersion:             "3.0.0",
 		Timeout:                11 * time.Second,
 		ConnectTimeout:         11 * time.Second,
+		ReadTimeout:            11 * time.Second,
 		Port:                   9042,
 		NumConns:               2,
 		Consistency:            Quorum,
@@ -367,7 +388,8 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
 		NextPagePrefetch:       0.25,
 		Metadata: MetadataConfig{
-			CacheMode: Full,
+			CacheMode:            Full,
+			SystemRequestTimeout: 60 * time.Second,
 		},
 	}
 	return cfg
@@ -439,6 +461,26 @@ type MetadataConfig struct {
 	//
 	// Consider using [SessionReadyListenersMux] if you need to register multiple listeners for the same session ready event.
 	SessionReadyListener SessionReadyListener
+
+	// SystemRequestTimeout — client-side per-request timeout for queries to
+	// system / system_schema tables (`system.local`, `system.peers[_v2]`,
+	// `system_schema.*`) and other internal control-conn frames at runtime.
+	// Independent of ClusterConfig.Timeout and ConnectTimeout: schema operations
+	// (e.g. reading metadata of a large keyspace) can legitimately take
+	// significantly longer than normal user queries, so they need a separate,
+	// typically longer, timeout.
+	//
+	// Applied as requestTimeout in Conn.exec for system queries (via
+	// controlConn.query / controlConn.writeFrame / Conn.querySystem). Only takes
+	// effect after finalizeConnection — during init these requests are bound to
+	// ConnectTimeout via Conn.systemRequestTimeout. STARTUP/AUTH/OPTIONS and
+	// USE keyspace are init-phase only and never use SystemRequestTimeout; they
+	// are always bound to ConnectTimeout.
+	//
+	// The defensive socket read deadline is configured via ClusterConfig.ReadTimeout.
+	//
+	// Default: 60s.
+	SystemRequestTimeout time.Duration
 }
 
 type HostListenersConfig struct {

--- a/conn.go
+++ b/conn.go
@@ -135,18 +135,20 @@ type SslOptions struct {
 
 // ConnConfig contains configuration options for establishing connections to Cassandra nodes.
 type ConnConfig struct {
-	ProtoVersion   int
-	CQLVersion     string
-	Timeout        time.Duration
-	WriteTimeout   time.Duration
-	ConnectTimeout time.Duration
-	Dialer         Dialer
-	HostDialer     HostDialer
-	Compressor     Compressor
-	Authenticator  Authenticator
-	AuthProvider   func(h *HostInfo) (Authenticator, error)
-	Keepalive      time.Duration
-	Logger         StructuredLogger
+	ProtoVersion         int
+	CQLVersion           string
+	Timeout              time.Duration
+	WriteTimeout         time.Duration
+	ConnectTimeout       time.Duration
+	ReadTimeout          time.Duration
+	SystemRequestTimeout time.Duration
+	Dialer               Dialer
+	HostDialer           HostDialer
+	Compressor           Compressor
+	Authenticator        Authenticator
+	AuthProvider         func(h *HostInfo) (Authenticator, error)
+	Keepalive            time.Duration
+	Logger               StructuredLogger
 
 	tlsConfig       *tls.Config
 	disableCoalesce bool
@@ -170,10 +172,18 @@ type Conn struct {
 	r ConnReader
 	w contextWriter
 
-	writeTimeout   time.Duration
-	cfg            *ConnConfig
-	frameObserver  FrameHeaderObserver
-	streamObserver StreamObserver
+	// systemRequestTimeout — snapshot of the client-side timeout for schema/system
+	// queries. During init it equals ConnectTimeout; after finalizeConnection it
+	// switches to Metadata.SystemRequestTimeout. Used as requestTimeout in
+	// Conn.querySystem and controlConn.query.
+	//
+	// The source of truth for read/write socket deadlines are the atomics inside
+	// connReader and deadlineContextWriter/writeCoalescer; they are updated via
+	// c.r.SetTimeout() and c.w.setWriteTimeout() in finalizeConnection.
+	systemRequestTimeout time.Duration
+	cfg                  *ConnConfig
+	frameObserver        FrameHeaderObserver
+	streamObserver       StreamObserver
 
 	headerBuf [frameHeadSize]byte
 
@@ -238,11 +248,6 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		return nil, err
 	}
 
-	writeTimeout := cfg.Timeout
-	if cfg.WriteTimeout > 0 {
-		writeTimeout = cfg.WriteTimeout
-	}
-
 	logger := cfg.Logger
 	if logger == nil {
 		logger = s.logger
@@ -252,33 +257,67 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
+
+	reader := &connReader{
+		conn: dialedHost.Conn,
+		r:    bufio.NewReader(dialedHost.Conn),
+	}
+
+	// During the init phase we pin the socket write deadline (and below in init()
+	// the read deadline and systemRequestTimeout) to ConnectTimeout, NOT to
+	// WriteTimeout/Timeout. The reason is not obvious from the docs, so in detail:
+	//
+	// The init phase (dial → STARTUP/AUTH/OPTIONS → system.local → USE keyspace)
+	// and runtime are different budgets by nature:
+	//   • Init happens once per connection and must succeed regardless of network
+	//     conditions. It is not a user request — it makes no sense to apply the
+	//     user's (often aggressive) Timeout/WriteTimeout to it.
+	//   • Runtime is user queries, where the user actually wants short timeouts
+	//     so they can retry quickly on other hosts.
+	//
+	// Before these budgets were conflated: the write deadline during
+	// init was WriteTimeout || Timeout. With a legitimate ClusterConfig.Timeout=100ms
+	// (user wants fast retries on user queries) STARTUP/AUTH could not be written
+	// within that 100ms — CreateSession() failed with
+	// "no connections were made when creating the session"
+	// (scylladb/gocql#532, fix — PR #531).
+	//
+	// After SCYLLA-2121 init is fully pinned to ConnectTimeout (a separate, usually
+	// generous handshake budget). Once the connection is fully ready, the caller
+	// (hostConnPool.connect / controlConn.connect / attemptReconnectToAnyOfHosts)
+	// calls conn.finalizeConnection() — there the writer and reader atomics switch
+	// to WriteTimeout and ReadTimeout, and systemRequestTimeout switches to
+	// Metadata.SystemRequestTimeout. From that point on the documented semantics
+	// "WriteTimeout limits the time the driver waits to write a request"
+	// work as expected.
+	//
+	// Regression test — TestNewConnectWithLowTimeout.
+	writer := &deadlineContextWriter{
+		w:         dialedHost.Conn,
+		semaphore: make(chan struct{}, 1),
+		quit:      make(chan struct{}),
+	}
+	writer.setWriteTimeout(cfg.ConnectTimeout)
+
 	c := &Conn{
-		r: &connReader{
-			conn: dialedHost.Conn,
-			r:    bufio.NewReader(dialedHost.Conn),
-		},
-		cfg:           cfg,
-		calls:         make(map[int]*callReq),
-		version:       uint8(cfg.ProtoVersion),
-		addr:          dialedHost.Conn.RemoteAddr().String(),
-		errorHandler:  errorHandler,
-		compressor:    cfg.Compressor,
-		session:       s,
-		streams:       streams.New(cfg.ProtoVersion),
-		host:          host,
-		isSchemaV2:    true, // Try using "system.peers_v2" until proven otherwise
-		frameObserver: s.frameObserver,
-		w: &deadlineContextWriter{
-			w:         dialedHost.Conn,
-			timeout:   writeTimeout,
-			semaphore: make(chan struct{}, 1),
-			quit:      make(chan struct{}),
-		},
-		ctx:            ctx,
-		cancel:         cancel,
-		logger:         logger,
-		streamObserver: s.streamObserver,
-		writeTimeout:   writeTimeout,
+		r:                    reader,
+		cfg:                  cfg,
+		calls:                make(map[int]*callReq),
+		version:              uint8(cfg.ProtoVersion),
+		addr:                 dialedHost.Conn.RemoteAddr().String(),
+		errorHandler:         errorHandler,
+		compressor:           cfg.Compressor,
+		session:              s,
+		streams:              streams.New(cfg.ProtoVersion),
+		host:                 host,
+		isSchemaV2:           true, // Try using "system.peers_v2" until proven otherwise
+		frameObserver:        s.frameObserver,
+		w:                    writer,
+		ctx:                  ctx,
+		cancel:               cancel,
+		logger:               logger,
+		streamObserver:       s.streamObserver,
+		systemRequestTimeout: cfg.ConnectTimeout, // during init, schema queries are bound to ConnectTimeout
 	}
 
 	if err := c.init(ctx, dialedHost); err != nil {
@@ -306,16 +345,21 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 		conn:        c,
 	}
 
+	// During the init phase the socket read deadline is pinned to ConnectTimeout —
+	// see the detailed rationale (separate init vs runtime budgets) in the
+	// dialWithoutObserver comment. After startup.setupConn the caller invokes
+	// finalizeConnection(), which switches the read deadline to ReadTimeout.
 	c.r.SetTimeout(c.cfg.ConnectTimeout)
 	if err := startup.setupConn(ctx); err != nil {
 		return err
 	}
 
-	c.r.SetTimeout(c.cfg.Timeout)
-
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
-		c.w = newWriteCoalescer(dialedHost.Conn, c.writeTimeout, c.session.cfg.WriteCoalesceWaitTime, ctx.Done())
+		// During init the writeCoalescer also starts with ConnectTimeout (see
+		// dialWithoutObserver); finalizeConnection() will update its atomic
+		// via c.w.setWriteTimeout(WriteTimeout).
+		c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, ctx.Done())
 	}
 
 	go c.serve(ctx)
@@ -326,6 +370,40 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 
 func (c *Conn) Write(p []byte) (n int, err error) {
 	return c.w.writeContext(context.Background(), p)
+}
+
+// finalizeConnection switches the connection from init mode to operational mode:
+// all timeouts pinned to ConnectTimeout during initialization are replaced by
+// their normal values from ClusterConfig:
+//   - socket read deadline → ReadTimeout (defensive net against a silent server);
+//   - socket write deadline → WriteTimeout;
+//   - per-Conn systemRequestTimeout → Metadata.SystemRequestTimeout (budget for
+//     schema/system queries via Conn.querySystem and controlConn.query).
+//
+// Called exactly once — by the caller, after the connection is fully initialized
+// (added to the pool via hostConnPool.connect or registered as the control
+// connection via controlConn.setupConn) and ready to serve regular requests.
+// Until that point all socket reads/writes and all internal init-phase requests
+// (STARTUP/AUTH/OPTIONS/system.local/USE keyspace) are bound to ConnectTimeout —
+// a low user-supplied Timeout must not break session establishment.
+//
+// Per-request timeouts (ClusterConfig.Timeout by default, Query.WithRequestTimeout
+// for override, Metadata.SystemRequestTimeout for system queries) are implemented
+// via callReq.timer inside Conn.exec and fire independently of the socket read
+// deadline — therefore a schema query with a large Metadata.SystemRequestTimeout
+// is not capped by a tighter ReadTimeout.
+func (c *Conn) finalizeConnection() {
+	c.r.SetTimeout(c.cfg.ReadTimeout)
+	c.w.setWriteTimeout(c.cfg.WriteTimeout)
+	c.setSystemRequestTimeout(c.cfg.SystemRequestTimeout)
+}
+
+// setSystemRequestTimeout stores the per-Conn snapshot of the client-side timeout
+// for schema/system queries. Matches upstream scylladb/gocql, but without
+// recalculateSystemRequestTimeout — the Scylla-specific " USING TIMEOUT" clause
+// is not ported, to preserve cross-compatibility with Cassandra.
+func (c *Conn) setSystemRequestTimeout(t time.Duration) {
+	c.systemRequestTimeout = t
 }
 
 type startupCoordinator struct {
@@ -433,7 +511,7 @@ func (s *startupCoordinator) write(ctx context.Context, frame frameBuilder, star
 		return nil, ctx.Err()
 	}
 
-	framer, err := s.conn.execInternal(ctx, frame, nil, startupCompleted.Load())
+	framer, err := s.conn.execInternal(ctx, frame, nil, startupCompleted.Load(), s.conn.cfg.ConnectTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +725,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		case <-timer.C:
 		}
 
-		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil)
+		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout)
 		if err != nil {
 			failures++
 			continue
@@ -896,9 +974,12 @@ type ConnReader interface {
 // connReader implements ConnReader.
 // It retries to read data up to 5 times or returns error.
 type connReader struct {
-	conn    net.Conn
-	r       *bufio.Reader
-	timeout time.Duration
+	conn net.Conn
+	r    *bufio.Reader
+	// timeout is read by Read() and updated by SetTimeout(). Stored as int64 nanoseconds
+	// to allow lock-free concurrent access between the reader goroutine and the caller
+	// that finalizes the connection (Conn.finalizeConnection).
+	timeout atomic.Int64
 }
 
 func (c *connReader) Read(p []byte) (n int, err error) {
@@ -906,8 +987,8 @@ func (c *connReader) Read(p []byte) (n int, err error) {
 
 	for i := 0; i < maxAttempts; i++ {
 		var nn int
-		if c.timeout > 0 {
-			c.conn.SetReadDeadline(time.Now().Add(c.timeout))
+		if timeout := time.Duration(c.GetTimeout()); timeout > 0 {
+			c.conn.SetReadDeadline(time.Now().Add(timeout)) //nolint:errcheck
 		}
 
 		nn, err = io.ReadFull(c.r, p[n:])
@@ -953,11 +1034,11 @@ func (c *connReader) SetWriteDeadline(t time.Time) error {
 }
 
 func (c *connReader) SetTimeout(timeout time.Duration) {
-	c.timeout = timeout
+	c.timeout.Store(int64(timeout))
 }
 
 func (c *connReader) GetTimeout() time.Duration {
-	return c.timeout
+	return time.Duration(c.timeout.Load())
 }
 
 type callReq struct {
@@ -996,6 +1077,10 @@ type contextWriter interface {
 	// early. writeContext must return a non-nil error if it returns n < len(p). writeContext must not modify the
 	// data in p, even temporarily.
 	writeContext(ctx context.Context, p []byte) (n int, err error)
+
+	// setWriteTimeout updates the write deadline used for subsequent writeContext calls.
+	// Used by Conn.finalizeConnection to switch from ConnectTimeout to operational WriteTimeout.
+	setWriteTimeout(timeout time.Duration)
 }
 
 type deadlineWriter interface {
@@ -1004,8 +1089,11 @@ type deadlineWriter interface {
 }
 
 type deadlineContextWriter struct {
-	w       deadlineWriter
-	timeout time.Duration
+	w deadlineWriter
+	// timeout (int64 nanoseconds) is read by writeContext() and updated by setWriteTimeout().
+	// Atomic to allow lock-free concurrent access from query goroutines and the caller
+	// of Conn.finalizeConnection().
+	timeout atomic.Int64
 	// semaphore protects critical section for SetWriteDeadline/Write.
 	// It is a channel with capacity 1.
 	semaphore chan struct{}
@@ -1030,13 +1118,18 @@ func (c *deadlineContextWriter) writeContext(ctx context.Context, p []byte) (int
 		<-c.semaphore
 	}()
 
-	if c.timeout > 0 {
-		err := c.w.SetWriteDeadline(time.Now().Add(c.timeout))
+	if timeout := time.Duration(c.timeout.Load()); timeout > 0 {
+		err := c.w.SetWriteDeadline(time.Now().Add(timeout))
 		if err != nil {
 			return 0, err
 		}
 	}
 	return c.w.Write(p)
+}
+
+// setWriteTimeout implements contextWriter.
+func (c *deadlineContextWriter) setWriteTimeout(timeout time.Duration) {
+	c.timeout.Store(int64(timeout))
 }
 
 func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.Duration,
@@ -1045,8 +1138,8 @@ func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.
 		writeCh: make(chan writeRequest),
 		c:       conn,
 		quit:    quit,
-		timeout: writeTimeout,
 	}
+	wc.setWriteTimeout(writeTimeout)
 	go wc.writeFlusher(coalesceDuration)
 	return wc
 }
@@ -1059,7 +1152,9 @@ type writeCoalescer struct {
 	quit    <-chan struct{}
 	writeCh chan writeRequest
 
-	timeout time.Duration
+	// timeout (int64 nanoseconds) — read by flush() goroutine, updated by setWriteTimeout().
+	// Atomic for safe concurrent access.
+	timeout atomic.Int64
 
 	testEnqueuedHook func()
 	testFlushedHook  func()
@@ -1100,6 +1195,16 @@ func (w *writeCoalescer) writeContext(ctx context.Context, p []byte) (int, error
 
 	result := <-resultChan
 	return result.n, result.err
+}
+
+// setWriteTimeout implements contextWriter.
+func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
+	w.timeout.Store(int64(timeout))
+}
+
+// getWriteTimeout helper
+func (w *writeCoalescer) getWriteTimeout() time.Duration {
+	return time.Duration(w.timeout.Load())
 }
 
 func (w *writeCoalescer) writeFlusher(interval time.Duration) {
@@ -1154,8 +1259,8 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 
 func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buffers) {
 	// Flush everything we have so far.
-	if w.timeout > 0 {
-		err := w.c.SetWriteDeadline(time.Now().Add(w.timeout))
+	if timeout := w.getWriteTimeout(); timeout > 0 {
+		err := w.c.SetWriteDeadline(time.Now().Add(timeout))
 		if err != nil {
 			for i := range resultChans {
 				resultChans[i] <- writeResult{
@@ -1209,11 +1314,17 @@ func (c *Conn) addCall(call *callReq) error {
 	return nil
 }
 
-func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*framer, error) {
-	return c.execInternal(ctx, req, tracer, true)
+// exec sends a single CQL frame on this connection and waits for the response.
+//
+// requestTimeout is the client-side timeout for waiting on the response to this
+// specific request. If 0, there is no client-side timeout (we rely solely on ctx
+// and the socket read deadline). Drives a dedicated callReq.timer independently
+// of the global ClusterConfig.Timeout.
+func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error) {
+	return c.execInternal(ctx, req, tracer, true, requestTimeout)
 }
 
-func (c *Conn) execInternal(ctx context.Context, req frameBuilder, tracer Tracer, startupCompleted bool) (*framer, error) {
+func (c *Conn) execInternal(ctx context.Context, req frameBuilder, tracer Tracer, startupCompleted bool, requestTimeout time.Duration) (*framer, error) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
@@ -1309,7 +1420,7 @@ func (c *Conn) execInternal(ctx context.Context, req frameBuilder, tracer Tracer
 	}
 
 	var timeoutCh <-chan time.Time
-	if timeout := c.r.GetTimeout(); timeout > 0 {
+	if requestTimeout > 0 {
 		if call.timer == nil {
 			call.timer = time.NewTimer(0)
 			<-call.timer.C
@@ -1322,7 +1433,7 @@ func (c *Conn) execInternal(ctx context.Context, req frameBuilder, tracer Tracer
 			}
 		}
 
-		call.timer.Reset(timeout)
+		call.timer.Reset(requestTimeout)
 		timeoutCh = call.timer.C
 	}
 
@@ -1450,7 +1561,7 @@ type inflightPrepare struct {
 	preparedStatment *preparedStatment
 }
 
-func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer, keyspace string) (*preparedStatment, error) {
+func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer, keyspace string, requestTimeout time.Duration) (*preparedStatment, error) {
 	stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), keyspace, stmt)
 	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
 		flight := &inflightPrepare{
@@ -1474,7 +1585,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer,
 			// we won the race to do the load, if our context is canceled we shouldnt
 			// stop the load as other callers are waiting for it but this caller should get
 			// their context cancelled error.
-			framer, err := c.exec(c.ctx, prep, tracer)
+			framer, err := c.exec(c.ctx, prep, tracer, requestTimeout)
 			if err != nil {
 				flight.err = err
 				c.session.stmtsLRU.remove(stmtCacheKey)
@@ -1548,6 +1659,11 @@ func marshalQueryValue(typ TypeInfo, value interface{}, dst *queryValues) error 
 
 func (c *Conn) executeQuery(ctx context.Context, q *internalQuery) *Iter {
 	qryOpts := q.qryOpts
+	// requestTimeout is passed through as-is. By default Query/Batch are initialized
+	// to s.cfg.Timeout (see defaultsFromSession/Session.Batch), so 0 here is only
+	// possible if the caller explicitly invoked SetRequestTimeout(0) — Conn.exec
+	// interprets that as "no client-side timeout" (we rely on ctx and ReadTimeout).
+	requestTimeout := qryOpts.requestTimeout
 	params := queryParams{
 		consistency: q.GetConsistency(),
 	}
@@ -1584,7 +1700,7 @@ func (c *Conn) executeQuery(ctx context.Context, q *internalQuery) *Iter {
 	if !qryOpts.skipPrepare && shouldPrepare(qryOpts.stmt) {
 		// Prepare all DML queries. Other queries can not be prepared.
 		var err error
-		info, err = c.prepareStatement(ctx, qryOpts.stmt, qryOpts.trace, usedKeyspace)
+		info, err = c.prepareStatement(ctx, qryOpts.stmt, qryOpts.trace, usedKeyspace, requestTimeout)
 		if err != nil {
 			iter.err = err
 			return iter
@@ -1647,7 +1763,7 @@ func (c *Conn) executeQuery(ctx context.Context, q *internalQuery) *Iter {
 		}
 	}
 
-	framer, err := c.exec(ctx, frame, qryOpts.trace)
+	framer, err := c.exec(ctx, frame, qryOpts.trace, requestTimeout)
 	if err != nil {
 		iter.err = err
 		return iter
@@ -1785,7 +1901,9 @@ func (c *Conn) UseKeyspace(keyspace string) error {
 	q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
 	q.params.consistency = c.session.cons
 
-	framer, err := c.exec(c.ctx, q, nil)
+	// UseKeyspace is invoked from pool.connect before finalizeConnection — it is
+	// part of connection initialization, so we use ConnectTimeout.
+	framer, err := c.exec(c.ctx, q, nil, c.cfg.ConnectTimeout)
 	if err != nil {
 		return err
 	}
@@ -1810,6 +1928,8 @@ func (c *Conn) UseKeyspace(keyspace string) error {
 
 func (c *Conn) executeBatch(ctx context.Context, b *internalBatch) *Iter {
 	iter := newIter(b.metrics, b.Keyspace(), b.routingInfo, nil)
+	// See the comment in executeQuery.
+	requestTimeout := b.batchOpts.requestTimeout
 	n := len(b.batchOpts.entries)
 	req := &writeBatchFrame{
 		typ:                   b.batchOpts.bType,
@@ -1838,7 +1958,7 @@ func (c *Conn) executeBatch(ctx context.Context, b *internalBatch) *Iter {
 		batchStmt := &req.statements[i]
 
 		if len(entry.Args) > 0 || entry.binding != nil {
-			info, err := c.prepareStatement(ctx, entry.Stmt, b.batchOpts.trace, usedKeyspace)
+			info, err := c.prepareStatement(ctx, entry.Stmt, b.batchOpts.trace, usedKeyspace, requestTimeout)
 			if err != nil {
 				iter.err = err
 				return iter
@@ -1884,7 +2004,7 @@ func (c *Conn) executeBatch(ctx context.Context, b *internalBatch) *Iter {
 		}
 	}
 
-	framer, err := c.exec(ctx, req, b.batchOpts.trace)
+	framer, err := c.exec(ctx, req, b.batchOpts.trace, requestTimeout)
 	if err != nil {
 		iter.err = err
 		return iter
@@ -1948,7 +2068,7 @@ func (c *Conn) querySystemPeers(ctx context.Context, version cassVersion) *Iter 
 
 	if version.AtLeast(4, 0, 0) && isSchemaV2 {
 		// Try "system.peers_v2" and fallback to "system.peers" if it's not found
-		iter := c.query(ctx, peerV2Schemas)
+		iter := c.querySystem(ctx, peerV2Schemas)
 
 		err := iter.checkErrAndNotFound()
 		if err != nil {
@@ -1956,19 +2076,34 @@ func (c *Conn) querySystemPeers(ctx context.Context, version cassVersion) *Iter 
 				c.mu.Lock()
 				c.isSchemaV2 = false
 				c.mu.Unlock()
-				return c.query(ctx, peerSchema)
+				return c.querySystem(ctx, peerSchema)
 			} else {
 				return iter
 			}
 		}
 		return iter
 	} else {
-		return c.query(ctx, peerSchema)
+		return c.querySystem(ctx, peerSchema)
 	}
 }
 
 func (c *Conn) querySystemLocal(ctx context.Context) *Iter {
-	return c.query(ctx, "SELECT * FROM system.local WHERE key='local'")
+	return c.querySystem(ctx, "SELECT * FROM system.local WHERE key='local'")
+}
+
+// querySystem runs a query against schema/system tables with a per-request
+// timeout of systemRequestTimeout (a snapshot of Metadata.SystemRequestTimeout).
+// Used for schema/topology discovery (system.local, system.peers,
+// system_schema.*). USING TIMEOUT is not added — for cross-compatibility with
+// Cassandra.
+//
+// Matches upstream scylladb/gocql Conn.querySystem.
+func (c *Conn) querySystem(ctx context.Context, statement string, values ...interface{}) *Iter {
+	q := c.session.Query(statement, values...).Consistency(One).Trace(nil).
+		WithRequestTimeout(c.systemRequestTimeout)
+	q.skipPrepare = true
+	q.disableSkipMetadata = true
+	return q.iterInternal(c, ctx)
 }
 
 func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -281,6 +281,37 @@ func TestStartupTimeout(t *testing.T) {
 	cancel()
 }
 
+// TestNewConnectWithLowTimeout verifies that ConnectTimeout covers the entire
+// connection initialization phase, including writes. A low user-supplied
+// Timeout must not break session establishment — it only applies after a
+// successful init. Regression test for scylladb/gocql#532 (PR #531).
+//
+// We use 100ms as a "low but not pathological" Timeout. Before the fix the
+// write deadline for STARTUP/AUTH was set to Timeout=100ms — the packets did
+// not have time to be sent and `CreateSession` returned "no connections were
+// made". With ConnectTimeout=5s initialization passes cleanly.
+func TestNewConnectWithLowTimeout(t *testing.T) {
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Timeout = 100 * time.Millisecond
+	cluster.WriteTimeout = 100 * time.Millisecond
+	cluster.ConnectTimeout = 5 * time.Second
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession should succeed when ConnectTimeout is generous: %v", err)
+	}
+	defer session.Close()
+
+	// Sanity: the "timeout" query in TestServer never gets a response — the
+	// normal Timeout bounds the wait on this specific request, and it fails.
+	if err := session.Query("timeout").Exec(); err == nil {
+		t.Fatal("expected query to fail with client-side timeout")
+	}
+}
+
 func TestTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -614,6 +645,146 @@ func TestQueryTimeout(t *testing.T) {
 	}
 }
 
+// TestInitSchemaQueryRespectsConnectTimeout verifies that a schema query inside
+// controlConn.setupConn (called during session initialization) is capped by
+// ConnectTimeout — via Conn.systemRequestTimeout, which is initialized to
+// ConnectTimeout in dialWithoutObserver. After finalizeConnection,
+// systemRequestTimeout switches to ClusterConfig.Metadata.SystemRequestTimeout
+// (runtime path).
+//
+// Regression test for scylladb/gocql PR #222+#536 (client-side, no USING TIMEOUT).
+func TestInitSchemaQueryRespectsConnectTimeout(t *testing.T) {
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	// Hang all schema/system queries on the server side.
+	atomic.StoreInt32(&srv.TimeoutOnSystemQueries, 1)
+
+	cluster := NewCluster(srv.Address)
+	cluster.ProtoVersion = int(defaultProto)
+	// Small ConnectTimeout — it must fire on the init schema query inside setupConn.
+	cluster.ConnectTimeout = 100 * time.Millisecond
+	cluster.Timeout = 5 * time.Second
+	cluster.Metadata.SystemRequestTimeout = 60 * time.Second // runtime value, does not apply during init
+
+	start := time.Now()
+	_, err := cluster.CreateSession()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("CreateSession should fail when init schema query hangs and ConnectTimeout is low")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("ConnectTimeout not honored on init schema query: elapsed %v, expected ~100ms", elapsed)
+	}
+}
+
+// TestControlConnQueryRespectsSystemRequestTimeout verifies that the per-request
+// budget for queries via controlConn.query (schema discovery: reads from
+// system_schema.*, system.local, system.peers[_v2]) is taken from
+// Metadata.SystemRequestTimeout, NOT from ClusterConfig.Timeout.
+//
+// Before the fix, controlConn.query built a Query via session.Query(...), which
+// inherits ClusterConfig.Timeout — schema discovery on a large keyspace would
+// be cut off by an aggressive user timeout, contrary to the docs and unlike
+// Conn.querySystem.
+//
+// Regression test for SCYLLA-2121 (v2). NewTestServer does not respond to
+// system.local, so a full session with a control conn cannot be assembled
+// through the mock. The test goes around: it uses testCluster
+// (disableControlConn=true) to get a working pool, then manually builds a
+// controlConn around the real Conn.
+func TestControlConnQueryRespectsSystemRequestTimeout(t *testing.T) {
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	// Large ClusterConfig.Timeout — it must NOT affect the schema query after
+	// the fix. Small Metadata.SystemRequestTimeout — that is what should fire.
+	cluster.Timeout = 5 * time.Second
+	cluster.Metadata.SystemRequestTimeout = 200 * time.Millisecond
+
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	defer db.Close()
+
+	// Grab one real Conn from the pool.
+	var (
+		conn *Conn
+		host *HostInfo
+	)
+	db.pool.mu.RLock()
+	for _, hp := range db.pool.hostConnPools {
+		hp.mu.RLock()
+		if len(hp.conns) > 0 {
+			conn = hp.conns[0]
+			host = hp.host
+		}
+		hp.mu.RUnlock()
+		if conn != nil {
+			break
+		}
+	}
+	db.pool.mu.RUnlock()
+	if conn == nil {
+		t.Fatal("no live connection in pool")
+	}
+
+	// Build a controlConn around this Conn (without a real .connect — the mock
+	// does not respond to system.local). Retries are disabled so elapsed is
+	// ~200ms rather than N*200ms.
+	ctrl := createControlConn(db)
+	ctrl.conn.Store(&connHost{conn: conn, host: host})
+	ctrl.retry = &SimpleRetryPolicy{NumRetries: 0}
+
+	// "timeout" — the mock hangs on this query until Stop().
+	start := time.Now()
+	iter := ctrl.query("timeout")
+	err = iter.Close()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error on hung query, got nil")
+	}
+	// SystemRequestTimeout=200ms should fire well before ClusterConfig.Timeout=5s.
+	// We use a generous upper bound of 2s — before the fix elapsed would have been ~5s.
+	if elapsed > 2*time.Second {
+		t.Fatalf("Metadata.SystemRequestTimeout not honored by controlConn.query: elapsed %v, expected ~200ms", elapsed)
+	}
+}
+
+// TestQueryRequestTimeout verifies that Query.WithRequestTimeout() sets a
+// client-side timeout for a specific query that is shorter than the global
+// ClusterConfig.Timeout. Regression test for scylladb/gocql PR #535.
+func TestQueryRequestTimeout(t *testing.T) {
+	srv := NewTestServer(t, defaultProto, context.Background())
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	// High session-level Timeout to make sure it is the per-request timeout
+	// that fires, not the global one.
+	cluster.Timeout = 5 * time.Second
+
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	defer db.Close()
+
+	start := time.Now()
+	err = db.Query("timeout").WithRequestTimeout(50 * time.Millisecond).Exec()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected per-request timeout error, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("per-request timeout not honored: elapsed %v, expected ~50ms", elapsed)
+	}
+}
+
 func BenchmarkSingleConn(b *testing.B) {
 	srv := NewTestServer(b, 3, context.Background())
 	defer srv.Stop()
@@ -888,7 +1059,6 @@ func TestWriteCoalescing(t *testing.T) {
 		writeCh: make(chan writeRequest),
 		c:       client,
 		quit:    ctx.Done(),
-		timeout: 500 * time.Millisecond,
 		testEnqueuedHook: func() {
 			enqueued <- struct{}{}
 		},
@@ -896,6 +1066,7 @@ func TestWriteCoalescing(t *testing.T) {
 			client.Close()
 		},
 	}
+	w.setWriteTimeout(500 * time.Millisecond)
 	timerC := make(chan time.Time, 1)
 	go func() {
 		w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
@@ -1132,11 +1303,12 @@ func NewSSLTestServer(t testing.TB, protocol uint8, ctx context.Context) *TestSe
 }
 
 type TestServer struct {
-	Address          string
-	TimeoutOnStartup int32
-	t                testing.TB
-	listen           net.Listener
-	nKillReq         int64
+	Address                string
+	TimeoutOnStartup       int32
+	TimeoutOnSystemQueries int32
+	t                      testing.TB
+	listen                 net.Listener
+	nKillReq               int64
 
 	protocol   byte
 	headerSize int
@@ -1277,6 +1449,13 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, useProtoV5, star
 		query, err := reqFrame.readLongString()
 		if err != nil {
 			srv.errorLocked(err)
+			return
+		}
+		if atomic.LoadInt32(&srv.TimeoutOnSystemQueries) > 0 &&
+			(strings.Contains(strings.ToLower(query), " system.") ||
+				strings.Contains(strings.ToLower(query), " system_schema.")) {
+			// Do not respond to schema/system queries.
+			<-srv.ctx.Done()
 			return
 		}
 		first := query
@@ -1516,16 +1695,16 @@ func TestConnProcessAllFramesInSingleSegment(t *testing.T) {
 		addr:       server.RemoteAddr().String(),
 		streams:    streams.New(protoVersion5),
 		isSchemaV2: true,
-		w: &deadlineContextWriter{
-			w:         server,
-			timeout:   time.Second * 10,
-			semaphore: make(chan struct{}, 1),
-			quit:      make(chan struct{}),
-		},
-		writeTimeout: time.Second * 10,
-		session:      &Session{types: GlobalTypes},
-		logger:       &defaultLogger{},
+		session:    &Session{types: GlobalTypes},
+		logger:     &defaultLogger{},
 	}
+	writer := &deadlineContextWriter{
+		w:         server,
+		semaphore: make(chan struct{}, 1),
+		quit:      make(chan struct{}),
+	}
+	writer.timeout.Store(int64(time.Second * 10))
+	c.w = writer
 
 	call1 := &callReq{
 		timeout:  make(chan struct{}),

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -142,19 +142,30 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 		}
 	}
 
+	writeTimeout := cfg.WriteTimeout
+	if writeTimeout == 0 {
+		writeTimeout = cfg.Timeout
+	}
+	readTimeout := cfg.ReadTimeout
+	if readTimeout == 0 {
+		readTimeout = cfg.ConnectTimeout
+	}
+
 	return &ConnConfig{
-		ProtoVersion:   cfg.ProtoVersion,
-		CQLVersion:     cfg.CQLVersion,
-		Timeout:        cfg.Timeout,
-		WriteTimeout:   cfg.WriteTimeout,
-		ConnectTimeout: cfg.ConnectTimeout,
-		Dialer:         cfg.Dialer,
-		HostDialer:     hostDialer,
-		Compressor:     cfg.Compressor,
-		Authenticator:  cfg.Authenticator,
-		AuthProvider:   cfg.AuthProvider,
-		Keepalive:      cfg.SocketKeepalive,
-		Logger:         cfg.Logger,
+		ProtoVersion:         cfg.ProtoVersion,
+		CQLVersion:           cfg.CQLVersion,
+		Timeout:              cfg.Timeout,
+		WriteTimeout:         writeTimeout,
+		ConnectTimeout:       cfg.ConnectTimeout,
+		ReadTimeout:          readTimeout,
+		SystemRequestTimeout: cfg.Metadata.SystemRequestTimeout,
+		Dialer:               cfg.Dialer,
+		HostDialer:           hostDialer,
+		Compressor:           cfg.Compressor,
+		Authenticator:        cfg.Authenticator,
+		AuthProvider:         cfg.AuthProvider,
+		Keepalive:            cfg.SocketKeepalive,
+		Logger:               cfg.Logger,
 	}, nil
 }
 
@@ -598,6 +609,10 @@ func (pool *hostConnPool) connect() (err error) {
 			return err
 		}
 	}
+
+	// Connection is fully initialized — switch deadlines from ConnectTimeout to
+	// operational Timeout / WriteTimeout before serving regular queries.
+	conn.finalizeConnection()
 
 	// add the Conn to the pool
 	pool.mu.Lock()

--- a/control.go
+++ b/control.go
@@ -291,6 +291,7 @@ func (c *controlConn) connect(hosts []*HostInfo, sessionInit bool) error {
 		}
 		err = c.setupConn(conn, sessionInit)
 		if err == nil {
+			conn.finalizeConnection()
 			break
 		}
 		c.session.logger.Info("Control connection setup failed after connecting to host.",
@@ -360,6 +361,11 @@ func (c *controlConn) setupConn(conn *Conn, sessionInit bool) error {
 
 	c.conn.Store(ch)
 
+	// NOTE: caller must invoke conn.finalizeConnection() after a successful return
+	// from setupConn (matches upstream scylladb/gocql). Switches the conn from
+	// ConnectTimeout-bound init mode to operational ReadTimeout/WriteTimeout/
+	// Metadata.SystemRequestTimeout.
+
 	c.session.logger.Info("Control connection connected to host.",
 		NewLogFieldIP("host_addr", host.ConnectAddress()), NewLogFieldString("host_id", host.HostID()))
 
@@ -402,7 +408,7 @@ func (c *controlConn) registerEvents(conn *Conn) error {
 	framer, err := conn.exec(context.Background(),
 		&writeRegisterFrame{
 			events: events,
-		}, nil)
+		}, nil, conn.cfg.ConnectTimeout)
 	if err != nil {
 		return err
 	}
@@ -493,6 +499,7 @@ func (c *controlConn) attemptReconnectToAnyOfHosts(hosts []*HostInfo) (*Conn, er
 		}
 		err = c.setupConn(conn, false)
 		if err == nil {
+			conn.finalizeConnection()
 			break
 		}
 		c.session.logger.Info("During reconnection, control connection setup failed after connecting to host.",
@@ -524,7 +531,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 		NewLogFieldString("host_id", conn.host.HostID()),
 		NewLogFieldError("err", err))
 
-	c.reconnect()
+	go c.reconnect()
 }
 
 func (c *controlConn) getConn() *connHost {
@@ -537,7 +544,12 @@ func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 		return nil, errNoControl
 	}
 
-	framer, err := ch.conn.exec(context.Background(), w, nil)
+	// controlConn.writeFrame is called from heartBeat and other internal
+	// control-conn operations. For consistency with upstream scylladb/gocql, the
+	// client-side timeout is taken from Metadata.SystemRequestTimeout — the same
+	// budget caps queries to schema/system tables, which also go through the
+	// control connection.
+	framer, err := ch.conn.exec(context.Background(), w, nil, c.session.cfg.Metadata.SystemRequestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -574,9 +586,27 @@ func (c *controlConn) withConn(fn func(*Conn) *Iter) *Iter {
 	})
 }
 
-// query will return nil if the connection is closed or nil
+// query will return nil if the connection is closed or nil.
+//
+// control-conn queries target schema/system tables (`system.local`,
+// `system.peers[_v2]`, `system_schema.*`) and logically belong to the same
+// budget as Conn.querySystem. The per-request timeout is therefore taken from
+// Metadata.SystemRequestTimeout, not ClusterConfig.Timeout — otherwise an
+// aggressive user Timeout (typically tens or hundreds of milliseconds) would
+// cut off schema discovery on large keyspaces.
+//
+// controlConn.query is only called in the runtime phase (via
+// schemaDescriber.fetchSchema/fetchAllSchema/refreshSchemas and
+// Conn.awaitSchemaAgreement) — the connection has already passed
+// finalizeConnection. The init path goes through Conn.querySystemLocal directly
+// and is capped at ConnectTimeout via Conn.systemRequestTimeout.
+//
+// Important: WithRequestTimeout must be set before newInternalQuery; otherwise
+// requestTimeout is snapshotted from ClusterConfig.Timeout into queryOptions
+// before we override it.
 func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter) {
-	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{}).Trace(nil)
+	q := c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{}).Trace(nil).
+		WithRequestTimeout(c.session.cfg.Metadata.SystemRequestTimeout)
 	qry := newInternalQuery(q, context.TODO())
 
 	for {

--- a/control_test.go
+++ b/control_test.go
@@ -28,8 +28,12 @@
 package gocql
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestHostInfo_Lookup(t *testing.T) {
@@ -55,5 +59,80 @@ func TestHostInfo_Lookup(t *testing.T) {
 		if !host.ConnectAddress().Equal(test.ip) {
 			t.Errorf("expected ip %v got %v for addr %q", test.ip, host.ConnectAddress(), test.addr)
 		}
+	}
+}
+
+// blockingDNSResolver is a DNSResolver that sends a signal on `entered` on the
+// first call and blocks the return until `unblock` is closed. It is used to
+// turn the fallback path in controlConn.attemptReconnect into an "endless" one
+// — which lets us detect whether HandleError blocks on reconnect synchronously
+// or launches it in a goroutine.
+type blockingDNSResolver struct {
+	entered chan<- struct{}
+	unblock <-chan struct{}
+}
+
+func (b *blockingDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	select {
+	case b.entered <- struct{}{}:
+	default:
+	}
+	<-b.unblock
+	return nil, fmt.Errorf("blocked")
+}
+
+// TestControlConn_HandleError_LaunchesReconnectInGoroutine verifies that
+// HandleError launches reconnect in a background goroutine, not synchronously.
+// Regression test for scylladb/gocql#521 (deadlock in connection storm): a
+// synchronous reconnect could hold the controlConn mutex while attemptReconnect
+// did DNS resolution / TCP dial.
+func TestControlConn_HandleError_LaunchesReconnectInGoroutine(t *testing.T) {
+	resolverEntered := make(chan struct{}, 1)
+	unblock := make(chan struct{})
+	defer close(unblock)
+
+	resolver := &blockingDNSResolver{
+		entered: resolverEntered,
+		unblock: unblock,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := &Session{
+		cfg: ClusterConfig{
+			DNSResolver: resolver,
+			Hosts:       []string{"nonexistent.invalid"},
+			Port:        9042,
+		},
+		ctx:    ctx,
+		logger: newTestLogger(LogLevelDebug),
+	}
+
+	cc := createControlConn(session)
+
+	fakeConn := &Conn{host: &HostInfo{}}
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		cc.HandleError(fakeConn, errors.New("boom"), true)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("HandleError did not return within 2s; it likely runs reconnect synchronously")
+	}
+
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("HandleError took %v, expected <100ms (sync reconnect bug?)", elapsed)
+	}
+
+	select {
+	case <-resolverEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect goroutine never reached DNS resolution; was it started at all?")
 	}
 }

--- a/query_executor.go
+++ b/query_executor.go
@@ -294,6 +294,12 @@ type queryOptions struct {
 
 	// getKeyspace is field so that it can be overriden in tests
 	getKeyspace func() string
+
+	// requestTimeout is a snapshot of Query.requestTimeout taken when queryOptions
+	// is created. Initialized to ClusterConfig.Timeout by default via
+	// defaultsFromSession. 0 is interpreted by Conn.exec as "no client-side
+	// timeout".
+	requestTimeout time.Duration
 }
 
 func newQueryOptions(q *Query, ctx context.Context) *queryOptions {
@@ -330,6 +336,7 @@ func newQueryOptions(q *Query, ctx context.Context) *queryOptions {
 		nowInSecondsValue:     q.nowInSecondsValue,
 		keyspace:              q.keyspace,
 		hostID:                q.hostID,
+		requestTimeout:        q.requestTimeout,
 	}
 }
 
@@ -518,6 +525,9 @@ type batchOptions struct {
 	idempotent    bool
 	routingKey    []byte
 	nowInSeconds  *int
+
+	// requestTimeout — see queryOptions.requestTimeout.
+	requestTimeout time.Duration
 }
 
 func newBatchOptions(b *Batch, ctx context.Context) *batchOptions {
@@ -551,6 +561,7 @@ func newBatchOptions(b *Batch, ctx context.Context) *batchOptions {
 		idempotent:            b.IsIdempotent(),
 		routingKey:            newRoutingKey,
 		nowInSeconds:          b.nowInSeconds,
+		requestTimeout:        b.requestTimeout,
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -764,7 +764,7 @@ func (s *Session) StatementMetadata(ctx context.Context, stmt, keyspace string) 
 	}
 
 	// get the query info for the statement
-	info, err := conn.prepareStatement(ctx, stmt, nil, keyspace)
+	info, err := conn.prepareStatement(ctx, stmt, nil, keyspace, s.cfg.Timeout)
 	if err != nil {
 		// TODO: it would be nice to mark hosts here but as we are not using the policies
 		// to fetch hosts we cant and we can't use the policies because they might
@@ -1077,6 +1077,15 @@ type Query struct {
 
 	keyspace          string
 	nowInSecondsValue *int
+
+	// requestTimeout caps the time spent waiting for a server response to this
+	// specific query. Implemented via callReq.timer inside Conn.exec —
+	// independently of the socket read deadline (ClusterConfig.ReadTimeout).
+	// Initialized by default to ClusterConfig.Timeout in Session.Query / Session.Bind.
+	// 0 means "no client-side timeout" (rely on ctx and ReadTimeout).
+	//
+	// Change via WithRequestTimeout / SetRequestTimeout.
+	requestTimeout time.Duration
 }
 
 type queryRoutingInfo struct {
@@ -1112,6 +1121,7 @@ func (q *Query) defaultsFromSession() {
 	q.serialCons = s.cfg.SerialConsistency
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
+	q.requestTimeout = s.cfg.Timeout
 
 	q.spec = &NonSpeculativeExecution{}
 }
@@ -1232,6 +1242,33 @@ func (q *Query) WithContext(ctx context.Context) *Query {
 	q2 := *q
 	q2.context = ctx
 	return &q2
+}
+
+// WithRequestTimeout sets the client-side timeout for waiting on a server
+// response to this specific query. Independent of ClusterConfig.Timeout: it lets
+// individual queries be more urgent or more lenient without touching the global
+// timeout. Implemented via callReq.timer inside Conn.exec — independently of
+// the socket read deadline (ClusterConfig.ReadTimeout, the defensive net).
+//
+// By default (when a Query is created via Session.Query / Session.Bind)
+// requestTimeout is initialized to ClusterConfig.Timeout. Setting it to 0
+// disables the client-side timeout for this query (we rely on ctx and ReadTimeout).
+func (q *Query) WithRequestTimeout(d time.Duration) *Query {
+	q.requestTimeout = d
+	return q
+}
+
+// SetRequestTimeout is an alias for WithRequestTimeout, matching the name used
+// in upstream scylladb/gocql. Semantically equivalent.
+func (q *Query) SetRequestTimeout(d time.Duration) *Query {
+	return q.WithRequestTimeout(d)
+}
+
+// GetRequestTimeout returns the current per-request timeout. The default is
+// ClusterConfig.Timeout (set in Session.Query / Session.Bind). 0 means the
+// timeout has been explicitly disabled via SetRequestTimeout(0).
+func (q *Query) GetRequestTimeout() time.Duration {
+	return q.requestTimeout
 }
 
 // Keyspace returns the keyspace the query will be executed against.
@@ -1999,6 +2036,11 @@ type Batch struct {
 	context               context.Context
 	keyspace              string
 	nowInSeconds          *int
+
+	// requestTimeout — see Query.requestTimeout. Initialized to
+	// ClusterConfig.Timeout by default in Session.Batch. Change via
+	// WithRequestTimeout / SetRequestTimeout.
+	requestTimeout time.Duration
 }
 
 // Deprecated: use Session.Batch instead
@@ -2022,6 +2064,7 @@ func (s *Session) Batch(typ BatchType) *Batch {
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
 		spec:             &NonSpeculativeExecution{},
+		requestTimeout:   s.cfg.Timeout,
 	}
 
 	return batch
@@ -2126,6 +2169,25 @@ func (b *Batch) WithContext(ctx context.Context) *Batch {
 	b2 := *b
 	b2.context = ctx
 	return &b2
+}
+
+// WithRequestTimeout — see Query.WithRequestTimeout.
+func (b *Batch) WithRequestTimeout(d time.Duration) *Batch {
+	b.requestTimeout = d
+	return b
+}
+
+// SetRequestTimeout is an alias for WithRequestTimeout, matching the name used
+// in upstream scylladb/gocql.
+func (b *Batch) SetRequestTimeout(d time.Duration) *Batch {
+	return b.WithRequestTimeout(d)
+}
+
+// GetRequestTimeout returns the current per-request timeout. The default is
+// ClusterConfig.Timeout (set in Session.Batch). 0 means the timeout has been
+// explicitly disabled via SetRequestTimeout(0).
+func (b *Batch) GetRequestTimeout() time.Duration {
+	return b.requestTimeout
 }
 
 // Size returns the number of batch statements to be executed by the batch operation.


### PR DESCRIPTION
Related Issue: https://github.com/apache/cassandra-gocql-driver/issues/1919

Splits previously conflated timeout budgets so a low user-supplied Timeout no longer breaks session establishment, and adds dedicated client-side budgets for system queries and per-request overrides. Also fixes a potential controlConn reconnect deadlock.

* `ClusterConfig.ReadTimeout`: socket-level read deadline, defaults to `11s`, falls back to `ConnectTimeout` if unset. Decoupled from `Timeout`, which is now purely a per-request client-side budget.
* `ClusterConfig.Metadata.SystemRequestTimeout` (default `60s`): per-request budget for `system`/`system_schema` queries and other runtime control-conn frames. Applied via `Conn.querySystem`, `controlConn.query` and `controlConn.writeFrame`.
* `Query/Batch.WithRequestTimeout` / `SetRequestTimeout` / `GetRequestTimeout`: per-request override of `ClusterConfig.Timeout`, enforced via `callReq.timer` in `Conn.exec` independently of the socket deadline. 0 disables the client-side timer.
* `Conn.finalizeConnection`: switches an initialized connection from ConnectTimeout-bound init mode to operational `ReadTimeout` / `WriteTimeout` / `Metadata.SystemRequestTimeout`. Called by `hostConnPool.connect`, `controlConn.connect` and `controlConn.attemptReconnectToAnyOfHosts`. Until then, all socket reads/writes and internal init-phase requests (`STARTUP`/`AUTH`/`OPTIONS`/`system.local`/`USE keyspace`) are pinned to `ConnectTimeout`. Fixes "no connections were made when creating the session" when Timeout is low.
* `controlConn.HandleError` now launches reconnect in a goroutine to avoid a potential deadlock during a connection storm where attemptReconnect holds the controlConn mutex while doing DNS resolution / TCP dial.
* `connReader.timeout`, `deadlineContextWriter.timeout` and `writeCoalescer.timeout` are now atomics to allow `finalizeConnection` to update them concurrently with reader/writer goroutines.
* Regression tests: `TestNewConnectWithLowTimeout`, `TestInitSchemaQueryRespectsConnectTimeout`, `TestControlConnQueryRespectsSystemRequestTimeout`, `TestQueryRequestTimeout`, `TestControlConn_HandleError_LaunchesReconnectInGoroutine`.
* `README`: new "Connection Timeouts" section documenting the layers and picking guidance.