### PR TITLE
CASSGO-128 Fix LZ4 test fails on arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,25 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
-  build:
-    name: Unit tests
+  unit-tests-amd64:
+    name: Unit tests AMD64
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.25', '1.26' ]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Run linting
+        run: make check
+      - name: Run unit tests
+        run: make test-unit
+  
+  unit-tests-arm64:
+    name: Unit tests ARM64
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         go: [ '1.25', '1.26' ]
@@ -27,7 +43,8 @@ jobs:
   integration-cassandra:
     timeout-minutes: 15
     needs:
-      - build
+      - unit-tests-amd64
+      - unit-tests-arm64
     name: Integration Tests
     runs-on: ubuntu-latest
     strategy:
@@ -93,7 +110,8 @@ jobs:
   integration-auth-cassandra:
     timeout-minutes: 15
     needs:
-      - build
+      - unit-tests-amd64
+      - unit-tests-arm64
     name: Integration Tests with auth
     runs-on: ubuntu-latest
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Correct protocol negotiation with non-Cassandra servers (CASSGO-131)
+- LZ4 test fails on arm64 (CASSGO-128)
 
 ## [2.1.2]
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ module github.com/apache/cassandra-gocql-driver/v2
 require (
 	github.com/golang/snappy v0.0.3
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
-	github.com/pierrec/lz4/v4 v4.1.8
+	github.com/pierrec/lz4/v4 v4.1.27
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pierrec/lz4/v4 v4.1.8 h1:ieHkV+i2BRzngO4Wd/3HGowuZStgq6QkPsD1eolNAO4=
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk=
+github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Fixed by bumping pierrec/lz4 lib version to v4.1.27. Additionally, added arm64 machines to the testing matrix for unit tests.

Patch by Bohdan Siryk; reviwed by João Reis for CASSGO-128