### PR TITLE
CASSGO-130 Add Query.Binding() function to override binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security-model discoverability (CASSANDRA-21464)
 - Improve host_source locking and ring refresh concurrency (CASSGO-121)
 - Add PreparedMetadata (Keyspace, Table) and IsPrepared fields to ObservedQuery, and parallel PreparedMetadata / IsPrepared slices to ObservedBatch, for statement-level observability without CQL parsing (CASSGO-119)
+- Query.Binding() method to override binding function for a query object.
 
 ### Fixed
 - Correct protocol negotiation with non-Cassandra servers (CASSGO-131)

--- a/session.go
+++ b/session.go
@@ -1326,6 +1326,14 @@ func (q *Query) Idempotent(value bool) *Query {
 // For supported Go to CQL type conversions for query parameters, see Session.Query documentation.
 func (q *Query) Bind(v ...interface{}) *Query {
 	q.values = v
+	q.binding = nil
+	return q
+}
+
+// Binding sets a function for dynamic generation of query arguments.
+func (q *Query) Binding(binding func(q *QueryInfo) ([]interface{}, error)) *Query {
+	q.values = nil
+	q.binding = binding
 	return q
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -403,3 +403,60 @@ func TestRetryType_IgnoreRethrow(t *testing.T) {
 		resetObserved()
 	}
 }
+
+func TestStaticQueryInfo_OverrideBindingFunction(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, "CREATE TABLE IF NOT EXISTS gocql_test.static_query_info_override (id int, value text, PRIMARY KEY (id))"); err != nil {
+		t.Fatalf("failed to create table with error '%v'", err)
+	}
+
+	if err := session.Query("INSERT INTO static_query_info_override (id, value) VALUES (?, ?)", 1, "foo").Exec(); err != nil {
+		t.Fatalf("insert into static_query_info_override failed, err '%v'", err)
+	}
+
+	if err := session.Query("INSERT INTO static_query_info_override (id, value) VALUES (?, ?)", 2, "bar").Exec(); err != nil {
+		t.Fatalf("insert into static_query_info_override failed, err '%v'", err)
+	}
+
+	qry := session.Bind("SELECT id, value FROM static_query_info_override WHERE id = ?", func(q *QueryInfo) ([]interface{}, error) {
+		values := make([]interface{}, 1)
+		values[0] = 1
+		return values, nil
+	})
+
+	iter := qry.Iter()
+	var id int
+	var value string
+	iter.Scan(&id, &value)
+	if err := iter.Close(); err != nil {
+		t.Fatalf("query with exposed info failed, err '%v'", err)
+	}
+
+	if id != 1 {
+		t.Fatalf("Expected id %d, but got %d", 113, id)
+	}
+	if value != "foo" {
+		t.Fatalf("Expected value %s, but got %s", "foo", value)
+	}
+
+	qry.Binding(func(q *QueryInfo) ([]interface{}, error) {
+		values := make([]interface{}, 1)
+		values[0] = 2
+		return values, nil
+	})
+
+	iter = qry.Iter()
+	iter.Scan(&id, &value)
+	if err := iter.Close(); err != nil {
+		t.Fatalf("query with exposed info failed, err '%v'", err)
+	}
+
+	if id != 2 {
+		t.Fatalf("Expected id %d, but got %d", 2, id)
+	}
+	if value != "bar" {
+		t.Fatalf("Expected value %s, but got %s", "bar", value)
+	}
+}


### PR DESCRIPTION
As Query is supposed to be reusable since cqlbp v2, it should be possible to overwrite a binding too.