### PR TITLE
CASSGO-126 Fix system.peers_v2 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent panic when using a HostFilter and keyspace is not replicated to every DC (CASSGO-122)
+- system.peers fallback doesn't work in some scenarios (CASSGO-126)
 
 ## [2.1.1]
 

--- a/conn.go
+++ b/conn.go
@@ -1952,7 +1952,8 @@ func (c *Conn) querySystemPeers(ctx context.Context, version cassVersion) *Iter 
 
 		err := iter.checkErrAndNotFound()
 		if err != nil {
-			if errFrame, ok := err.(errorFrame); ok && errFrame.code == ErrCodeInvalid { // system.peers_v2 not found, try system.peers
+			var requestErr RequestError
+			if errors.As(err, &requestErr) && requestErr.Code() == ErrCodeInvalid { // system.peers_v2 not found, try system.peers
 				c.mu.Lock()
 				c.isSchemaV2 = false
 				c.mu.Unlock()


### PR DESCRIPTION
The fallback to system.peers if system.peers_v2 doesn't exist doesn't work. This patch addresses this.
