### PR TITLE
fix protocol negotiation error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve host_source locking and ring refresh concurrency (CASSGO-121)
 - Add PreparedMetadata (Keyspace, Table) and IsPrepared fields to ObservedQuery, and parallel PreparedMetadata / IsPrepared slices to ObservedBatch, for statement-level observability without CQL parsing (CASSGO-119)
 
+### Fixed
+- Correct protocol negotiation with non-Cassandra servers (CASSGO-131)
+
 ## [2.1.2]
 
 ### Fixed

--- a/conn_test.go
+++ b/conn_test.go
@@ -1259,7 +1259,12 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, useProtoV5, star
 		srv.errorLocked("process frame with a nil header")
 		return
 	}
-	respFrame := newFramer(nil, byte(head.version), GlobalTypes)
+	// use the configured version unless it wasn't specified
+	version := srv.protocol
+	if version == 0 {
+		version = byte(head.version)
+	}
+	respFrame := newFramer(nil, version, GlobalTypes)
 
 	if srv.customRequestHandler != nil {
 		if err := srv.customRequestHandler(srv, reqFrame, respFrame); err != nil {

--- a/protocol_negotiation_test.go
+++ b/protocol_negotiation_test.go
@@ -231,9 +231,18 @@ func TestProtocolNegotiation(t *testing.T) {
 				forceZeroStreamID:         tc.forceZeroStreamID,
 			}
 
+			// use the maximum protocol supported
+			protocol := uint8(0)
+			for _, supportedVersion := range tc.supportedVersions {
+				supportedProto := uint8(supportedVersion)
+				if supportedProto > protocol {
+					protocol = supportedProto
+				}
+			}
+
 			srv := newTestServerOpts{
 				addr:                       "127.0.0.1:0",
-				protocol:                   5,
+				protocol:                   protocol,
 				customRequestHandler:       handler.handle,
 				dontFailOnProtocolMismatch: true,
 			}.newServer(t, context.Background())

--- a/session.go
+++ b/session.go
@@ -2532,6 +2532,10 @@ var (
 // ErrProtocol represents a protocol-level error.
 type ErrProtocol struct{ error }
 
+func (e ErrProtocol) Unwrap() error {
+	return e.error
+}
+
 // NewErrProtocol creates a new protocol error with the specified format and arguments.
 func NewErrProtocol(format string, args ...interface{}) error {
 	return ErrProtocol{fmt.Errorf(format, args...)}


### PR DESCRIPTION
In CASSGO-97 and #1920 the handling was changed to better support non-zero stream id error responses. But because of hardcoding of version 5 in the test harness there was a regression where older protocol responses were not supported anymore.

By adding an Unwrap method to ErrProtocol now the existing checking in checkProtocolRelatedError will correctly catch the protocolError.