### PR TITLE
add DCLocalRoundRobin host selection policy

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -840,6 +840,52 @@ func (d *dcAwareRR) RemoveHost(host *HostInfo) {
 func (d *dcAwareRR) HostUp(host *HostInfo)   { d.AddHost(host) }
 func (d *dcAwareRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
 
+func (d *dcAwareRR) Pick(q ExecutableStatement) NextHost {
+	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
+	return roundRobbin(int(nextStartOffset), d.localHosts.get(), d.remoteHosts.get())
+}
+
+type dcLocalRR struct {
+	local           string
+	localHosts      cowHostList
+	lastUsedHostIdx uint64
+}
+
+// DCLocalRoundRobinPolicy is a host selection policies which will allow and
+// return hosts which are in the local datacenter and will ignore hosts
+// from other datacenters
+func DCLocalRoundRobinPolicy(localDC string) HostSelectionPolicy {
+	return &dcLocalRR{local: localDC}
+}
+
+func (d *dcLocalRR) Init(*Session)                       {}
+func (d *dcLocalRR) KeyspaceChanged(KeyspaceUpdateEvent) {}
+func (d *dcLocalRR) SetPartitioner(p string)             {}
+
+func (d *dcLocalRR) IsLocal(host *HostInfo) bool {
+	return host.DataCenter() == d.local
+}
+
+func (d *dcLocalRR) AddHost(host *HostInfo) {
+	if d.IsLocal(host) {
+		d.localHosts.add(host)
+	}
+}
+
+func (d *dcLocalRR) RemoveHost(host *HostInfo) {
+	if d.IsLocal(host) {
+		d.localHosts.remove(host.ConnectAddress())
+	}
+}
+
+func (d *dcLocalRR) HostUp(host *HostInfo)   { d.AddHost(host) }
+func (d *dcLocalRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
+
+func (d *dcLocalRR) Pick(q ExecutableStatement) NextHost {
+	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
+	return roundRobbin(int(nextStartOffset), d.localHosts.get())
+}
+
 // This function is supposed to be called in a fashion
 // roundRobbin(offset, hostsPriority1, hostsPriority2, hostsPriority3 ... )
 //
@@ -879,11 +925,6 @@ func roundRobbin(shift int, hosts ...[]*HostInfo) NextHost {
 			}
 		}
 	}
-}
-
-func (d *dcAwareRR) Pick(q ExecutableStatement) NextHost {
-	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
-	return roundRobbin(int(nextStartOffset), d.localHosts.get(), d.remoteHosts.get())
 }
 
 // RackAwareRoundRobinPolicy is a host selection policies which will prioritize and

--- a/policies_test.go
+++ b/policies_test.go
@@ -445,6 +445,47 @@ func TestHostPolicy_DCAwareRR(t *testing.T) {
 
 }
 
+func TestHostPolicy_DCLocalRR(t *testing.T) {
+	p := DCLocalRoundRobinPolicy("local")
+
+	hosts := [...]*HostInfo{
+		{hostId: "0", connectAddress: net.ParseIP("10.0.0.1"), dataCenter: "remote"},
+		{hostId: "1", connectAddress: net.ParseIP("10.0.0.2"), dataCenter: "local"},
+		{hostId: "2", connectAddress: net.ParseIP("10.0.0.3"), dataCenter: "local"},
+		{hostId: "3", connectAddress: net.ParseIP("10.0.0.4"), dataCenter: "remote"},
+	}
+
+	for _, host := range hosts {
+		p.AddHost(host)
+	}
+
+	got := make(map[string]bool, len(hosts))
+	var dcs []string
+
+	it := p.Pick(nil)
+	for h := it(); h != nil; h = it() {
+		id := h.Info().hostId
+		dc := h.Info().dataCenter
+
+		if got[id] {
+			t.Fatalf("got duplicate host %s", id)
+		}
+		got[id] = true
+		dcs = append(dcs, dc)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected %d hosts got %d", len(hosts), len(got))
+	}
+
+	for _, dc := range dcs {
+		if dc != "local" {
+			t.Fatalf("got remote dc from local only policy: %v", dcs)
+		}
+	}
+
+}
+
 // Tests of the token-aware host selection policy implementation with a
 // DC aware round-robin host selection policy fallback
 // with {"class": "NetworkTopologyStrategy", "a": 1, "b": 1, "c": 1} replication.


### PR DESCRIPTION
As requested in #956 we need an option to not fallback to remote datacenter in DCAware host selection policy.
Unfortunately we first try to connect to remote datacenter host and receive local hosts there. So the way with HostFilter does not work for us. It seems that such host selection policy should work for us... 